### PR TITLE
Add source readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Earth4All.jl
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://worlddynamics.github.io/Earth4All.jl/)
 
-Repository of the Julia implementation of the [Earth4All model](https://earth4all.life/the-science-rp/) using the [WorldDynamics framework](https://github.com/worlddynamics/WorldDynamics.jl).
+Repository of the Julia implementation of the [Earth4All model](https://earth4all.life/the-science-rp/) using the [WorldDynamics framework](https://github.com/worlddynamics/WorldDynamics.jl), based on the [April 2023 Vensim version](https://web.archive.org/web/20220830093115/https://earth4all.life/the-science/) available [here](https://stockholmuniversity.app.box.com/s/uh7fjh52pvh7yx1mqfwqcyxdcvegrodf/folder/170558692760) (a copy is also available in the `vensim_source` folder of the current repository).
 
 ## How to run the model 
 

--- a/vensim_source/mov220501-18 E4A-global jr GL.mdl
+++ b/vensim_source/mov220501-18 E4A-global jr GL.mdl
@@ -1,0 +1,8664 @@
+{UTF-8}
+"Food sector productivity index (1980=1)"=
+	EXP("ROC in food sector productivity 1/y" * ( Time - 1980))
+	*
+	IF THEN ELSE(Time>2022, EXP( "Extra ROC in food sector productivity from 2022 1/y"* \
+		( Time - 2022)), 1)
+	~	
+	~		|
+
+"ROC in food sector productivity 1/y"=
+	0.002
+	~	1/y [0,0.02,0.001]
+	~	0.002 chosen to fit SSP2 4-5
+	|
+
+"Extra ROC in food sector productivity from 2022 1/y"=
+	0
+	~	 [0,0.01,0.001]
+	~	0 in TLTL and 0 in GL. SInce ROC in food sector is already 0.002 1/y
+	|
+
+"Extra rate of decline in CH4 pr kg crop after 2022 1/y"=
+	0.01
+	~	1/y [0,0.02,0.01]
+	~	0 in TLTL, 0.01 in GL
+	|
+
+"Extra rate of decline in N2O per kg fertilizer from 2022 1/y"=
+	0.01
+	~	1/y [0,0.02,0.01]
+	~	0 in TLTL, 0.01 in GL
+	|
+
+kg N2O emission per kg fertiliser=
+	kg N2O per kg fertilizer in 1980
+	*  
+	EXP(-("Rate of decline in N2O per kg fertiliser 1/y")
+	 * ( Time - 1980))
+	*IF THEN ELSE(Time>2022, EXP(-("Extra rate of decline in N2O per kg fertilizer from 2022 1/y"\
+		)
+	 * ( Time - 2022)), 1)
+	~	1
+	~		|
+
+kg CH4 emission per kg crop=
+	kg CH4 per kg crop in 1980 
+	*  
+	EXP(-("Rate of decline in CH4 per kg crop 1/y")
+	 * ( Time - 1980))
+	*IF THEN ELSE(Time>2022, EXP(-("Extra rate of decline in CH4 pr kg crop after 2022 1/y"\
+		)
+	 * ( Time - 2022)), 1)
+	~	1
+	~		|
+
+"Rate of decline in N2O per kg fertiliser 1/y"=
+	0.01
+	~	1/y [0,0.02,0.01]
+	~	211102 Should be 0.008 to fit observed time series in N2O emissions and \
+		fertilizer use
+	|
+
+"Margin in 1980 (1)"=
+	0.25
+	~	1
+	~		|
+
+"Recent sales Gu/y"=
+	SMOOTHI("Deliveries Gu/y", Sales averaging time y, "Demand in 1980 G$/y" )
+	~	Gu/y
+	~		|
+
+"National income G$/y"=
+	"Sales G$/y"
+	~	G$/y
+	~		|
+
+"Sales G$/y"=
+	"Deliveries Gu/y" * "Price per unit $/u"
+	~	
+	~		|
+
+"CO2 per GDP (kgCO2/$)"=
+	( "CO2 emissions GtCO2/y" / "GDP G$/y" ) * 1000
+	~	tCO2/$
+	~		|
+
+"Price per unit $/u"=
+	"Cost per unit in 1980 $/u" * ( 1 + "Margin in 1980 (1)" )
+	~	$/u
+	~		|
+
+"Deliveries Gu/y"=
+	( ( "Effective purchasing power G$/y" / "Price per unit $/u" ) / ( "Delivery delay - index (1)"\
+		 / DDI in 1980 y ) )
+	*
+	IF THEN ELSE ( Time > 1984, "Pink noise in sales (1)", 1)
+	~	Gu/y
+	~		|
+
+Time to implement new taxes y=
+	5
+	~	y [0,10,1]
+	~		|
+
+"Owner taxes G$/y"=
+	"Income tax owners (1)"
+	+
+	"Extra taxes from 2022 G$/y" * "Fraction of extra taxes paid by owners (1)"
+	~	G$/y
+	~		|
+
+"Extra taxes from 2022 G$/y"=
+	SMOOTH("Goal for extra taxes from 2022 G$/y", Time to implement new taxes y)
+	~	G$/y
+	~		|
+
+"Owner operating income after tax G$/y"=
+	"Owner income G$/y" - "Owner taxes G$/y"
+	~	G$/y
+	~		|
+
+"Fraction of govmnt budget to workers (1)"=
+	SMOOTH("Goal for fraction of govmnt budget to workers (1)", Time to implement new taxes y\
+		)
+	~	(1)
+	~		|
+
+"Govmnt gross income G$/y"=
+	"Worker taxes G$/y" + "Owner taxes G$/y" + "Sales tax workers G$/y" + "Sales tax owners G$/y"
+	+ "Income from commons from 2022 G$/y"
+	~	G$/y
+	~		|
+
+"Transfer payments G$/y"=
+	"Govmnt gross income G$/y" * "Fraction of govmnt budget to workers (1)"
+	~	G$/y
+	~		|
+
+"Owner tax rate (1)"=
+	"Owner taxes G$/y" / "Owner income G$/y"
+	~	1
+	~		|
+
+"Worker taxes G$/y"=
+	"Income tax workers (1)"
+	+
+	"Extra taxes from 2022 G$/y" * ( 1 - "Fraction of extra taxes paid by owners (1)" )
+	~	G$/y
+	~		|
+
+"Govmnt gross income (as share of NI)"=
+	"Govmnt gross income G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Fraction transferred in 1980 (1)"=
+	0.3
+	~	
+	~	Logic: 0.3 is value for US 1980 to 2020 (8% of GDP transferred of budget \
+		28% of GDP = 0.29. Ca 0.5 in Norway
+	|
+
+"CO2 emissions GtCO2/y"=
+	"CO2 from energy and industry GtCO2/y" + "CO2 emissions from LULUC GtCO2/y" - "Direct air capture of CO2 GtCO2/y"
+	~	GtCO2/y
+	~		|
+
+"Goal for fraction of govmnt budget to workers (1)"=
+	"Fraction transferred in 1980 (1)"
+	+
+	IF THEN ELSE(Time>2022, "Extra transfer of govmnt budget to workers (1)", 0)
+	~	1
+	~		|
+
+"Direct air capture of CO2 GtCO2/y"=
+	IF THEN ELSE(Time>2022,
+	 RAMP(("Direct air capture of CO2 in 2100 GtCO2/y" ) / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	, 0 )
+	~	Gt/y
+	~		|
+
+"Cost of energy G$/y"=
+	"Cost of fossil fuel for non-el use G$/y" + "Cost of electricity G$/y" + "Cost of grid G$/y"\
+		 + "Cost of new electrification G$/y"
+	 + "Cost of CCS G$/y"
+	+ "Cost of air capture G$/y"
+	~	G$/y
+	~		|
+
+"Income from commons from 2022 G$/y"=
+	"National income G$/y"
+	*
+	IF THEN ELSE(Time>2022, 
+	RAMP( "Goal for extra income from commons (share of NI)" / Introduction period for policy y
+	, 2022, 2020 + Introduction period for policy y)
+	, 0)
+	~	G$/y
+	~		|
+
+"Cost of air capture G$/y"=
+	"Direct air capture of CO2 GtCO2/y" * "Cost of CCS $/tCO2"
+	~	G$/y
+	~		|
+
+"Direct air capture of CO2 in 2100 GtCO2/y"=
+	8
+	~	GtCO2/y [0,15,1]
+	~	0 in TLTL and 8 in GL
+		8 GtCO2/y is about the same amount as is annually absorbed in the world's \
+		forestry land in 2100, and thus a conceivable potential in BECCS - but \
+		wildly unrealistic, unless one discovers other ways of binding CO2. But 12 \
+		is necessary to hold warming below 2 deg C
+	|
+
+"Installed CCS capacity GtCO2/y"=
+	"Fraction of CO2-sources with CCS (1)" *
+	( "CO2 from non-fossil industrial processes GtCO2/y" +"CO2 from energy production GtCO2/y"\
+		 ) /
+	(1 - "Fraction of CO2-sources with CCS (1)" )
+	~	GtCO2/y
+	~		|
+
+"Cost of CCS G$/y"=
+	"Installed CCS capacity GtCO2/y"
+	*
+	"Cost of CCS $/tCO2"
+	~	G$/y
+	~		|
+
+"Rate of technological advance 1/y"=
+	( "Domestic rate of technological advance 1/y" + 0 )
+	*
+	"Reduction in ROTA from inequality 1/y"
+	+
+	"Imported ROTA 1/y"
+	~	1/y
+	~		|
+
+"Imported ROTA 1/y"=
+	IF THEN ELSE(Time>2022,
+	MAX(0, 
+	"Max imported ROTA from 2022 1/y" * 
+	( 1 - 1 * ( "GDP per person k$/p/y" / "GDPpp of technology leader k$/p/y" - 1 ))
+	), 
+	0)
+	~	1
+	~		|
+
+"Domestic rate of technological advance 1/y"=
+	( "Domestic ROTA in 1980 1/y" + (IF THEN ELSE(Time>2022, "Extra domestic ROTA from 2022 1/y"\
+		, 0))
+	* 
+	( 1 +  "sSCeoROTA>0" * ( "State capacity (fraction of GDP)" / "State capacity in 1980 (fraction of GDP)"
+	 - 1 )))
+	~	1/y
+	~		|
+
+"Extra pension tax from 2022 (share of NI)"=
+	0.02
+	~	1 [0,0.02,0.01]
+	~	0 in TLTL and 0.02 in GL
+	|
+
+"Average wellbeing from progress (1)"=
+	( 1 + "sROPeoAW>0" * ( "Observed rate of progress 1/y" - "Threshold progress rate 1/y"\
+		 ))
+	*
+	"Wellbeing effect of participation (1)"
+	~	1
+	~		|
+
+"AVERAGE WELLBEING INDEX (1)"=
+	( 0.5 * "Average wellbeing from disposable income (1)"
+	+
+	0.5 * "Average wellbeing from public spending (1)")
+	* "Average wellbeing from inequality (1)"
+	* "Average wellbeing from global warming (1)"
+	* "Average wellbeing from progress (1)"
+	~	1
+	~		|
+
+"Extra general tax from 2022 G$/y"=
+	IF THEN ELSE(Time>2022, "Extra general tax rate from 2022 (1)" + "Extra empowerment tax from 2022 (share of NI)"\
+		 + "Extra pension tax from 2022 (share of NI)", 0)
+	*
+	"National income G$/y"
+	~	1
+	~		|
+
+"Extra empowerment tax from 2022 (share of NI)"=
+	0.02
+	~	1 [0,0.02,0.01]
+	~	0 in TLTL and 0.02 in GL
+	|
+
+"Worker tax rate (1)"=
+	"Worker taxes G$/y" / "Worker income G$/y"
+	~	1
+	~		|
+
+"Fraction new electrification (1)"=
+	"Fraction new electrification in 1980 (1)"
+	+
+	RAMP(("Fraction new electrification in 2022 (1)" - "Fraction new electrification in 1980 (1)"\
+		 ) / 42, 1980, 2022)
+	+
+	RAMP(( "Goal for fraction new electrification (1)" - "Fraction new electrification in 2022 (1)"\
+		 ) / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction regenerative agriculture (1)"=
+	RAMP( "Goal for fraction regenerative agriculture (1)" / Introduction period for policy y
+	, 2022, 2020 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Extra fertility reduction (1)"=
+	RAMP( "Goal for extra fertility reduction (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction new red meat (1)"=
+	RAMP( "Goal for fraction new red meat (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction of CO2-sources with CCS (1)"=
+	"Fraction of CO2-sources with CCS in 2022 (1)"
+	+
+	RAMP(( "Goal for fraction of CO2-sources with CCS (1)" - "Fraction of CO2-sources with CCS in 2022 (1)"\
+		 ) / Introduction period for policy y
+	, 2022 , 2022 + Introduction period for policy y)
+	~	
+	~		|
+
+"Desired renewable electricity share (1)"=
+	"Renewable el fraction in 1980 (1)"
+	+
+	RAMP(( "Renewable el fraction in 2022 (1)" - "Renewable el fraction in 1980 (1)" ) /\
+		 42, 1980, 2022)
+	+
+	RAMP(( "Goal for renewable el fraction (1)" - "Renewable el fraction in 2022 (1)" ) \
+		/ Introduction period for policy y, 2022, 2022 + Introduction period for policy y )
+	~	1
+	~		|
+
+"Crop waste reduction (1)"=
+	RAMP( "Goal for crop waste reduction (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y )
+	~	1
+	~		|
+
+Introduction period for policy y=
+	IF THEN ELSE("Exogenous introduction period?">0, Exogenous introduction period y, Reform delay y\
+		)
+	~	y
+	~		|
+
+"Extra normal LPR from 2022 (1)"=
+	RAMP("Goal for extra normal LPR (1)" / Introduction period for policy y, 2022, 2022 \
+		+ Introduction period for policy y)
+	~	1
+	~		|
+
+Extra pension age y=
+	RAMP(( Goal for extra pension age y - Extra pension age in 2022 y ) / Introduction period for policy y\
+		, 2022, 22022 + Introduction period for policy y)
+	~	1/y
+	~		|
+
+Reform delay y=
+	SMOOTH(Indicated reform delay y, Time to change reform delay y)
+	~	y
+	~		|
+
+Exogenous introduction period y=
+	30
+	~	y [0,70,10]
+	~		|
+
+"Exogenous introduction period?"=
+	0
+	~	 [0,1,1]
+	~		|
+
+"10-yr loop delay y"=
+	2.3
+	~	y [2,3,0.1]
+	~	was 3*0.85=2.55, so 2.6
+	|
+
+Unemployment perception time y=
+	"10-yr loop delay y" / 3
+	~	y [0,2,0.05]
+	~	was 2, so 1, so 0.8, so 0.7, so 0.9,so 0.8
+	|
+
+"Hiring/firing delay y"=
+	"10-yr loop delay y" / 3
+	~	 [0,2,0.1]
+	~	was 1, so 0.8, so 0.7, so 0.9, so 0.8,
+	|
+
+Time to change tooling y=
+	"10-yr loop delay y"/3
+	~	y [0,1,0.01]
+	~	was 0.8, so 0.7, so 0.9, so 0.8,
+	|
+
+"Cancellation of debt G$/y"=
+	PULSE( 2022, 1)* Govmnt debt G$ * "Fraction of govmnt debt cancelled in 2022 1/y"
+	~	G$/y
+	~		|
+
+"OWeoLOC (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoLOC<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"CO2 from non-fossil industrial processes GtCO2/y"=
+	( "Non-fossil CO2 per person tCO2/p/y" / 1000 )
+	* Population Mp
+	* ( 1 - "Fraction of CO2-sources with CCS (1)")
+	~	GtCO2/y
+	~		|
+
+Life of capacity PIS y=
+	( Life of capacity PIS in 1980 y * "OWeoLOC (1)" ) / "Excess demand effect on life of capacity (1)"
+	~	y
+	~		|
+
+Life of capacity PUS in 1980 y=
+	15 * "OWeoLOC (1)"
+	~	y
+	~		|
+
+"sOWeoLOC<0"=
+	-0.1
+	~	1 [-1,0,0.01]
+	~	220323 Set to -0.1 to get life of capacity reduced from 15 y in 2022 (+1.3 \
+		deg C) to 13 y in 2100 at +2.5 deg C.
+	|
+
+"CO2 from energy production GtCO2/y"=
+	"Use of fossil fuels Mtoe/y" * ( tCO2 per toe / 1000 )
+	* 
+	( 1 - "Fraction of CO2-sources with CCS (1)" )
+	~	GtCO2/y
+	~		|
+
+"Cost of TAs in 2022 G$/y"=
+	9145
+	~	G$/y
+	~		|
+
+"Extra taxes for TAs from 2022 G$/y"=
+	IF THEN ELSE(Time>2022, "Extra cost of TAs from 2022 G$/y" * "Fraction of extra TA cost paid by extra taxes (1)"\
+		 , 0 )
+	~	1
+	~		|
+
+"Goal for extra taxes from 2022 G$/y"=
+	"Extra general tax from 2022 G$/y" + "Extra taxes for TAs from 2022 G$/y"
+	~	
+	~		|
+
+"Extra cost of TAs from 2022 G$/y"=
+	MAX(0, "Cost of TAs G$/y" - "Cost of TAs in 2022 G$/y")
+	~	G$/y
+	~		|
+
+"Extra cost of TAs as share of GDP (1)"=
+	"Extra cost of TAs from 2022 G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Productivity loss from unprofitable activity (1)"=
+	"Extra cost of TAs as share of GDP (1)" * "Fraction unprofitable activity in TAs (1)"
+	~	1
+	~		|
+
+"Investment share of GDP (1)"=
+	( "Investment in new capacity PIS G$/y" + "Govmnt investment in public capacity G$/y"\
+		 ) / "GDP G$/y"
+	~	1
+	~		|
+
+"Indicated TFP (1)"=
+	"TFP including effect of 5TAs (1)" * OWeoTFP
+	~	1
+	~		|
+
+OWeoTFP=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoTFP<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"xExtra TA cost in 2100 (share of GDP)"=
+	0
+	~	1 [0,1,0.05]
+	~		|
+
+"xExtra cost of TAs as share of GDP (1)"=
+	"xExtra TA cost in 2022 (share of GDP)" + RAMP(("xExtra TA cost in 2100 (share of GDP)"\
+		-"xExtra TA cost in 2022 (share of GDP)")/78, 2022, 2022 + 78)
+	~	1
+	~		|
+
+"sOWeoTFP<0"=
+	-0.1
+	~	1 [-0.5,0,0.01]
+	~	220323 Set to - 0.1 to get TFP reduced by 10 % at +2.5 deg C. (dvs -4% per \
+		deg C)
+	|
+
+"xExtra TA cost in 2022 (share of GDP)"=
+	0
+	~	
+	~		|
+
+"Fertilizer use per person kg/p/y"=
+	( "Fertilizer use Mt/y" / Population Mp ) * 1000
+	~	kg/p/y
+	~		|
+
+"Energy use per person toe/p/y"=
+	"ENERGY USE Mtoe/y" / Population Mp
+	~	toe/p/y
+	~		|
+
+"Goal for income tax rate owners (1)"=
+	0.3
+	~	1 [0,1,0.05]
+	~		|
+
+"Basic income tax rate owners (1)"=
+	MIN(1, "Income tax rate owners in 1980 (1)"
+	+
+	RAMP(( "Income tax rate owners in 2022 (1)" - "Income tax rate owners in 1980 (1)" )\
+		 / 42, 1980, 2022)
+	+
+	RAMP(( "Goal for income tax rate owners (1)" - "Income tax rate owners in 2022 (1)" \
+		) / 78, 2022, 2100) )
+	~	1
+	~		|
+
+"Owner income G$/y"=
+	"National income G$/y" * ( 1 - "Worker share of output (1)")
+	~	G$/y
+	~		|
+
+"Income tax workers (1)"=
+	"Basic income tax rate workers (1)" 
+	* "National income G$/y" * "Worker share of output (1)"
+	~	1 [0,0.3,0.01]
+	~		|
+
+"Fraction of extra TA cost paid by extra taxes (1)"=
+	0.5
+	~	1 [0,1,0.1]
+	~	0.5 in TLTL 1.0 in GL
+	|
+
+"Worker income G$/y"=
+	"National income G$/y" * "Worker share of output (1)"
+	~	G$/y
+	~		|
+
+"Income tax owners (1)"=
+	"Basic income tax rate owners (1)"
+	*
+	"National income G$/y" * ( 1 - "Worker share of output (1)")
+	~	1 [0,0.3,0.01]
+	~		|
+
+"sLPeoAWP>0"=
+	0.5
+	~	 [0,1,0.1]
+	~		|
+
+"Wellbeing effect of participation (1)"=
+	1 + "sLPeoAWP>0" * ( "Labour participation rate (1)" / "Threshold participation (1)"\
+		 - 1 )
+	~	
+	~		|
+
+"GDP per person k$/p/y"=
+	"GDP G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+Govmnt debt G$= INTEG (
+	"Govmnt new debt G$/y"-"Cancellation of debt G$/y"-"Govmnt payback G$/y",
+		Govmnt debt in 1980 G$)
+	~	G$
+	~		|
+
+"Owner cash inflow G$/y"=
+	"Owner operating income after tax G$/y"
+	~	G$/y
+	~		|
+
+"Threshold participation (1)"=
+	0.8
+	~	 [0,1,0.1]
+	~		|
+
+"Govmnt new debt G$/y"=
+	MAX(0, ( Max govmnt debt G$ - Govmnt debt G$ ) / Govmnt drawdown period y) + 
+	STEP( "Govmnt stimulus from 2022 (share of NI)", 2022 ) * "National income G$/y"
+	~	G$/y
+	~		|
+
+"Bank cash inflow as share of NI (1)"=
+	"Bank cash inflow from lending G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Demand for red meat Mt-red-meat/y"=
+	( ( Population Mp * "Demand for red meat per person kg-red-meat/p/y" ) / 1000 )
+	*
+	( 1 - "Fraction new red meat (1)" )
+	~	Mt/y
+	~		|
+
+"Crop use Mt/y"=
+	"Crop supply (after 20 % waste) Mt-crop/y" * ( 1 + "Crop waste reduction (1)" )
+	~	Mt/y
+	~		|
+
+"Non-fossil CO2 per person tCO2/p/y"=
+	"Max non-fossil CO2 per person tCO2/p/y" *
+	( 1 - EXP(-("GDP per person k$/p/y" / 10)))
+	~	tCO2/p/y
+	~		|
+
+"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"=
+	"Fraction new electrification (1)" * "Demand for fossil fuel for non-el use before NE Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+Time to change reform delay y=
+	10
+	~	y
+	~	The time it takes for society to shorten decision and implementation delay.
+	|
+
+"Cost index for Regenerative agriculture (1)"=
+	( 1 - "Cost reduction per doubling in Regenerative agriculture (1)" ) ^ "Number of doublings in reg ag (1)"
+	~	
+	~		|
+
+Experience gained before 2022 Mha=
+	5
+	~	Mha [0,30,1]
+	~		|
+
+"Goal for fraction new red meat (1)"=
+	0.5
+	~	1 [0,1,0.05]
+	~	0.1 in TLTL, 0.5 i GL (lowered from 1 on 220427)
+	|
+
+"Goal for renewable el fraction (1)"=
+	1
+	~	1 [0,1,0.1]
+	~	0.5 i TLTL and 1 in GL
+	|
+
+Desired no of children 1=
+	(
+	( DNCmin + ( DNC in 1980 - DNCmin ) * EXP(-DNCgamma * ( "Effective GDP per person k$/p/y"\
+		 - "GDP per person in 1980 k$/p/y"
+	))) *
+	(1 + "DNCalfa<0" * ("Effective GDP per person k$/p/y" - "GDP per person in 1980 k$/p/y"\
+		 ))
+	)
+	* ( 1 - "Extra fertility reduction (1)" )
+	* "Fertility multiplier (1)"
+	~	1
+	~		|
+
+Indicated reform delay y=
+	Normal reform delay y 
+	*
+	"Social trust effect on reform delay (1)"
+	*
+	"Social tension effect on reform delay (1)"
+	~	
+	~		|
+
+"Desired supply of renewable electricity TWh/y"=
+	"Demand for electricity TWh/y" * "Desired renewable electricity share (1)"
+	~	TWh/y
+	~		|
+
+"Cost of extra fertility reduction (share of GDP)"=
+	"Cost of Max fertility reduction (share of GDP)" * "Extra fertility reduction (1)"
+	~	1
+	~		|
+
+"Goal for crop waste reduction (1)"=
+	0.2
+	~	1 [0,0.2,0.01]
+	~	0.05 in TLTL and 0,2 in GL
+	|
+
+"Goal for fraction regenerative agriculture (1)"=
+	0.5
+	~	1 [0,0.9,0.1]
+	~	0.1 in TLTL and 0.5 in GL (lowered from 0.9 220427)
+	|
+
+"Number of doublings in reg ag (1)"=
+	LN( ( Regenerative agriculture area Mha + Experience gained before 2022 Mha ) / Experience gained before 2022 Mha\
+		) / 0.693
+	~	1
+	~	ln2 = 0.693
+	|
+
+"Goal for fraction new electrification (1)"=
+	1
+	~	1 [0,1,0.01]
+	~	0.5 i TLTL and 1 in GL
+	|
+
+"Inequity effect on logistic k (1)"=
+	1 + "sINEeoLOK<0" * ( "Inequality (1)" / 0.5 - 1 )
+	~	1
+	~		|
+
+"Normal k (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	was 1, so 0.3, so 0.15, so 0.2
+		goal is to have 600 Mp > 15k$/y in 2000, ie 10 % of population at the \
+		time. And 50 % > 15 k$/p/y in 2020
+	|
+
+"Population below 15 k$/p/y Mp"=
+	Population Mp * "Fraction below 15 k$/p/y (1)"
+	~	Mp
+	~		|
+
+"sINEeoLOK<0"=
+	-0.5
+	~	1 [-1,0,0.1]
+	~	was - 1
+	|
+
+"Logistic k (1)"=
+	"Normal k (1)" * "Inequity effect on logistic k (1)"
+	~	1
+	~		|
+
+"Goal for extra fertility reduction (1)"=
+	0.2
+	~	1 [0,0.2,0.01]
+	~	0 in TLTL and 0.2 in GL
+	|
+
+"Fraction below 15 k$/p/y (1)"=
+	1 - ( 1 / ( 1 + EXP( - "Logistic k (1)" * ( "GDP per person k$/p/y" - 14))))
+	~	
+	~		|
+
+"Satisfactory public spending (1)"=
+	0.3
+	~	1 [0,1,0.01]
+	~		|
+
+"Social tension (1)"=
+	1 + "sPPReoSTE<0" * ( "Observed rate of progress 1/y" - "Acceptable progress 1/y" )
+	~	1
+	~		|
+
+"Social tension effect on reform delay (1)"=
+	1 + "sSTEeoRD>0" * ( "Social tension (1)" / "Social tension in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Social tension in 1980 (1)"=
+	1.3
+	~	1
+	~		|
+
+"Acceptable inequality (1)"=
+	0.6
+	~	1 [0,1,0.01]
+	~	was 0.5
+	|
+
+"Social trust effect on reform delay (1)"=
+	1 + "sSTReoRD<0" * ( "Social trust (1)" / "Social trust in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Social trust in 1980 (1)"=
+	0.6
+	~	1
+	~		|
+
+"Public spending effect on social trust (1)"= WITH LOOKUP (
+	Public spending as share of GDP / "Satisfactory public spending (1)",
+		([(0,0)-(1,2)],(0,0),(1,1) ))
+	~	1
+	~		|
+
+"GDP G$/y"=
+	"Output Gu/y" * "Price per unit $/u"
+	~	G$/y
+	~		|
+
+"sSTReoRD<0"=
+	-1
+	~	1 [-1,0,0.1]
+	~	was -0.1
+	|
+
+Time to establish social trust y=
+	10
+	~	y
+	~		|
+
+"Average wellbeing from global warming (1)"=
+	MAX("Min wellbeing from global warming (1)", MIN(1, 1 + "sGWeoAW<0" * ( Perceived warming deg C\
+		 / Threshold warming deg C - 1)))
+	~	1
+	~		|
+
+"Income tax rate owners in 2022 (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	was 0.4 - reduced to match liberalization 1980-2020
+	|
+
+"Inequity effect on social trust (1)"= WITH LOOKUP (
+	"Inequality (1)"/ "Acceptable inequality (1)",
+		([(0,0)-(4,2)],(0,1),(1,1),(2,0) ))
+	~	1
+	~		|
+
+"Min wellbeing from global warming (1)"=
+	0.2
+	~	 [0,0.3,0.01]
+	~	was 0.15
+	|
+
+"Social trust (1)"=
+	SMOOTHI("Indicated social trust (1)", Time to establish social trust y, "Social trust in 1980 (1)"\
+		)
+	~	1
+	~		|
+
+"sSTEeoRD>0"=
+	1
+	~	1 [0,1,0.01]
+	~		|
+
+Public spending as share of GDP=
+	"Public spending per person k$/p/y" / "GDP per person k$/p/y"
+	~	1
+	~		|
+
+Normal reform delay y=
+	30
+	~	 [0,70,10]
+	~		|
+
+"Indicated social trust (1)"=
+	"Public spending effect on social trust (1)" * "Inequity effect on social trust (1)"
+	~	1
+	~		|
+
+"sPPReoSTE<0"=
+	-15
+	~	1 [-20,0,1]
+	~	Assume social tension = 1 at 0.02 1/y
+		And social tension = 0.7 at 0.04
+	|
+
+"Average wellbeing from public spending (1)"=
+	EXP("Diminishing return public spending (1)" + LN( "Public spending per person k$/p/y"\
+		 / "Threshold public spending k$/p/y" ))
+	~	1
+	~		|
+
+"Public spending per person k$/p/y"=
+	"Govmnt spending G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+"Observed rate of progress 1/y"=
+	SMOOTHI( (( "AVERAGE WELLBEING INDEX (1)" - "Past AWI (1)") / "AVERAGE WELLBEING INDEX (1)"\
+		)
+	/ Average wellbeing perception delay y, Average wellbeing perception delay y , 0 )
+	~	
+	~		|
+
+"Threshold disposable income k$/p/y"=
+	15
+	~	k$/p/y
+	~	What is needed to satisfy the UN SDGs according to David Collste et al
+	|
+
+"Threshold public spending k$/p/y"=
+	3
+	~	k$/p/y
+	~	Normal public spending at GDPpp=15.000 k$/p/y, namely 20 % of GDP
+	|
+
+"Acceptable progress 1/y"=
+	0.02
+	~	1/y [0,0.04,0.001]
+	~		|
+
+"sROPeoAW>0"=
+	6
+	~	1 [0,10,0.1]
+	~	was 1, so 10, so 3, so 8, so 6, so 9
+	|
+
+"Threshold inequality (1)"=
+	0.5
+	~	
+	~	Inequity index is defined as oso/wso = (1 - wso) / wso = 1/wso - 1 which \
+		equals 1 at wso=0.5, and
+	|
+
+"Average wellbeing from inequality (1)"=
+	1 + "sIIeoAW<0" * ( "Inequality (1)" / "Threshold inequality (1)" - 1 )
+	~	1
+	~		|
+
+"Diminishing return disposable income (1)"=
+	0.5
+	~	1 [0,1,0.1]
+	~		|
+
+"sIIeoAW<0"=
+	-0.6
+	~	 [-5,0,0.1]
+	~	was -0.6, -1.2, so -1
+	|
+
+"sGWeoAW<0"=
+	-0.58
+	~	1 [-1,0,0.01]
+	~	was -1, so -0.6, so -0.5
+	|
+
+Average wellbeing perception delay y=
+	9
+	~	y [0,15,1]
+	~	was 4, 6, so 8, 10
+	|
+
+"AWI in 1980 (1)"=
+	0.65
+	~	 [0,2,0.01]
+	~	was 1, 1,02, so 0.98
+	|
+
+"Past AWI (1)"=
+	SMOOTHI("AVERAGE WELLBEING INDEX (1)", Average wellbeing perception delay y, "AWI in 1980 (1)"\
+		)
+	~	1
+	~		|
+
+"Diminishing return public spending (1)"=
+	0.7
+	~	1 [0,1,0.1]
+	~	was 0.8, so 0.7
+		More utility from public spending (0.8) than from dispoable income (0.5)
+	|
+
+"Average wellbeing from disposable income (1)"=
+	EXP("Diminishing return disposable income (1)" + LN( "Worker disposable income k$/p/y"\
+		 / "Threshold disposable income k$/p/y" ))
+	~	1
+	~		|
+
+Threshold warming deg C=
+	1
+	~	deg C
+	~	IPCC expects climate damage to be visible when warming passes 1 deg C and \
+		be significant at +2 deg C
+	|
+
+"Threshold progress rate 1/y"=
+	0.02
+	~	 [0,0.04,0.001]
+	~	If there is progress above 2 % per year, there is social clm
+	|
+
+GDPppeoROCCLR=
+	MAX( 0 , 1 + "sGDPppeoROCCLR<0" * ( "GDP per person k$/p/y" / GDP per person in 1980\
+		 - 1 ))
+	~	1
+	~		|
+
+"ROC in ECLR 1/y"=
+	"ROC in ECLR in 1980 1/y" * GDPppeoROCCLR
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"sGDPppeoROCCLR<0"=
+	-0.1
+	~	1 [-1,0,0.01]
+	~		|
+
+"Goal for extra normal LPR (1)"=
+	0
+	~	1 [0,0.1,0.01]
+	~	was 0.05
+		remeber it takes a lot of time to increase LPR
+	|
+
+"Goal for extra income from commons (share of NI)"=
+	0.02
+	~	1 [0,0.05,0.01]
+	~	0 i TLTL and 0.02 in GL
+	|
+
+"Normal LPR (1)"=
+	("Normal LPR in 1980 (1)" 
+	*
+	(1 + "sWSOeoLPR>0" * ( "Worker share of output (1)" / "WSO in 1980 (1)" - 1 )))
+	+
+	"Extra normal LPR from 2022 (1)"
+	~	1
+	~		|
+
+"Fraction of govmnt debt cancelled in 2022 1/y"=
+	0.1
+	~	1/y [0,1,0.1]
+	~	0 in TLTL and 0.1 in GL
+	|
+
+"Off-balance sheet govmnt inv in PIS (share of GDP)"=
+	IF THEN ELSE(Time>2022, "Unconventional stimulus in PIS from 2022 (share of GDP)", 0\
+		)
+	~	1 [0,0.1,0.01]
+	~		|
+
+"Off-balance-sheet govmnt inv in PUS (share of GDP)"=
+	IF THEN ELSE(Time>2022, 0.01 + "Unconventional stimulus in PUS from 2022 (share of GDP)"\
+		, 0.01)
+	~	1 [0,0.05,0.01]
+	~		|
+
+"Unconventional stimulus in PIS from 2022 (share of GDP)"=
+	0.01
+	~	1 [0,0.05,0.01]
+	~	0 in TLTL and 0.01 in GL
+		This is the place to input a government stimulus programme of x % of GDP \
+		for private sector
+	|
+
+"Unconventional stimulus in PUS from 2022 (share of GDP)"=
+	0.01
+	~	1 [0,0.05,0.01]
+	~	0 in TLTL and 0.01 in GL
+		This is the place to input an unconventional government stimulus programme \
+		of x % of GDP for public sector
+	|
+
+"Govmnt payback G$/y"=
+	Govmnt debt G$ /Govmnt payback period y
+	~	G$/y
+	~		|
+
+Max govmnt debt burden y=
+	1
+	~	y [0,2,0.1]
+	~		|
+
+"Govmnt interest cost G$/y"=
+	Govmnt debt G$ * "Govmnt borrowing cost 1/y"
+	~	G$/y
+	~		|
+
+"Fertilizer use in 1980 Mt/y"=
+	61
+	~	Mt/y
+	~		|
+
+Life expectancy y=
+	(
+	( LEmax - (LEmax - LE in 1980) * EXP(- LEgamma * ("Effective GDP per person k$/p/y" \
+		- "GDP per person in 1980 k$/p/y"))
+	) *
+	( 1 + LEalfa * ( "Effective GDP per person k$/p/y" - "GDP per person in 1980 k$/p/y"\
+		 ))
+	)
+	* "Warming effect on life expectancy (1)"
+	* "Life expectancy multipler (1)"
+	~	y
+	~		|
+
+"Inequality (1)"=
+	"Owner operating income after tax G$/y" / "Worker income after tax G$/y"
+	~	1
+	~		|
+
+Food footprint in 1980=
+	Cropland in 1980 Mha * "Fertilizer use in 1980 Mt/y"
+	~	Mha*Mt/y
+	~		|
+
+"FOOD FOOTPRINT INDEX (1980=1)"=
+	Food footprint / Food footprint in 1980
+	~	1
+	~		|
+
+"SSP2 family action from 2022? (1)"=
+	1
+	~	1 [0,1,1]
+	~	1 means action as per SSP2. 0 means no action
+	|
+
+"Fertility multiplier (1)"=
+	IF THEN ELSE("SSP2 family action from 2022? (1)" > 0, 
+	IF THEN ELSE(Time>2022, 1 + RAMP(("Max fertility multiplier (1)" - 1 )/78, 2022, 2100\
+		), 1), 
+	1)
+	~	
+	~		|
+
+"Reduction in ROTA from inequality 1/y"=
+	MIN(1, 1 + "sIIEeoROTA<0" * ( "INEQUALITY INDEX (1980=1)" / 1 - 1) )
+	~	1
+	~		|
+
+"Life expectancy multipler (1)"=
+	IF THEN ELSE("SSP2 family action from 2022? (1)" > 0, 
+	IF THEN ELSE(Time>2022, 1 + RAMP(("Max life expectancy multiplier (1)" - 1 )/78, 2022\
+		, 2100), 1), 
+	1)
+	~	
+	~		|
+
+"Inequality in 1980 (1)"=
+	0.61
+	~	1
+	~	=8426/13874
+	|
+
+"INEQUALITY INDEX (1980=1)"=
+	"Inequality (1)" / "Inequality in 1980 (1)"
+	~	1
+	~	Inequity is defined as "owners income after tax" divided by "workers \
+		imcome after tax".
+	|
+
+"Max life expectancy multiplier (1)"=
+	1.1
+	~	1 [0,1.3,0.01]
+	~	to match SSP2 assumption of LE up 2 years per decade
+	|
+
+Food footprint=
+	Cropland Mha * "Fertilizer use Mt/y"
+	~	Mha*Mt/y
+	~		|
+
+"Max fertility multiplier (1)"=
+	1.6
+	~	1 [1,1.5,0.01]
+	~	220224: changed from 1 to 1.6 to match SSP 2
+	|
+
+"CO2 emissions per person tCO2/y"=
+	( "CO2 from energy and industry GtCO2/y" / Population Mp ) * 1000
+	~	tCO2/p/y
+	~		|
+
+"Melting Mha/y"=
+	"Ice and snow cover excl G&A Mkm2" * "Melting rate surface 1/y"
+	~	Mkm3/y
+	~		|
+
+"Crop use per person t-crop/p/y"=
+	"Crop use Mt/y" / Population Mp
+	~	t/p/y
+	~		|
+
+"Forest absorption multipler (1)"=
+	IF THEN ELSE(Time>2022, 1 + "SSP2 land management action from 2022? (1)"* RAMP(("Max forest absorption multiplier (1)"\
+		 - 1)/78, 2022, 2100), 1)
+	~	
+	~		|
+
+"CO2 absorption in forestry land tCO2/ha/y"=
+	1.6 * "Forest absorption multipler (1)"
+	~	t/ha/y
+	~	Numbers for Northern forest from ESMICON 2016: 0.24 GtC/y * 3.7 tCO2/tC / 1100 Mha = \
+		0.8 tCO2/ha/y
+		Increased by 100% to include absorption in non-Northern forests
+	|
+
+"Old growth removal Mha/y"=
+	Old growth forest area Mha 1 * "Old growth removal rate 1/y" * "Old growth removal rate multiplier (1)"
+	~	Mha/y
+	~		|
+
+"Cropland expansion multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" *
+	RAMP((1 - 0 )/78, 2022, 2100),
+	1)
+	~	
+	~		|
+
+"Land erosion multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" * 
+	RAMP((1 - 0 )/ 78, 2022, 2100),
+	1)
+	~	1
+	~		|
+
+"Land erosion rate 1/y"=
+	"Land erosion rate in 1980 1/y" * "Fertilizer effect on erosion rate (1)" * "Land erosion multiplier (1)"
+	~	1/y
+	~		|
+
+"Cropland loss Mha/y"=
+	Cropland Mha * "Land erosion rate 1/y"
+	~	Mha/y
+	~		|
+
+"Grazing land yied in 1980 kg-red-meat/ha/y"=
+	14
+	*"CO2 effect on land yield (1)"
+	*"Warming effect on land yield (1)"
+	~	kg/kg [5,20,1]
+	~	Estimate derived from complex considerations. Should be between 10 and 30 \
+		kg red meat/ha/y in US grazing lands
+	|
+
+"Crop supply (after 20 % waste) Mt-crop/y"=
+	"Average crop yield t-crop/ha/y" * Cropland Mha
+	~	Mt/y
+	~		|
+
+"SSP2 land management action from 2022? (1)"=
+	1
+	~	1 [0,78,1]
+	~	1 means action as per SSP2. 0 means no action
+	|
+
+"Albedo in 1980 (1)"=
+	( Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2 * "Albedo ice and snow (1)"
+	+
+	( Global surface Mkm2 - Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2\
+		 ) * "Albedo global average (1)" )
+	/
+	Global surface Mkm2
+	~	1
+	~	Global average is 0.3, much higher than indicated by 75% ocean. Due to \
+		clouds! (Wikipedia)Fresh snow 0.8, desert 0.4, green grass, bare soil 0.2, \
+		0.25, forest ca 0.15, urban area ca 0.15 open ocean 0.06
+	|
+
+"Max forest absorption multiplier (1)"=
+	2
+	~	1
+	~		|
+
+"CO2 absorption in forestry land GtCO2/y"=
+	Forestry land Mha 
+	* ("CO2 absorption in forestry land tCO2/ha/y" / 1000 )
+	* "CO2 effect on land yield (1)"
+	* "Warming effect on land yield (1)"
+	~	GtCO2/y
+	~		|
+
+"Albedo (1)"=
+	( "Ice and snow cover excl G&A Mkm2" * "Albedo ice and snow (1)"
+	+
+	( Global surface Mkm2 - "Ice and snow cover excl G&A Mkm2" ) * "Albedo global average (1)"\
+		 )
+	/
+	Global surface Mkm2
+	~	1
+	~		|
+
+"Average crop yield t-crop/ha/y"=
+	( "Desired crop yield in conv ag t-crop/ha/y" * ( 1 - "Fraction regenerative agriculture (1)"\
+		 ) *
+	"Soil quality index in conv ag (1980=1)"
+	+
+	"Crop yield in reg ag t-crop/ha/y" * "Fraction regenerative agriculture (1)" )
+	* "CO2 effect on land yield (1)"
+	* "Warming effect on land yield (1)"
+	~	t/ha/y
+	~		|
+
+"Desired crop supply Mt-crop/y"=
+	"Crop demand Mt-crop/y"
+	~	Mt/y
+	~		|
+
+"Crop balance (1)"=
+	"Crop use Mt/y" / "Desired crop supply Mt-crop/y"
+	~	1
+	~		|
+
+Ice and snow cover Mha=
+	"Ice and snow cover excl G&A Mkm2" * 100
+	~	Mha
+	~		|
+
+"Old growth removal rate multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" *
+	RAMP((1 - 0 )/78, 2022, 2100), 1)
+	~	
+	~		|
+
+"Cropland expansion Mha/y"=
+	IF THEN ELSE(Forestry land Mha>0, Cropland Mha * "Cropland expansion rate 1/y", 0) 
+	*
+	"Acceptable loss of forestry land (1)"
+	*
+	"Cropland expansion multiplier (1)"
+	~	Mha/y
+	~		|
+
+"Land erosion rate in 1980 1/y"=
+	0.004
+	~	 [0,0.02,0.001]
+	~	equal to 1 / 250 years
+	|
+
+"4 TWh-el per Mtoe"=
+	"TWh-el per EJ - engineering equivalent" / "Mtoe per EJ - calorific equivalent"
+	~	MWh/toe
+	~		|
+
+"Renewable heat production Mtoe/y"=
+	"Biomass energy Mtoe/y" + "Green hydrogen Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"IIASA Renewable energy production EJ/yr"=
+	"Renewable electricity production TWh/y" / "TWh-el per EJ - engineering equivalent"
+	+
+	"Renewable heat production Mtoe/y" / "Mtoe per EJ - calorific equivalent"
+	~	EJ/y
+	~		|
+
+tCO2 per toe=
+	2.8*EXP("ROC in tCO2 per toe 1/y" * (Time -1980))
+	~	tCO2/toe
+	~	CO2 emissions per toe fell from 2.8 in 1980 to 2.4 in 2019 - minus 0.3 %/y \
+		- probably because of fuel shift
+	|
+
+"Efficiency of fossil power plant TWh-el/TWh-heat"=
+	0.345
+	~	1 [0,1,0.01]
+	~	1 toe contains 12 MWh-heat and produces ca 4 MWh-el in a modern fossil \
+		power plant. 4/12=ca0.345 (chosen to get 4 TWH-el per Mtoe)
+	|
+
+"Demand for fossil fuel for non-el use before NE Mtoe/y"=
+	( Population Mp
+	* "Traditional per person use of fossil fuels for non-el-use before EE toe/p/y" 
+	* EXP(-"Normal increase in energy efficiency 1/y" * ( Time - 1980 )))
+	/ "Extra energy productivity index 2022=1"
+	~	Mtoe/y
+	~		|
+
+"CO2 from energy and industry GtCO2/y"=
+	"CO2 from energy production GtCO2/y"
+	+
+	"CO2 from non-fossil industrial processes GtCO2/y"
+	~	GtCO2/y
+	~		|
+
+"ROC in tCO2 per toe 1/y"=
+	-0.003
+	~	
+	~	CO2 emissions per toe fell from 2.8 in 1980 to 2.4 in 2019 - minus 0.3 %/y \
+		- probably because of fuel shift
+	|
+
+"ENERGY USE Mtoe/y"=
+	"Demand for fossil fuel for non-el use Mtoe/y" + "Electricity production TWh/y" / "4 TWh-el per Mtoe"\
+		 + "Renewable heat production Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"IIASA Fossil energy production EJ/yr"=
+	"Use of fossil fuels Mtoe/y" / "Mtoe per EJ - calorific equivalent"
+	~	EJ/y
+	~		|
+
+"TWh-heat per EJ - calorific equivalent"=
+	278
+	~	TWh/EJ
+	~	From 1 J = 1 Ws and 1h = 3600 s
+	|
+
+"Demand for electricity before NE TWh/y"=
+	( Population Mp 
+	* "Traditional per person use of electricity before EE MWh/p/y" 
+	* EXP(-"Normal increase in energy efficiency 1/y" * ( Time - 1980)))
+	/ "Extra energy productivity index 2022=1"
+	~	TWh/y
+	~		|
+
+"Max non-fossil CO2 per person tCO2/p/y"=
+	0.5
+	~	tCO2/p/y [0,2,0.1]
+	~	CO2 from industrial processes was 3.4 GtCO2/y in 2019 i.e. 3.4/7.9=0.43 tCO2/p/y.
+		GDPpp=15.000 k$/p/y so max must be higher. In Norway much higher.
+	|
+
+"Mtoe per EJ - calorific equivalent"=
+	24
+	~	Mtoe/EJ
+	~	1 toe = 43 GJ. Means that 1Mtoe = 43 MGJ = 43e15 and 24 Mtoe = 1032 e15J = \
+		1.03 e18J = 1 EJ
+	|
+
+"TWh-el per EJ - engineering equivalent"=
+	"TWh-heat per EJ - calorific equivalent" * "Efficiency of fossil power plant TWh-el/TWh-heat"
+	~	TWh/EJ
+	~		|
+
+Total forest area Mha=
+	Old growth forest area Mha 1 + Forestry land Mha
+	~	Mha
+	~		|
+
+"Extra domestic ROTA from 2022 1/y"=
+	0.003
+	~	1/y [0,0.02,0.001]
+	~	220221 Changed from 0 to 0.003 to match SSP2 4-5 6-doubling of GDP from \
+		2000 to 2100
+	|
+
+"CO2 forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,0.01)],(1980,0.0032),(1990,0.0041),(2000,0.0046),(2020,0.0051),(2100\
+		,0.006) ))
+	~	W/m2/ppm
+	~		|
+
+N2O concentration in atm ppm=
+	N2O in atmosphere GtN2O / GtN2O per ppm
+	~	ppm
+	~		|
+
+"Forcing from CO2 W/m2"=
+	CO2 concentration in atm ppm * "CO2 forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from CO2 in 1980 W/m2" 
+		* ( 1 + LN( CO2 concentration in atm ppm / CO2 concentration in 1980 ppm))
+	|
+
+"Forcing from N2O W/m2"=
+	N2O concentration in atm ppm * "N2O forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from N2O in 1980 W/m2" * ( 1 + "N2O forcing per ppm W/m2/ppm" * ( N2O \
+		concentration in atm ppm / N2O concentration in atm in 1980 ppm
+		 - 1 ))
+	|
+
+"Acceptable loss of forestry land (1)"=
+	1 - EXP(-"Fraction forestry land remaining (1)"/"Threshold FFLR (1)")
+	~	1
+	~		|
+
+"Warming from extra heat deg/ZJ"=
+	0.0006
+	~	 [0,0.01,0.001]
+	~	was 0.8/1400=0.0006
+		since ca 1400 ZJ (40 years at net 35) added from 1980 to 2020 gave 1.2 - \
+		0.4 = 0.8 deg C warming
+	|
+
+Observed warming deg C=
+	Warming in 1980 deg C + ( Extra heat in surface ZJ - Extra heat in 1980 ZJ )*"Warming from extra heat deg/ZJ"
+	~	deg C
+	~		|
+
+"Fraction forestry land remaining (1)"=
+	MAX(0, Forestry land Mha / Forestry land in 1980 Mha )
+	~	1
+	~		|
+
+"Man-made forcing W/m2"=
+	"Forcing from CO2 W/m2" + "Forcing from CH4 W/m2" + "Forcing from N2O W/m2" + "Forcing from other gases W/m2"
+	~	
+	~		|
+
+"Total man-made forcing W/m2"=
+	"Man-made forcing W/m2" + "Water vapour feedback W/m2"
+	~	W/m2
+	~	"Forcing from CO2 W/m2" + "Forcing from CH4 W/m2" + "Forcing from N2O W/m2" \
+		+"Forcing from other gases 
+		+"Water vapour feedback W/m2"
+	|
+
+CH4 concentration in atm ppm=
+	CH4 in atmosphere GtCH4 / GtCH4 per ppm
+	~	ppm
+	~		|
+
+"Transfer rate for heat going to abyss 1/y"=
+	"Transfer rate surface-abyss in 1980 1/y" * (( Observed warming deg C + 287 ) /  287\
+		 )
+	~	1/y
+	~	I assume 273 + 14 = 287 deg K was the normal temperature in 1850
+	|
+
+CO2 concentration in atm ppm=
+	CO2 in atmosphere GtCO2 / GtCO2 per ppm
+	~	ppm
+	~		|
+
+N2O conc in 1980 ppm=
+	N2O in atm in 1980 GtN2O / Mass of atmosphere Zt
+	~	ppm
+	~		|
+
+GtCH4 per ppm=
+	5
+	~	GtCH4/ppm
+	~	In 1980 4 GtCH4 gave 1446 ppb = 1.5 ppm
+	|
+
+CH4 conc in 1980 ppm=
+	CH4 in atm in 1980 GtCH4 / Mass of atmosphere Zt
+	~	
+	~		|
+
+Mass of atmosphere Zt=
+	5
+	~	Zt
+	~	Weight of atmosphere is 5 * 10^15 ton. 29 g/mol
+	|
+
+"OWeoCOC (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoCOC>0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"Warming effect on life expectancy (1)"=
+	IF THEN ELSE(Time>2022, MAX(0, 1 + "sOWeoLE<0" * 
+	( Observed warming deg C / Observed warming in 2022 deg C - 1 )), 1 )
+	~	1
+	~		|
+
+OWeoLoCO2=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoLoCO2>0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"New forestry land Mha/y"=
+	"Old growth removal Mha/y" * ( 1 - "Fraction cleared for grazing (1)")
+	~	Mha/y
+	~		|
+
+"Forcing from CH4 W/m2"=
+	CH4 concentration in atm ppm * "CH4 forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from CH4 in 1980 W/m2" * ( 1 + "CH4 forcing per ppm W/m2/ppm" * (( CH4 \
+		concentration in atm ppm / CH4 concentration in atm in 1980 ppm
+		 ) - 1 ))
+	|
+
+Observed warming in 2022 deg C=
+	1.35
+	~	deg C
+	~	was 1.29, so 1.54, so 1.31, so 1.3
+	|
+
+"New grazing land Mha/y"=
+	"Old growth removal Mha/y" * "Fraction cleared for grazing (1)"
+	~	Mha/y
+	~		|
+
+"Warming effect on land yield (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoACY<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+CO2 concentration in 2022 ppm=
+	420
+	~	ppm
+	~	410 i 2018 plus ca 2 ppm/y
+	|
+
+"Traditional per person use of electricity before EE MWh/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(65,20)],(0,0),(10,4),(20,7),(30,9),(50,12),(65,13) ))
+	~	MWh/p/y
+	~	211023: Set equal to
+		([(0,0)-(60,10)],(0,0),(6.1,2.02),(9.3,2.35),(12.8,3.05),(60,10) )
+		corrected for 1%/y normal energy efficiency rise
+	|
+
+"CO2 effect on land yield (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sCO2CeoACY>0" * ( CO2 concentration in atm ppm / CO2 concentration in 2022 ppm\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"Traditional per person use of fossil fuels for non-el-use before EE toe/p/y"= WITH LOOKUP\
+		 (
+	"GDP per person k$/p/y",
+		([(0,0)-(60,5)],(0,0.3),(15,2),(25,3.1),(35,4),(50,5) ))
+	~	t/p/y
+	~	was([(0,0)-(60,5)],(0,0),(6.37,1),(9.63,1.1),(14,1.31),(50,5) )
+		211023: equal to
+		([(0,0)-(60,2)],(0,0),(6.1,0.85),(9.3,0.88),(12.8,0.88),(60,0.88) )
+		corrected for 1 %/y energy efficiency increase
+	|
+
+Warming in 1980 deg C=
+	0.4
+	~	deg C
+	~		|
+
+"Melting rate deep ice 1/y"=
+	"Melting rate surface 1/y" / "Surface vs deep rate (1)"
+	~	1/y
+	~		|
+
+"Risk of extreme heat event (1)"= WITH LOOKUP (
+	Observed warming deg C,
+		([(0,0)-(6,40)],(0,1),(1.2,4.8),(2,8.6),(2.9,14),(5.2,40) ))
+	~	1
+	~		|
+
+"Water vapour concentration 1980 g/kg"=
+	2
+	~	g/kg [0,3,0.1]
+	~	Value from ESMICON-pp
+	|
+
+"Water vapor concentration g/kg"=
+	"Water vapour concentration 1980 g/kg" *
+	( 1 + "sOWeoWV>0" * ( Observed warming deg C/ Warming in 1980 deg C - 1 ))
+	~	g/kg
+	~		|
+
+"Water vapor feedback in 1980 W/m2"=
+	0.9
+	~	W/m2 [0,1,0.1]
+	~	Equals fraction H20 / CO2 in Nature articlw (=0.8) times CO2 forcing in \
+		1980 (= 1.07 W/m2)
+	|
+
+"Forcing from other gases W/m2"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,1)],(1980,0.18),(2000,0.36),(2020,0.39),(2050,0.37),(2100,0) ))
+	~	W/m2
+	~	unclear what is happening in SSP 2.0
+	|
+
+"Transfer rate surface-abyss in 1980 1/y"=
+	0.01
+	~	y [0,0.03,0.001]
+	~	211103: changed from 0.001 to 0.01, ie equilibration time 100 years
+	|
+
+"N2O forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,2)],(1980,0.43),(2000,0.64),(2010,0.73),(2020,0.8),(2100,1) ))
+	~	1 [0,20,1]
+	~	Adjusted to get N2O forcing right, from 0.1 to 0.2 W/m2 1980 to 2020
+	|
+
+"Extra warming from forcing ZJ/y"=
+	( "Total man-made forcing W/m2"
+	* Global surface Mkm2)   
+	* 31.5 / 1000
+	~	ZJ/y
+	~	1 TW gir 31.5 ZJ/y (1 Z = 1E21)
+		since there are 365*24*60*60 = 31.5 million seconds in a year, and 1 J = 1Ws
+		1 W/m2 = 16 ZJ/y
+	|
+
+Amount of ice in 1980 Mkm3=
+	55
+	~	Mkm3 [0,55,1]
+	~	16 Mkm2 is Greenland 2.2 and Antarctica 14.2, say 3km thick => 52 Mkm3.
+		30 Mkm2 is land and ocean ice, say 100 m thick => 3 Mkm3
+	|
+
+"sWVeoWVF>0"=
+	3
+	~	1 [0,5,0.1]
+	~	Taken from scatter diagram ESMICON-pp Humidity effect on H2O Blocking
+	|
+
+"Melting rate surface in 1980 1/y"=
+	0.0015
+	~	1/y [0,0.003,0.0001]
+	~	was 0.001
+	|
+
+"CH4 forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,2)],(1980,0.82),(2000,0.94),(2020,1.01),(2100,1.1) ))
+	~	W/m2/ppm
+	~	To get CH4 forcing = 0.5 W/m2 in 2015
+	|
+
+"sOWeoWV>0"=
+	0.18
+	~	1 [0,0.3,0.01]
+	~	220221 Chosen to be smaller than CO2 forcing in 1980 and larger in 2020
+	|
+
+"Water vapour feedback W/m2"=
+	"Water vapor feedback in 1980 W/m2" 
+	* ( 1 + "sWVeoWVF>0" * ( "Water vapor concentration g/kg" / "Water vapour concentration 1980 g/kg"\
+		 - 1 ))
+	~	1
+	~	This is really "Forcing from H2O W/m2". Renamed "Water vapor feedback \
+		W/m2" to fit climate community language
+	|
+
+"Perceived unemployment CB (1)"=
+	SMOOTH("Unemployment rate (1)", Unemployment perception time CB y)
+	~	1
+	~		|
+
+"Fraction unprofitable activity in TAs (1)"=
+	0.3
+	~	 [0,1,0.1]
+	~		|
+
+"Cost of food and energy TAs G$/y"=
+	"Cost of food G$/y" + "Cost of energy G$/y"
+	~	
+	~		|
+
+"Demand in 1980 G$/y"=
+	"Optimal output in 1980 Gu/y" * "Price per unit $/u" * "SWI in 1980 (1)"
+	~	G$/y
+	~	28160*0.8=22528
+	|
+
+"Loss of cropland Mha/y"=
+	"Cropland loss Mha/y" + "Urban expansion Mha/y"
+	~	Mha/y
+	~		|
+
+"Loss of forest land Mha/y"=
+	"Old growth removal Mha/y" + "Cropland expansion Mha/y"
+	~	Mha/y
+	~		|
+
+"Average gross income per worker k$/p/y"=
+	"Wage rate $/ph" * "Average hours worked kh/y"
+	~	k$/p/y
+	~		|
+
+"Labour use Gph/y"=
+	Workforce Mp * "Average hours worked kh/y"
+	~	Gph/y
+	~		|
+
+"Labour use in 1980 Gph/y"=
+	Workforce in 1980 Mp * "Average hours worked in 1980 kh/y"
+	~	Gph/y
+	~		|
+
+"Cost of TAs G$/y"=
+	"Cost of food and energy TAs G$/y"
+	~	G$/y
+	~		|
+
+"Wage effect on optimal CLR (1)"=
+	SMOOTH("Indicated wage effect on optimal CLR (1)", Time to change tooling y)
+	~	1
+	~		|
+
+"Reduction in TFP from unprofitable activity (1)"=
+	SMOOTH("Productivity loss from unprofitable activity (1)", Investment planning time y\
+		 + Construction time PIS y)
+	~	1
+	~		|
+
+"Participation (1)"=
+	"Labour participation rate (1)" * ( 1 - "Perceived unemployment rate (1)" )
+	~	1
+	~		|
+
+"Indicated wage effect on optimal CLR (1)"=
+	1 + "sWSOeoCLR>0" * ( "Worker share of output (1)" / "WSO in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Average hours worked in 1980 kh/y"=
+	"Normal hours worked in 1980 kh/ftj/y" / "Persons per full-time job in 1980 p/ftj"
+	~	kh/y
+	~		|
+
+"Persons per full-time job in 1980 p/ftj"=
+	1
+	~	p/ftj
+	~		|
+
+"Average hours worked kh/y"=
+	"Normal hours worked kh/ftj/y" / "Persons per full-time job p/ftj"
+	~	kh/y
+	~		|
+
+Govmnt spending as share of GDP=
+	"Govmnt spending G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Worker disposable income k$/p/y"=
+	"Permanent worker cash inflow G$/y" / Workforce Mp
+	~	k$/p/y
+	~		|
+
+"Fraction of available capital to new capacity (1)"=
+	SMOOTH("FRA in 1980 (1)" * "FRACA mult from GDPpp - Line (1)"
+	*
+	( "WSO effect on flow to capacity addition (1)" 
+	+ 
+	"CBC effect on flow to capacity addion (1)" 
+	+ 
+	"ED effect on flow to capacity addition (1)"
+	 ) / 3, 
+	Investment planning time y )
+	~	1
+	~		|
+
+"FRACA mult from GDPpp - Line (1)"=
+	MAX(FRACA min, 1 + "sGDPppeoFRACA<0" * ( "GDP per person k$/p/y" / GDP per person in 1980\
+		 - 1 ))
+	~	1
+	~		|
+
+"sGDPppeoFRACA<0"=
+	-0.2
+	~	1 [-0.3,0,0.01]
+	~	was -0.1, so -0.15
+	|
+
+FRACA min=
+	0.65
+	~	1 [0,1,0.01]
+	~	was 0.8, so 0.7
+	|
+
+"Wage rate erosion rate 1/y"=
+	"Inflation rate 1/y" * ( 1 - "Fraction of inflation compensated (1)" )
+	~	1/y [0,0.02,0.001]
+	~		|
+
+"Labour productivity $/ph"=
+	( "Output Gu/y" * "Price per unit $/u" ) / "Labour use Gph/y"
+	~	$/ph
+	~		|
+
+"Labour productivity in 1980 $/ph"=
+	( "Optimal output in 1980 Gu/y" * "Cost per unit in 1980 $/u" ) / "Labour use in 1980 Gph/y"
+	~	$/ph
+	~		|
+
+"Optimal capital labour ratio kcu/ftj"=
+	"Embedded CLR kcu/ftj" * "Wage effect on optimal CLR (1)"
+	~	kcu/ftj
+	~		|
+
+"Change in wage rate $/ph/y"=
+	"Wage rate $/ph" * "ROC in WSO - Table 1/y"
+	~	$/ph/y
+	~		|
+
+"WSO effect on flow to capacity addition (1)"=
+	1 + "sWSOeoFRA<0" * ("Wage share (1)" / "WSO in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Optimal real output Gu/y"=
+	"Optimal output in 1980 Gu/y" * 
+	( ( Capacity PIS Gcu + Capacity PUS Gcu ) / ( CAP PIS in 1980 Gcu + CAP PUS in 1980 Gcu\
+		) )^Kappa * 
+	( "Labour use Gph/y" / "Labour use in 1980 Gph/y" )^Lambda  * 
+	( "Embedded TFP (1)" )
+	~	G$/y
+	~	was "Embedded TFP in 1980 (1)" * EXP("ROC in embedded TFP 1/y" * ( Time - \
+		1980 )
+	|
+
+"Fraction of inflation compensated (1)"=
+	1
+	~	1 [0,2,0.1]
+	~		|
+
+"Wage rate in 1980 $/ph"=
+	"Labour productivity in 1980 $/ph" * "WSO in 1980 (1)"
+	~	$/ph
+	~		|
+
+"CLR in 1980 kcu/ftj"=
+	41
+	~	kcu/ftj [8,12,0.1]
+	~	was 10
+		220113 changed from 9.8 to 10 for China
+		211222 Equal to capacity (3750 cu) divided by Available work seekers (383 Mp) = 9.8 \
+		for China in 1980
+		was 41
+		211127 changed from 44.7 to get suitable amplitude for new lower savings \
+		slope. Equilibrium 40.3
+	|
+
+"Embedded CLR kcu/ftj"= INTEG (
+	"Change in embedded CLR kcu/ftj/y",
+		"CLR in 1980 kcu/ftj")
+	~	kcu/ftj
+	~		|
+
+"Change in embedded CLR kcu/ftj/y"=
+	"ROC in ECLR 1/y" * "Embedded CLR kcu/ftj"
+	~	kcu/ftj/y
+	~		|
+
+"ROC in ECLR in 1980 1/y"=
+	0.02
+	~	1/y [0,0.1,0.001]
+	~	was 0.06
+		220114 changfd from 0.03 to 0.06 to get correct workforce growth to 810 Mp at peak \
+		in 2020
+		211216 increased from 0.01 to 0.03 to get decline in wso over time
+		210827 was 0.015, so 0.02, so 0.015, so 0.017
+	|
+
+"Central bank signal rate 1/y"= INTEG (
+	"Change in signal rate 1/yy",
+		"Normal signal rate 1/y")
+	~	1/y
+	~		|
+
+"Labour participation rate (1)"=
+	SMOOTH("Indicated labour participation rate (1)", "Time to enter/leave labor market y"\
+		)
+	~	1
+	~		|
+
+"Acceptable unemployment rate (1)"=
+	0.05
+	~	1 [0,0.1,0.001]
+	~		|
+
+"sTIeoNHW<0"=
+	-0.03
+	~	1 [-0.1,0,0.01]
+	~	NWH falls linerly from 2000 h/y at 6 k$/p/y to 1500 h/y at 48 k$/p/y.
+		Means sTeoNHW<0=-0.03
+	|
+
+Optimal workforce Mp=
+	( Capacity Gcu / "Optimal capital labour ratio kcu/ftj" ) * "Persons per full-time job p/ftj"
+	~	Mp
+	~		|
+
+"Persons per full-time job p/ftj"=
+	1
+	~	p/ftj [0,2,0.01]
+	~		|
+
+"Wage rate $/ph"= INTEG (
+	"Change in wage rate $/ph/y"-"Wage rate erosion $/ph/y",
+		"Wage rate in 1980 $/ph")
+	~	$/ph
+	~		|
+
+"Hours worked mult from GDPpp (1)"=
+	1 + "sTIeoNHW<0" * ( "GDP per person k$/p/y" / GDP per person in 1980 - 1 )
+	~	1
+	~	Falls linerly from 2000 h/y at 6 k$/p/y to 1500 h/y at 48 k$/p/y.
+		Means sTeoNHW<0=-0.03
+	|
+
+"sWSOeoCLR>0"=
+	1.05
+	~	1 [0.9,1.1,0.01]
+	~	was 0.6, so 1.2, so 1, so 1.1, so 1
+	|
+
+"Wage share (1)"=
+	"Wage rate $/ph" / "Labour productivity $/ph"
+	~	1
+	~		|
+
+"Normal hours worked in 1980 kh/ftj/y"=
+	2
+	~	kh/ftj/y
+	~		|
+
+"Normal hours worked kh/ftj/y"=
+	SMOOTHI( "Normal hours worked in 1980 kh/ftj/y" * "Hours worked mult from GDPpp (1)"\
+		, Time to adjust hours worked y, "Normal hours worked in 1980 kh/ftj/y")
+	~	kh/ftj/y
+	~		|
+
+"FRACA mult from GDPpp - Table (1)"= WITH LOOKUP (
+	"GDP per person k$/p/y" / GDP per person in 1980,
+		([(0,0)-(16,1)],(0,1),(1,1),(2,0.85),(2.1,0.84),(4,0.65),(8,0.55),(16,0.5) ))
+	~	
+	~		|
+
+"WSO in 1980 (1)"=
+	0.5
+	~	1 [0.4,0.8,0.01]
+	~		|
+
+"Real wage erosion rate 1/y"=
+	0.015
+	~	y [0,0.02,0.001]
+	~	was 0.015, so 0.01,
+	|
+
+Working age population Mp=
+	"Aged 20-pension age Mp"
+	~	Mp
+	~		|
+
+"Change in workforce Mp/y"=
+	( Optimal workforce Mp - Workforce Mp ) / "Hiring/firing delay y"
+	~	Mj/y
+	~		|
+
+Available workforce Mp=
+	Working age population Mp * "Labour participation rate (1)"
+	~	Mp
+	~		|
+
+Time to adjust hours worked y=
+	5
+	~	y
+	~		|
+
+"Wage rate erosion $/ph/y"=
+	"Wage rate $/ph" * "Wage rate erosion rate 1/y"
+	~	$/ph/y
+	~		|
+
+"Long-term erosion of wso 1/y"=
+	"Worker share of output (1)" * "Real wage erosion rate 1/y"
+	~	1/y
+	~		|
+
+"Perceived unemployment rate (1)"=
+	SMOOTHI("Unemployment rate (1)", Unemployment perception time y , "Unemployment rate in 1980 (1)"\
+		)
+	~	
+	~		|
+
+"sWSOeoLPR>0"=
+	0.2
+	~	1 [0,1,0.01]
+	~	was 1, so 0, so 0.5
+	|
+
+"Unemployment rate (1)"=
+	Unemployed Mp / Available workforce Mp
+	~	1
+	~		|
+
+"Unemployment rate in 1980 (1)"=
+	0.05
+	~	1 [0,0.1,0.01]
+	~		|
+
+"sPUNeoLPR>0"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~	was 0.5, so 0
+	|
+
+"Worker share of output (1)"= INTEG (
+	"Change in wso 1/y"-"Long-term erosion of wso 1/y",
+		"WSO in 1980 (1)")
+	~	1
+	~		|
+
+"ROC in WSO - Table 1/y"= WITH LOOKUP (
+	"Perceived unemployment rate (1)" / "Acceptable unemployment rate (1)",
+		([(0,-0.06)-(2,0.06)],(0,0.06),(0.5,0.02),(1,0),(1.5,-0.007),(2,-0.01) ))
+	~	1/y
+	~		|
+
+Workforce in 1980 Mp=
+	1530
+	~	Mp [1000,1800,10]
+	~	was 1330, so 1600, so 1530 to avoid tarnsient in unemployment.
+		Still need to ge the phase right (that is bottom in unemployment around \
+		2000, 2008, 2020). Should probably be done by adjusting the labor \
+		participation rate in 1980
+	|
+
+Workforce Mp= INTEG (
+	"Change in workforce Mp/y",
+		Workforce in 1980 Mp)
+	~	Mp
+	~		|
+
+"Indicated labour participation rate (1)"=
+	"Normal LPR (1)" - "Perceived surplus workforce (1)"
+	~	1
+	~		|
+
+Unemployed Mp=
+	MAX(0, Available workforce Mp - Workforce Mp)
+	~	Mp
+	~		|
+
+"Perceived surplus workforce (1)"=
+	"Acceptable unemployment rate (1)" * ( 1 + "sPUNeoLPR>0" * ( "Perceived unemployment rate (1)"\
+		 / "Acceptable unemployment rate (1)"
+	 - 1 ))
+	~	1
+	~		|
+
+"Normal LPR in 1980 (1)"=
+	0.85
+	~	1 [0.7,0.9,0.01]
+	~	was 0.7
+	|
+
+"Time to enter/leave labor market y"=
+	5
+	~	y [0,20,1]
+	~		|
+
+"Change in wso 1/y"=
+	"Worker share of output (1)" * "ROC in WSO - Table 1/y"
+	~	1/y
+	~		|
+
+GDP per person in 1980=
+	6.4
+	~	k$/p/y [6.2,6.5,0.02]
+	~	was 6.1
+	|
+
+Observed fertility 1=
+	Desired no of children 1 * "Fraction achieving desired family size (1)"
+	~	1
+	~	220207 changed from "As math: Observed fertility 1"
+		220114 changed from Desired no of children 1 * "Fraction achieving desired family \
+		size (1)"
+		210821 changed from: IF THEN ELSE(Time>"Fertility = 2.5 introduction time \
+		y", 2.5 , Desired no of children 1)
+	|
+
+Capacity Gcu=
+	Capacity PIS Gcu + Capacity PUS Gcu
+	~	Gcu
+	~		|
+
+"Passing 40 in 1980 Mp/y"=
+	64
+	~	Mp/y [0,20,1]
+	~	was 13
+	|
+
+"TFP including effect of 5TAs (1)"=
+	"TFP excluding effect of 5TAs (1)" * ( 1 - "Reduction in TFP from unprofitable activity (1)"\
+		 )
+	~	1
+	~	was
+		"TFP excluding effect of 5TAs (1)" * ( 1 - "Reduction in TFP from \
+		less-cost-effective activities (1)" )
+	|
+
+"Passing 60 in 1980 Mp/y"=
+	38
+	~	Mp/y [0,20,1]
+	~	was 8
+	|
+
+"Passing 60 Mp/y"= 
+	DELAY N("Passing 40 Mp/y", 20, "Passing 60 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+"Deaths Mp/y"= 
+	DELAY N("Passing 60 Mp/y", LE at 60 y, "Dying in 1980 Mp/y", Order)
+	~	Mp/y
+	~	211111: Changed from IF THEN ELSE(LE at 60 y > 0, SMOOTH3("Aged 60 + Mp" / \
+		LE at 60 y, 20), 0)
+	|
+
+"Aged 40-60 in 1980 Mp"=
+	768
+	~	Mp
+	~	was 174
+	|
+
+"Dying in 1980 Mp/y"=
+	30
+	~	Mp/y [0,12,1]
+	~	was 6.3
+	|
+
+"Aged 60 + Mp"= INTEG (
+	"Passing 60 Mp/y"-"Deaths Mp/y",
+		"Aged 60+ in 1980 Mp")
+	~	Mp
+	~	was 382
+	|
+
+"Max imported ROTA from 2022 1/y"=
+	0.005
+	~	1/y [0,0.005,0.001]
+	~	0 in TLTL and 0.005 in GL
+		was at least 0.02 for China from 1980 to 2010: The technological lead of \
+		the West added at least 2 % points to China's growth.
+	|
+
+"Cost per unit in 1980 $/u"=
+	0.8
+	~	$/u [0.9,1.2,0.01]
+	~		|
+
+"Jobs in 1980 M-ftj"=
+	1600
+	~	Mp [350,400,1]
+	~	500
+		220109 changed from 382 to 500 to match David's data
+		211222 Equal to (Aged 20-pension age)*0.9*0.95=447*0.9*0.95=382, and reduced to 371 \
+		to avoid transient
+		was 1600
+		was 1330 (*1.2 = 1.600) to get phase correct
+	|
+
+"Passing 40 Mp/y"= 
+	DELAY N("Passing 20 Mp/y", 20, "Passing 40 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+"Aged 60+ in 1980 Mp"=
+	382
+	~	Mp
+	~	was 86
+	|
+
+"GDPpp of technology leader k$/p/y"=
+	15
+	~	k$/p/y
+	~	I assume countries stop copying at GDPpp=15.000 $/p/y
+	|
+
+"Capacity initiation PUS Gcu/y"=
+	MAX( ( "Govmnt investment in public capacity G$/y" + "Off-balance-sheet govmnt inv in PUS (share of GDP)"\
+		 * "GDP G$/y") / "Cost of capacity $/cu", 0)
+	~	Gcu/y
+	~		|
+
+"Aged 40-60 Mp"= INTEG (
+	"Passing 40 Mp/y"-"Passing 60 Mp/y",
+		"Aged 40-60 in 1980 Mp")
+	~	
+	~	was 768
+	|
+
+"Passing 20 in 1980 Mp/y"=
+	100
+	~	Mp/y [0,30,1]
+	~	was 21
+	|
+
+"Passing 20 Mp/y"= 
+	DELAY N("Births Mp/y", 20, "Passing 20 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+Multiplier to avoid transient in unemployment=
+	1
+	~	1 [0.8,1.2,0.01]
+	~	220114 changed from 0.97 to 1 to get initial jobs = 500 Mp
+	|
+
+"Optimal ouput - value G$/y"=
+	"Optimal real output Gu/y" * "Price per unit $/u"
+	~	G$/y
+	~		|
+
+"Capacity initiation PIS Gcu/y"=
+	MAX( ( "Investment in new capacity PIS G$/y" + "Off-balance sheet govmnt inv in PIS (share of GDP)"\
+		 * "GDP G$/y" )  / "Cost of capacity $/cu" , 0)
+	~	Gcu/y
+	~		|
+
+"Govmnt stimulus from 2022 (share of NI)"=
+	0
+	~	1 [0,0.1,0.01]
+	~		|
+
+Regenerative agriculture area Mha=
+	Cropland Mha * "Fraction regenerative agriculture (1)"
+	~	Mha
+	~		|
+
+"Cost of fertilizer G$/y"=
+	"Fertilizer use Mt/y" * "Cost per ton fertilizer $/t" / 1000
+	~	G$/y
+	~		|
+
+Goal for extra pension age y=
+	0
+	~	1 [0,10,1]
+	~	Can be set to 5, if one want to lift the pension age from 82 to 89 in 2100.
+	|
+
+Pension age y=
+	IF THEN ELSE(Life expectancy y < LE in 1980, Pension age in 1980 y, Pension age in 1980 y\
+		 + "sLEeoPa>0" * ( Life expectancy y + Extra pension age y
+	 - LE in 1980 ))
+	~	y [62,80,1]
+	~		|
+
+"Cost of food G$/y"=
+	"Agriculture as fraction of GDP (1)" * "GDP G$/y" + "Cost of regenerative agriculture G$/y"\
+		 + "Cost of fertilizer G$/y"
+	~	G$/y
+	~		|
+
+"Effective GDP per person k$/p/y"=
+	SMOOTHI("GDP per person k$/p/y", Time to adapt to higher income y, "GDP per person in 1980 k$/p/y"\
+		)
+	~	k$/p/y
+	~		|
+
+Forestry land Mha= INTEG (
+	"New forestry land Mha/y"-"Cropland expansion Mha/y",
+		Forestry land in 1980 Mha)
+	~	Mha
+	~		|
+
+Cropland Mha= INTEG (
+	"Cropland expansion Mha/y"-"Cropland loss Mha/y"-"Urban expansion Mha/y",
+		Cropland in 1980 Mha)
+	~	Mha
+	~	From HYDE: Cropland 1.600
+	|
+
+"Agriculture as fraction of GDP (1)"=
+	0.05
+	~	
+	~		|
+
+"Cost of food and energy as share of GDP (1)"=
+	"Cost of food and energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Extra CO2 absorption in reg ag GtCO2/y"=
+	Regenerative agriculture area Mha * "CO2 absorbed in reg ag tCO2/ha/y" / 1000
+	~	GtCO2/y
+	~		|
+
+"CO2 absorbed in reg ag tCO2/ha/y"=
+	1
+	~	
+	~	pure guess, but this is approx what is photosyntesized per ha per year
+	|
+
+"Cost of food and energy G$/y"=
+	"Cost of food G$/y" + "Cost of energy G$/y"
+	~	G$/y
+	~		|
+
+"CO2 emissions from LULUC GtCO2/y"=
+	"CO2 release from forest cut GtCO2/y" - "CO2 absorption in forestry land GtCO2/y" - \
+		"Extra CO2 absorption in reg ag GtCO2/y"
+	~	
+	~		|
+
+"CO2 release from forest cut GtCO2/y"=
+	(( "Old growth removal Mha/y" + "Cropland expansion Mha/y" )
+	* 
+	"CO2 release per ha of forest cut tCO2/ha") / 1000
+	~	GtCO2/y
+	~		|
+
+"sIIEeoROTA<0"=
+	-0.1
+	~	1 [-0.2,0,0.01]
+	~		|
+
+Extra pension age in 2022 y=
+	0
+	~	1 [0,0.4,0.02]
+	~		|
+
+"Embedded labour productivity in 1980 k$/p/y"=
+	"Optimal output in 1980 Gu/y" / "Jobs in 1980 M-ftj"
+	~	k$/p/y
+	~		|
+
+"sCO2CeoACY>0"=
+	0.3
+	~	1 [0,1,0.1]
+	~	I assume that yields increase in proportion with CO2 ppm (ie s=1) after \
+		2022, but should have been at a a declining pace
+	|
+
+"sOWeoACY<0"=
+	-0.3
+	~	1 [-1,0,0.1]
+	~	I assume that yields decrease slowly with rising temperatures after 2022, \
+		but should accelerate.
+	|
+
+"CO2 release per ha of forest cut tCO2/ha"=
+	65
+	~	t/ha
+	~	Numbers for Northern forests from ESMICON 2016: (215 GtC * 3.7 tCO2/tC ) / 1100 Mha \
+		= 72 tCO2/ha
+		Numbers for Southern forests from ESMICON 2016: (260 GtC * 3.7 tCO2/tC ) / \
+		1600 Mha = 60 tCO2/ha
+	|
+
+"sFFLReoOGRR<0"=
+	-5
+	~	1 [-5,0,0.1]
+	~	Parametrized to ensure there is still some forestry land in 2100 in Base \
+		Case
+	|
+
+"Cost of capacity $/cu"=
+	"Cost of capacity in 1980 $/cu" * "OWeoCOC (1)"
+	~	$/cu
+	~		|
+
+"Cost of capacity in 1980 $/cu"=
+	1
+	~	$/cu [0.8,1.3,0.01]
+	~		|
+
+"Forests cleared Mha/y"=
+	0
+	~	
+	~		|
+
+"OGRR in 1980 1/y"=
+	0.004
+	~	1/y [0,0.01,0.001]
+	~	0.4 % per year is a rough estimate based on tropical rainforest removal of \
+		1%/y and Northern forest regrowth of 0.3%/y
+	|
+
+"Threshold FFLR (1)"=
+	0.2
+	~	1 [0,2,0.1]
+	~	Parametrized to ensure there is still some forestry land in 2100 in Base \
+		Case
+	|
+
+"Old growth removal rate 1/y"=
+	"OGRR in 1980 1/y"
+	*
+	FFLReoOGRR
+	~	1/y
+	~		|
+
+FFLReoOGRR=
+	MAX(1, 1 + "sFFLReoOGRR<0" * ( "Fraction forestry land remaining (1)" - "Threshold FFLR (1)"\
+		 ))
+	~	1
+	~		|
+
+"sPUNeoPEW>0"=
+	0.5
+	~	1
+	~		|
+
+"Time to join/leave job market y"=
+	3
+	~	1 [0,10,1]
+	~	was 8, so 4, so 5
+	|
+
+"Fraction NASJ in 1980 (1)"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~		|
+
+"ROC in CLR 1/y"=
+	"ROC in CLR in 1980 1/y"
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"Fraction Aged 20-pension age wanting paid work in 1980 (1)"=
+	0.9
+	~	1 [0.9,1.2,0.01]
+	~	was 1.13
+		220113 changed from 0.7 to 1.13 to fit Chinese WF statistics (WF=500, Aged \
+		20-pension age = 466). Means 34 out of 500 Mp below 20 working, 7%. \
+		Probably much too low.
+		was 0.9 for world
+	|
+
+"Normal unemployment rate (1)"=
+	0.05
+	~	1 [0,0.1,0.01]
+	~		|
+
+Time for people to prepare for paid work y=
+	5
+	~	y [0,20,1]
+	~		|
+
+"sWSOeoWPR>0"=
+	1
+	~	1 [0,2,0.01]
+	~		|
+
+"Change in ECLR k$/y/y"=
+	"ROC in CLR 1/y" * "Embedded CLR k$/j"
+	~	k$/y/y
+	~		|
+
+"ROC in CLR in 1980 1/y"=
+	0.02
+	~	1/y [0,0.1,0.005]
+	~	was 0.06
+		220114 changfd from 0.03 to 0.06 to get correct workforce growth to 810 Mp at peak \
+		in 2020
+		211216 increased from 0.01 to 0.03 to get decline in wso over time
+		210827 was 0.015, so 0.02, so 0.015, so 0.017
+	|
+
+Infrastructure purchases ratio y=
+	Capacity PUS Gcu / "Govmnt purchases G$/y"
+	~	y
+	~	Is te equivalent of the capital output ratio in the productive economy.
+		Happens to be 6 years rather than 2.5
+	|
+
+"PCOR PUS cu/u/y"=
+	2.3
+	~	y [0,3.5,0.1]
+	~	was 2.5
+		211216 changed back from 2.3 to 2.5 to get slower growth
+	|
+
+"Embedded CLR k$/j"= INTEG (
+	"Change in ECLR k$/y/y",
+		"CLR in 1980 k$/j")
+	~	k$/j
+	~		|
+
+"Optimal output in 1980 Gu/y"=
+	CAP PIS in 1980 Gcu / "PCOR PIS cu/u/y" + CAP PUS in 1980 Gcu / "PCOR PUS cu/u/y"
+	~	G$/y
+	~		|
+
+"Owner savings fraction (1)"=
+	Owner savings fraction in 1980 
+	* 
+	( 1 + "sGDPeoOSR<0" * 
+	( "Effective GDP per person k$/p/y" / "GDP per person in 1980 k$/p/y" - 1 ))
+	~	1
+	~		|
+
+Capacity PUS Gcu= INTEG (
+	"Capacity addition PUS Gcu/y"-"Capacity discard PUS Gcu/y",
+		CAP PUS in 1980 Gcu)
+	~	Gcu
+	~		|
+
+Capacity under construction PUS Gcu= INTEG (
+	"Capacity initiation PUS Gcu/y"-"Capacity addition PUS Gcu/y",
+		CUC PUS in 1980 Gcu)
+	~	Gcu
+	~	was 160
+	|
+
+CUC PUS in 1980 Gcu=
+	( CAP PUS in 1980 Gcu / Life of capacity PUS in 1980 y ) * Construction time PUS y *\
+		 "Extra mult on CUC, to avoid initial transient in Investment share of GDP"
+	~	Gcu
+	~		|
+
+"Capacity addition PUS Gcu/y"=
+	Capacity under construction PUS Gcu / Construction time PUS y
+	~	Gcu/y
+	~		|
+
+Construction time PUS y=
+	1.5
+	~	y
+	~	was 2
+	|
+
+CAP PUS in 1980 Gcu=
+	5350
+	~	Gcu [750,1070,10]
+	~	was 1000
+		220113 Changed from 750 to 1000 to match China
+		was 5879, so 5350, so 14000
+	|
+
+Life of capacity PUS y=
+	Life of capacity PUS in 1980 y
+	~	y
+	~		|
+
+"Capacity discard PUS Gcu/y"=
+	Capacity PUS Gcu / Life of capacity PUS y
+	~	Gcu/y
+	~		|
+
+Life of extra CO2 in atm y=
+	Life of extra CO2 in atm in 1980 y * OWeoLoCO2
+	~	y [0,200,5]
+	~		|
+
+Life of extra CO2 in atm in 1980 y=
+	60
+	~	y
+	~	211102: changed from 9 to 60 to match observed history (after I found a mistake)
+		And before UG calculated that in ESMICON it rises from 40 to 60
+	|
+
+"sOWeoLoCO2>0"=
+	1
+	~	1 [0,2,0.1]
+	~	was 0
+	|
+
+"tCO2e/tCH4"=
+	23
+	~	1
+	~		|
+
+"GHG EMISSIONS GtCO2e/y"=
+	"CO2 emissions GtCO2/y" * "tCO2e/tCO2"
+	+
+	"CH4 emissions GtCH4/y" * "tCO2e/tCH4"
+	+
+	"N2O emissions GtN2O/y" * "tCO2e/tN2O"
+	~	GtCO2e/y
+	~		|
+
+"tCO2e/tN2O"=
+	7
+	~	1
+	~	guestimate
+	|
+
+"tCO2e/tCO2"=
+	1
+	~	1
+	~		|
+
+"Govmnt net income as share of NI (1)"=
+	"Govmnt net income G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Income tax rate owners in 1980 (1)"=
+	0.4
+	~	1 [0,1,0.1]
+	~	211125 changed from 0.2 to mimic more typical countries than US
+	|
+
+"Basic income tax rate workers (1)"=
+	0.2
+	~	1 [0,1,0.1]
+	~	211125 changed from 0.1 to mimic more typical countries than US
+	|
+
+"Extra general tax rate from 2022 (1)"=
+	0.01
+	~	1 [0,0.1,0.01]
+	~	0 in TLTL and 0.01 in GL
+	|
+
+"Extra cost of Energy Turnaround as share of GDP (1)"=
+	IF THEN ELSE(Time>2022, ( "Cost of energy G$/y" - "Traditional cost of energy G$/y" \
+		) / "GDP G$/y", 0)
+	~	1
+	~		|
+
+"Ratio of Energy cost to Trad energy cost (1)"=
+	"Cost of energy G$/y" / "Traditional cost of energy G$/y"
+	~	1
+	~		|
+
+"Extra cost of reg ag $/ha/y"=
+	"Extra cost of reg ag in 2022 $/ha/y" * "Cost index for Regenerative agriculture (1)"
+	~	$/ha/y [0,600,20]
+	~		|
+
+"Traditional cost of electricity $/kWh"=
+	0.03
+	~	$/kWh
+	~	80% fossil at 0.03, 15 % nuclear at 0.033, 5 % hydro at 0.025
+	|
+
+"Traditional cost of electricity G$/y"=
+	( "Demand for electricity before NE TWh/y" * "Traditional cost of electricity $/kWh"\
+		 / 1000 ) 
+	* "Adjustment factor to make costs match 1980-2022 (1)"
+	~	G$/y
+	~		|
+
+"Traditional cost of energy as share of GDP (1)"=
+	"Traditional cost of energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Traditional cost of fossil fuel for non-el use $/toe"=
+	240
+	~	$/toe
+	~	Cost per ton is cost per barrel times 6.
+		33% coal at 30*6=180, 33 % oil at 50*6=300, 33 % gas at 40*6=240
+	|
+
+"Addition of sun and wind capacity GW/y"=
+	"Addition of renewable el capacity GW/y"
+	~	GW/y
+	~		|
+
+"Adjustment factor to make costs match 1980-2022 (1)"=
+	1.35
+	~	1 [1,3,0.1]
+	~		|
+
+"Cost of regenerative agriculture G$/y"=
+	( "Extra cost of reg ag $/ha/y" * Regenerative agriculture area Mha ) / 1000
+	~	G$/y
+	~		|
+
+"Cost of grid G$/y"=
+	"Electricity production TWh/y" * "Transmission cost $/kWh"
+	~	G$/y
+	~		|
+
+"Extra cost of Food Turnaround as share of GDP (1)"=
+	"Extra cost of Food Turnaround G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Amount of fertilizer saved in reg ag kgN/ha/y"=
+	268 - "Sustainable fertiliser use kgN/ha/y"
+	~	kg/ha/y
+	~	Comment: From the table function I know that 268 kgN/ha/y fertilizer is \
+		needed to achieve the yield in regenerative agriculture (namely 7 \
+		tcrop/ha/y). I assume that reg ag reduces this need to the sustainable use \
+		20 kgN/ha/y
+	|
+
+"Traditional grid cost G$/y"=
+	"Demand for electricity before NE TWh/y" * "Transmission cost $/kWh"
+	~	G$/y
+	~		|
+
+"Extra cost of reg ag in 2022 $/ha/y"=
+	400
+	~	$/ha/y [0,600,50]
+	~	I assume that reg ag requires 30 % higher manpower input, and that this increases \
+		total farming cost by 30%.
+		Current manpower input in Norway is 20.000 fulltime farmers cultivating 1 \
+		Mha => 0.02 p/ha/y. At 600.000 kr/p/y this means an extra cost of \
+		30%*600.000 kr/p/y*0.02 p/ha/y = 3600 kr/p/y or 400$/ha/y
+	|
+
+"Cost per ton fertilizer $/t"=
+	500
+	~	$/t
+	~	Taken from Norway 2020 3000 - 5000 kr pr ton fertilizer
+	|
+
+"Cost reduction per doubling in Regenerative agriculture (1)"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~	was 0.1
+	|
+
+"Traditional cost of energy G$/y"=
+	"Traditional cost of electricity G$/y" + "Traditional cost of fossil fuel for non-el use G$/y"\
+		 + "Traditional grid cost G$/y"
+	~	G$/y
+	~		|
+
+Investment planning time y=
+	1
+	~	y [0,10,1]
+	~		|
+
+"Cost of nuclear electricity G$/y"=
+	"Nuclear electricity production TWh/y"
+	*
+	"Cost of nuclear el $/kWh"
+	~	G$/y
+	~		|
+
+"Cost of fossil fuel for non-el use G$/y"=
+	("Demand for fossil fuel for non-el use Mtoe/y"
+	* 
+	"Traditional cost of fossil fuel for non-el use $/toe" )
+	/1000
+	~	G$/y
+	~		|
+
+"Fertilizer cost reduction G$/y"=
+	( "Amount of fertilizer saved in reg ag kgN/ha/y" / 1000) * Regenerative agriculture area Mha\
+		 * ("Cost per ton fertilizer $/t" )
+	~	G$/y
+	~		|
+
+"Cost of energy as share of GDP (1)"=
+	"Cost of energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"OPEX fossil el G$/y"=
+	"OPEX fossil el $/kWh" * "Fossil electricity production TWh/y"
+	~	G$/y
+	~		|
+
+"Cost of renewable electricity G$/y"=
+	"CAPEX renewable el G$/y" + "OPEX renewable el G$/y"
+	~	G$/y
+	~		|
+
+"FRA in 1980 (1)"=
+	0.9
+	~	1 [0.8,1.2,0.01]
+	~	was 1, so 0.84
+		was 0.8, so 0.76, so 0.84 so back to 1, since this was case in GROWTH model
+		211126 changed from 1 to reduce GDP growth rate from 4 %/y to 3.5%
+	|
+
+"Cost of fossil electricity G$/y"=
+	"CAPEX fossil el G$/y" + "OPEX fossil el G$/y"
+	~	G$/y
+	~		|
+
+"Cost of nuclear el $/kWh"=
+	0.033
+	~	$/kWh
+	~	I assume nuclear el is 10 % more expensive than fossil el
+	|
+
+"Extra cost of Food Turnaround G$/y"=
+	"Cost of regenerative agriculture G$/y" - "Fertilizer cost reduction G$/y"
+	~	G$/y
+	~		|
+
+"Cost of electricity G$/y"=
+	"Cost of fossil electricity G$/y" + "Cost of renewable electricity G$/y" + "Cost of nuclear electricity G$/y"
+	~	G$/y
+	~		|
+
+"Traditional cost of fossil fuel for non-el use G$/y"=
+	( "Demand for fossil fuel for non-el use before NE Mtoe/y" * "Traditional cost of fossil fuel for non-el use $/toe"\
+		 / 1000 )
+	*
+	"Adjustment factor to make costs match 1980-2022 (1)"
+	~	G$/y
+	~		|
+
+"Transmission cost $/kWh"=
+	0.02
+	~	$/kWh
+	~	DNV-GL ETO 2018 p 176 says 0.02
+	|
+
+"Govmnt net income G$/y"=
+	"Govmnt gross income G$/y" - "Transfer payments G$/y" + "Sales tax G$/y"
+	~	G$/y
+	~		|
+
+"Cost of Max fertility reduction (share of GDP)"=
+	0.01
+	~	1
+	~		|
+
+"Births Mp/y"=
+	"Aged 20-40 years Mp" * "Fraction women (1)" * ( Observed fertility 1 / Fertile period y\
+		 )
+	~	Mp/y
+	~		|
+
+"State capacity in 1980 (fraction of GDP)"=
+	0.3
+	~	1 [0,1,0.01]
+	~	was 0.15
+	|
+
+"Change in TFP 1/y"=
+	"Rate of technological advance 1/y" * "TFP excluding effect of 5TAs (1)"
+	~	1/y
+	~		|
+
+"Domestic ROTA in 1980 1/y"=
+	0.01
+	~	1/y [0,0.04,0.001]
+	~	was 0.01, so 0.04
+	|
+
+"sSCeoROTA>0"=
+	0.5
+	~	1 [0,1,0.1]
+	~		|
+
+"sOWeoCOC>0"=
+	0.2
+	~	1 [0,1,0.01]
+	~	220323 Set 0.2 to get investment cost 20 % at +2.5 deg C (ie +8% per deg C)
+		Way way above the estimate of NN in SDR 2021 used "Loss of GDPPC growth per \
+		additional degree = 0.005", which I represent as sOWeoCI = 0.0065 from \
+		2022 (since observed warming in 2022 is 1.3 deg C)
+		(CI is capacity addition)
+	|
+
+"sOWeoLE<0"=
+	-0.02
+	~	1 [-0.4,0,0.01]
+	~	Set to -0.02 means a reduction in LE by 2.5 years in 2100 at +2.5 deg C, ie 1 years \
+		per deg C
+		NN in SDR 2021 used "Fractional increase in death rates per additional degree = \
+		0.02".
+		means a reduction in LE of 2 years when temp increases 1 deg C.
+	|
+
+"sIPReoVPSS>0"=
+	1
+	~	1 [1,2,0.1]
+	~	Guess
+	|
+
+"TFP excluding effect of 5TAs (1)"= INTEG (
+	"Change in TFP 1/y",
+		"TFP in 1980 (1)")
+	~	1
+	~		|
+
+"Public services per person k$/p/y"=
+	"Value of public services supplied G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+"Effect of capacity renewal 1/y"=
+	( "Indicated TFP (1)" - "Embedded TFP (1)" ) * "Capacity renewal rate 1/y"
+	~	1/y
+	~		|
+
+"Embedded TFP (1)"= INTEG (
+	"Effect of capacity renewal 1/y",
+		"Embedded TFP in 1980 (1)")
+	~	1
+	~		|
+
+"Capacity renewal rate 1/y"=
+	"Capacity addition PIS Gcu/y" / Capacity PIS Gcu
+	~	1/y
+	~		|
+
+"Productivity of public purchases (1)"=
+	MAX(0, 1 + "sIPReoVPSS>0"* LN(Infrastructure purchases ratio y/Infrastructure purchases ratio in 1980 y\
+		))
+	~	1
+	~		|
+
+Infrastructure purchases ratio in 1980 y=
+	1.2
+	~	y
+	~		|
+
+"TFP in 1980 (1)"=
+	1
+	~	1
+	~		|
+
+"Value of public services supplied G$/y"=
+	"Govmnt purchases G$/y" * "Productivity of public purchases (1)"
+	~	G$/y
+	~		|
+
+"State capacity (fraction of GDP)"=
+	"Value of public services supplied G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+xTFP observation time y=
+	4
+	~	y
+	~		|
+
+toe per tH2=
+	10
+	~	
+	~	Guess
+	|
+
+"kWh-el per kgH2"=
+	40
+	~	kWh/kgH2
+	~	Guess
+	|
+
+"Green hydrogen Mtoe/y"=
+	"Green hydrogen MtH2/y"
+	*
+	toe per tH2
+	~	Mtoe/y
+	~		|
+
+"Green hydrogen MtH2/y"=
+	"Renewable electricity production TWh/y"
+	*
+	"Fraction of renewable electricity to hydrogen (1)"
+	/
+	"kWh-el per kgH2"
+	~	MtH2/y
+	~		|
+
+"Fraction of renewable electricity to hydrogen (1)"=
+	0
+	~	1
+	~	Placeholder
+	|
+
+"MEMO Fraction of non-el fossil fuels use in hard to abate sectors HTAS (1)"=
+	0.4
+	~	1
+	~	Rough estimate of use as rawmaterial is 5%.
+		plastics prod / non-el FF gives 1980 (60 Mtp/y, 1.5 %) 2000 (200 Mtp/y, 3.7 %) 2020 \
+		(400 Mtp/y, 5.5%)
+		Must add room for fertilizer, reduction of steel, decarbonized gas, blue \
+		hydrogen
+	|
+
+"Demand for red meat per person kg-red-meat/p/y"=
+	"Traditional use of red meat per person kg-red-meat/p/y"
+	~	kg/p/y
+	~		|
+
+"Extra cooling from ice melt ZJ/y"=
+	"Melting rate deep ice 1/y" * Amount of ice in 1980 Mkm3 * Ton per m3 ice * "Heat required to melt ice kJ/kg"
+	~	ZJ/y
+	~		|
+
+GtN2O per ppm=
+	5
+	~	Gt/ppm
+	~	From UG ESMICON 3.29/0.65=
+	|
+
+"Albedo global average (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	Wikipedia says:land average = 0.3 ocean average = 0.06 ocean ice = 0.6 fresh snow = \
+		0.8
+		Gives 0.1 as world average with 75% ocean and 25 % land. But real albedo \
+		is higher because of clouds, perhaps around 0.3
+	|
+
+"N2O breakdown GtN2O/y"=
+	N2O in atmosphere GtN2O / Life of N2O in atm y
+	~	GtN2O/y
+	~		|
+
+"Heat to space ZJ/y"=
+	Extra heat in surface ZJ * "Transfer rate for heat going to space 1/y"
+	~	ZJ/y
+	~		|
+
+N2O in atmosphere GtN2O= INTEG (
+	"N2O emissions GtN2O/y" - "N2O breakdown GtN2O/y",
+		N2O in atm in 1980 GtN2O)
+	~	GtN2O
+	~		|
+
+"Surface vs deep rate (1)"=
+	4
+	~	1 [0,10,1]
+	~	211103: changed from 10 to 4
+	|
+
+"Albedo ice and snow (1)"=
+	0.7
+	~	1 [0,1,0.1]
+	~	Wikipedia says:land average = 0.3 ocean average = 0.06 ocean ice = 0.6 fresh snow = \
+		0.8
+		But real number is higher because of clouds, perhaps around 0.1
+	|
+
+Extra heat in surface ZJ= INTEG (
+	"Extra warming from forcing ZJ/y"-"Extra cooling from ice melt ZJ/y"-"Heat to deep ocean ZJ/y"\
+		-"Heat to space ZJ/y",
+		Extra heat in 1980 ZJ)
+	~	ZJ
+	~		|
+
+"Melting rate surface 1/y"=
+	"Melting rate surface in 1980 1/y" * ( Observed warming deg C / Warming in 1980 deg C\
+		 )
+	~	1/y
+	~		|
+
+"Transfer rate for heat going to space 1/y"=
+	( "Transfer rate surface-space in 1980 1/y" * (( Observed warming deg C + 297 ) /  297\
+		 ) )
+	*
+	( "Albedo (1)" / "Albedo in 1980 (1)" )
+	~	1/y
+	~		|
+
+tCO2 per tCH4=
+	2.75
+	~	t/t
+	~	CO2 = 12+16+16=44  CH4 = 12+1+1+1+1 = 16.   44/16=2.75
+	|
+
+"CO2 from CH4 GtCO2/y"=
+	"CH4 breakdown GtCH4/y" * tCO2 per tCH4
+	~	Gt/y
+	~		|
+
+"Transfer rate surface-space in 1980 1/y"=
+	0.01
+	~	1/y [0,0.02,0.001]
+	~	was 0.01, so 0.02 to obtain observed warming
+		211103: changed from 0.001 to 0.01, ie equilibration time 100 years
+	|
+
+"Heat to deep ocean ZJ/y"=
+	Extra heat in surface ZJ * "Transfer rate for heat going to abyss 1/y"
+	~	ZJ/y
+	~		|
+
+"Natural N2O emissions GtN2O/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,0.01)],(1980,0.009),(2020,0.009),(2099.27,0) ))
+	~	
+	~	211030 From UG FAO
+	|
+
+"CH4 emissions GtCH4/y"=
+	"Man-made CH4 emissions GtCH4/y" + "Natural CH4 emissions GtCH4/y"
+	~	Gt/y
+	~		|
+
+kg CH4 per kg crop in 1980=
+	0.05
+	~	1
+	~	220220 Adjusted to give correct natural emissions EM according to ESMICONpp
+	|
+
+kg N2O per kg fertilizer in 1980=
+	0.11
+	~	1
+	~	UG and ESMICON
+	|
+
+"Man-made N2O emissions GtN2O/y"=
+	"Fertilizer use Mt/y" * kg N2O emission per kg fertiliser / 1000
+	~	Gt/y
+	~		|
+
+"Traditional use of crops ex red meat Mt/y"=
+	( "Traditional use of crops Mt/y"
+	-
+	"Traditional use of feed for red meat Mt-crop/y" )
+	/
+	"Food sector productivity index (1980=1)"
+	~	Mt/y
+	~		|
+
+"N2O emissions GtN2O/y"=
+	"Natural N2O emissions GtN2O/y" + "Man-made N2O emissions GtN2O/y"
+	~	Gt/y
+	~		|
+
+CH4 in atm in 1980 GtCH4=
+	2.5
+	~	Gt/y
+	~	3 GtC from UG ESMICON multiplied with 12+1+1+1+1 = 16 / 12 = 1.33
+	|
+
+N2O in atm in 1980 GtN2O=
+	1.052
+	~	GtN2O [0,2,0.1]
+	~	1.052 Gt N2O according to ESMICON,
+		But this equals 1.052 Gt / 5E15 = 1E9/5E15=0.2 E-6 = 200 ppb, and should \
+		have been 320 ppb!
+	|
+
+"Natural CH4 emissions GtCH4/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,1)],(1980,0.19),(2020,0.19),(2100,0.19) ))
+	~	
+	~	220220 from ESMICONpp
+		was 0.29 and rising
+	|
+
+"Man-made CH4 emissions GtCH4/y"=
+	("Crop supply (after 20 % waste) Mt-crop/y" * kg CH4 emission per kg crop ) / 1000
+	~	Gt/y
+	~		|
+
+"Forcing from CO2 in 1980 W/m2"=
+	1.07
+	~	W/m2 [0,2,0.1]
+	~	From Esmicon Supplimentary information
+	|
+
+Life of N2O in atm y=
+	95
+	~	y [0,500,10]
+	~	from ESMICON, was 100
+	|
+
+"Red meat from feedlots Mt-red-meat/y"=
+	"Demand for red meat Mt-red-meat/y"- "Red meat from grazing land Mt-red-meat/y"
+	~	Mt/y
+	~		|
+
+"Rate of decline in CH4 per kg crop 1/y"=
+	0.01
+	~	1/y [0,0.03,0.01]
+	~	Guestimate to get concentration to follow forcing
+	|
+
+"Fertilizer effect on erosion rate (1)"=
+	1 + "sFUeoLER>0" * ( "Fertilizer use in conv ag kgN/ha/y"/ "Sustainable fertiliser use kgN/ha/y"\
+		 - 1 )
+	~	1
+	~		|
+
+"Red meat from grazing land Mt-red-meat/y"=
+	MIN("Demand for red meat Mt-red-meat/y", "Potential red meat from grazing land Mt-red-meat/y"\
+		)
+	~	Mt/y
+	~		|
+
+"Fertilizer use Mt/y"=
+	Cropland Mha * ( 1 - "Fraction regenerative agriculture (1)" ) * "Fertilizer use in conv ag kgN/ha/y"\
+		/ 1000
+	~	Mt/y
+	~		|
+
+"Crop demand Mt-crop/y"=
+	("Traditional use of crops ex red meat Mt/y"
+	+
+	"Feed for red meat Mt-crop/y"
+	+
+	"Crops for biofuel Mt-crop/y")
+	~	Mt/y
+	~		|
+
+"CAPEX fossil el G$/y"=
+	"CAPEX fossil el $/W" * "Addition of fossil el capacity GW/y"
+	~	G$/y
+	~		|
+
+"CAPEX renewable el G$/y"=
+	"CAPEX renewable el $/W" * "Addition of renewable el capacity GW/y"
+	~	G$/y
+	~		|
+
+"OPEX fossil el $/kWh"=
+	0.02
+	~	G$/y
+	~		|
+
+"Fraction of CO2-sources with CCS in 2022 (1)"=
+	0
+	~	1
+	~		|
+
+CH4 in atmosphere GtCH4= INTEG (
+	"CH4 emissions GtCH4/y"-"CH4 breakdown GtCH4/y",
+		CH4 in atm in 1980 GtCH4)
+	~	Gt
+	~		|
+
+"OPEX renewable el G$/y"=
+	"OPEX renewable el $/kWh" * "Renewable electricity production TWh/y"
+	~	G$/y
+	~		|
+
+"Goal for fraction of CO2-sources with CCS (1)"=
+	0.9
+	~	1 [0,0.9,0.1]
+	~	0.2 in TLTL and 0.9 in GL
+		set to 0.06 which means 6 % of non-el fossil use (5600 Mtoe/y= 15 GtCO2/y \
+		in 2050) and non-fossil CO2 industrial processes (16 GtCO2/y) are equipped \
+		with CCS. Means capturing ca 2 GtCO2/y or 2000 big CCS plants. Is our \
+		estimate of what is assumed in TLTL. Could be achieved by 2100.
+	|
+
+"Cost of CCS $/tCO2"=
+	95
+	~	$/tCO2
+	~	DNV-GL assumes cost of CCS at 95 USD/tCO2 in 2020, delining to 70 in 2050 (with \
+		limited uptake). 
+		This means 85 EUR/tCO2 declining to 63 when 1 USD = 0.9 EUR. Supports \
+		Lavutslippsutvalget:
+		To make gas power with CCS competitive with conventional gas power requires a carbon \
+		price of 50 EUR/tCO2.
+		Since each toe emits 2.8 tCO2, the cost of CCS is around 2.8*50 = 150 \
+		EUR/toe.
+	|
+
+"Fraction fossil plus nuclear electricity (1)"=
+	( "Fossil electricity production TWh/y" + "Nuclear electricity production TWh/y" ) /\
+		 "Electricity production TWh/y"
+	~	1
+	~		|
+
+"Extra increase in demand for electricity from NE TWh/y"=
+	"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	*
+	"Extra use of electricity per reduced use of non-el FF MWh/toe"
+	~	TWh/y
+	~		|
+
+"CAPEX renewable el $/W"=
+	"CAPEX renewable el in 1980 $/W" * "Cost index for sun and wind capacity (1)"
+	~	$/W
+	~		|
+
+"ROC in fertilizer productivity 1/y"=
+	0.01
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"ROC in soil quality in conv ag 1/y"=
+	0 + "sFUeoSQ<0" * ( "Fertilizer use in conv ag kgN/ha/y" / "Sustainable fertiliser use kgN/ha/y"\
+		 - 1 )
+	~	1/y
+	~		|
+
+Accumulated sun and wind capacity from 1980 GW= INTEG (
+	"Addition of sun and wind capacity GW/y",
+		Sun and wind capacity in 1980 GW)
+	~	Gha
+	~		|
+
+"Extra use of electricity per reduced use of non-el FF MWh/toe"=
+	3
+	~	
+	~	1.500 l of gasoline can be replaced with 3500 kWh when an electric car replaces a \
+		fossil car (ratio 3.5/1.5=2.3)
+		12.000 kWh heat in 1.000 l of heating oil can be replaced with 12.000 kWh heat from \
+		a heat pump drawing 3.000 KWh el (ratio 12/3 = 4)
+		A small petrol driven generator can generate 3kWh/h when drawing 1 liter of fuel pr \
+		hour.Can be replaced with a 2 kW electric engine (ratio 3kWh/1 liter = 3)
+		Old lightingen bulbs drawing 50 W can be replaced with LED drawing 8 W - I \
+		sort this as energy efficiency
+	|
+
+"Cost index for sun and wind capacity (1)"=
+	( 1 - "Cost reduction per doubling of sun and wind capacity (1)" ) ^ "Number of doublings in sun and wind capacity (1)"
+	~	
+	~		|
+
+"Cost of new electrification G$/y"=
+	( "Extra cost per reduced use of non-el FF $/toe" / 1000 )
+	* "Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	~	G$/y
+	~		|
+
+"Number of doublings in sun and wind capacity (1)"=
+	LN(2)+ LN(Accumulated sun and wind capacity from 1980 GW / Sun and wind capacity in 1980 GW\
+		)
+	~	1
+	~		|
+
+"Demand for fossil fuel for non-el use Mtoe/y"=
+	"Demand for fossil fuel for non-el use before NE Mtoe/y"
+	-
+	
+	"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"Fertilizer productivity index (1980=1)"=
+	EXP("ROC in fertilizer productivity 1/y" * ( Time - 1980))
+	~	1
+	~		|
+
+"Demand for electricity TWh/y"=
+	"Demand for electricity before NE TWh/y"
+	+
+	"Extra increase in demand for electricity from NE TWh/y"
+	~	TWh/y
+	~		|
+
+"Extra cost per reduced use of non-el FF $/toe"=
+	10
+	~	$/toe [0,200,10]
+	~	It costs an extra 200.000 kr/y in battery and power to save 1.500 liters \
+		of fuel (Ratio 15k$/1.5 toe=10)
+	|
+
+"Fertilizer use in conv ag kgN/ha/y"=
+	"Traditional fertilizer use in conv ag kgN/ha/y" / "Fertilizer productivity index (1980=1)"
+	~	kgN/ha/y
+	~		|
+
+"Cost reduction per doubling of sun and wind capacity (1)"=
+	0.2
+	~	1 [0,1,0.01]
+	~		|
+
+"Traditional fertilizer use in conv ag kgN/ha/y"= WITH LOOKUP (
+	"Desired crop yield in conv ag t-crop/ha/y",
+		([(1,0)-(10,600)],(1,0),(2,40),(2.5,50),(3,60),(3.5,70),(4.5,100),(6.5,200),(10,600\
+		) ))
+	~	
+	~	211030: Changed to fit UG numbers from FAO
+	|
+
+Sun and wind capacity in 1980 GW=
+	10
+	~	GW
+	~	Renewable capacity 300 minus hydro capacity 290
+	|
+
+"Addition of fossil el capacity GW/y"=
+	MAX(0, "Desired fossil el capacity change GW/y")
+	~	GW/y
+	~		|
+
+Desired renewable el capacity change GW=
+	Desired renewable el capacity GW - Renewable electricity capacity GW
+	~	GW
+	~		|
+
+Desired renewable el capacity GW=
+	"Desired supply of renewable electricity TWh/y" / "Renewable capacity up-time kh/y"
+	~	GW
+	~		|
+
+"Desired fossil el capacity change GW/y"=
+	( Desired fossil el capacity GW - Fossil electricity capacity GW ) / Fossil el cap construction time y
+	+
+	"Discard of fossil el capacity GW/y"
+	~	GW
+	~		|
+
+"Addition of renewable el capacity GW/y"=
+	MAX(0, ( Desired renewable el capacity change GW / Renewable el construction time y \
+		)
+	+
+	( "Discard of renewable el capacity GW/y" ))
+	~	GW/y
+	~		|
+
+"Renewable electricity production TWh/y"=
+	Renewable electricity capacity GW
+	* 
+	"Renewable capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+"Fossil capacity up-time kh/y"=
+	"Demand for fossil electricity TWh/y" / Fossil electricity capacity GW
+	~	kh/y
+	~	 8760 hours per year
+	|
+
+"8 khours per year"=
+	8
+	~	kh/y
+	~	8760 hours in a year
+	|
+
+"sFCUTeoLOFC>0"=
+	0.5
+	~	1 [0,1,0.1]
+	~	was 0.1, should be 1?
+	|
+
+Normal life of fossil el capacity y=
+	40
+	~	y
+	~	was 25
+	|
+
+"Demand for fossil electricity TWh/y"=
+	MAX(0, "Demand for electricity TWh/y" - "Low-carbon el production TWh/y")
+	~	TWh/y
+	~		|
+
+Fossil el cap construction time y=
+	3
+	~	
+	~		|
+
+Life of fossil el capacity y=
+	Normal life of fossil el capacity y * "FCUTeoLOFC (1)"
+	~	y [0,50,1]
+	~		|
+
+Renewable el construction time y=
+	3
+	~	
+	~		|
+
+Desired fossil el capacity GW=
+	"Demand for fossil electricity TWh/y" / "8 khours per year"
+	~	GW
+	~		|
+
+"FCUTeoLOFC (1)"=
+	1 + "sFCUTeoLOFC>0" * ( ("Fossil capacity up-time kh/y" / "8 khours per year" ) - 1 \
+		)
+	~	1
+	~		|
+
+"CH4 from production of fossil fuels GtCH4/y"=
+	0
+	~	
+	~		|
+
+"Use of fossil fuels Mtoe/y"=
+	"Demand for fossil fuel for non-el use Mtoe/y"
+	+
+	"Fossil fuels for electricity Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"Normal increase in energy efficiency 1/y"=
+	0.01
+	~	1/y
+	~		|
+
+"OPEX renewable el $/kWh"=
+	0.001
+	~	$/kWh
+	~		|
+
+"Renewable el fraction in 1980 (1)"=
+	0.065
+	~	1
+	~		|
+
+"Electricity balance (1)"=
+	"Electricity production TWh/y" / "Demand for electricity TWh/y"
+	~	1
+	~		|
+
+"Electricity production TWh/y"=
+	"Fossil electricity production TWh/y"
+	+ "Nuclear electricity production TWh/y"
+	+ "Renewable electricity production TWh/y"
+	~	TWh/y
+	~		|
+
+"Biomass energy Mtoe/y"=
+	0
+	~	Mtoe/y
+	~		|
+
+"CAPEX fossil el $/W"=
+	0.7
+	~	$/W
+	~	211117 changed from: 5.5
+		2.2 Gkr for 0.4 GW gas utility Kårstø 2006 = 5.5 kr/W = 0.7 $/W
+	|
+
+"Extra energy productivity index 2022=1"= INTEG (
+	"Increase in extra energy productivity index 1/y",
+		"Extra energy productivity index in 2022 (1)")
+	~	1
+	~		|
+
+Life of renewable el capacity y=
+	40
+	~	y
+	~		|
+
+"Fossil electricity production TWh/y"=
+	Fossil electricity capacity GW * "Fossil capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+Nuclear capacity GW= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,400)],(1980,75),(2000,310),(2020,310),(2098.9,310) ))
+	~	GW
+	~		|
+
+"Nuclear capacity up-time kh/y"=
+	8
+	~	h/y
+	~	Full time is 8760 h/y
+	|
+
+"Nuclear electricity production TWh/y"=
+	Nuclear capacity GW
+	* "Nuclear capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+Renewable el capacity in 1980 GW=
+	300
+	~	GW [0,1000,10]
+	~	was 200
+	|
+
+Fossil electricity capacity GW= INTEG (
+	"Addition of fossil el capacity GW/y"-"Discard of fossil el capacity GW/y",
+		Fossil el capacity in 1980 GW)
+	~	GW
+	~		|
+
+"CAPEX renewable el in 1980 $/W"=
+	7
+	~	$/W [0,10,1]
+	~	211117: changed from 10
+	|
+
+"Renewable el fraction in 2022 (1)"=
+	0.23
+	~	1 [0,1,0.01]
+	~		|
+
+"Discard of renewable el capacity GW/y"=
+	Renewable electricity capacity GW / Life of renewable el capacity y
+	~	GW/y
+	~		|
+
+"Low-carbon el production TWh/y"=
+	"Renewable electricity production TWh/y" + "Nuclear electricity production TWh/y"
+	~	TWh/y
+	~		|
+
+Fossil el capacity in 1980 GW=
+	980
+	~	GW [900,1000,10]
+	~	was 950
+	|
+
+"Fossil fuels for electricity Mtoe/y"=
+	"Fossil electricity production TWh/y" / "4 TWh-el per Mtoe"
+	~	Mtoe/y
+	~		|
+
+"Discard of fossil el capacity GW/y"=
+	Fossil electricity capacity GW/ Life of fossil el capacity y
+	~	GW/y
+	~		|
+
+"Increase in extra energy productivity index 1/y"=
+	"Extra energy productivity index 2022=1" * 0 + STEP("Extra ROC in energy productivity after 2022 1/y"\
+		, 2022)
+	~	1/y
+	~		|
+
+"Fraction new electrification in 2022 (1)"=
+	0.03
+	~	1 [0,0.01,0.001]
+	~	was 0.03
+	|
+
+"Extra energy productivity index in 2022 (1)"=
+	1
+	~	1
+	~		|
+
+Renewable electricity capacity GW= INTEG (
+	"Addition of renewable el capacity GW/y"-"Discard of renewable el capacity GW/y",
+		Renewable el capacity in 1980 GW)
+	~	GW
+	~		|
+
+"Renewable capacity up-time kh/y"=
+	3
+	~	h/y
+	~	Full time is 8760 hours per year. 3000 h/y is 34%.
+	|
+
+"Fraction new electrification in 1980 (1)"=
+	0
+	~	 [0,0.1,0.01]
+	~		|
+
+"Extra ROC in energy productivity after 2022 1/y"=
+	0.004
+	~	1/y [0,0.004,0.001]
+	~	0.002 in TLTL and 0.004 in GL
+		220221 changed from 0 to 0.002 to match SSP
+	|
+
+Perceived warming deg C=
+	SMOOTH(Observed warming deg C, Perception delay y)
+	~	deg C
+	~		|
+
+"Grazing land yield kg-red-meat/ha/y"=
+	"Grazing land yied in 1980 kg-red-meat/ha/y"
+	+ 0 * CO2 concentration in atm ppm
+	- 0 * Observed warming deg C
+	~	kg/ha/y
+	~		|
+
+"Cropland expansion rate 1/y"=
+	1/200 + "sFBeoCLE<0" * ( "Perceived crop balance (1)" - 1 )
+	~	1/y
+	~		|
+
+"Biofuels use Mtoe/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,200)],(1980,0),(1990,0),(2000,0),(2020,0),(2100,0) ))
+	~	Mt/y
+	~	was \
+		([(1980,0)-(2100,200)],(1980,0),(1990,0),(2000,2.5),(2020,40),(2100,40) )
+	|
+
+"Perceived crop balance (1)"=
+	"Crop balance (1)"/
+	(1 + "Desired reserve capacity (1)" )
+	~	1
+	~		|
+
+"Red meat supply per person kg-red-meat/p/y"=
+	("Red meat from grazing land Mt-red-meat/y"
+	+
+	"Red meat from feedlots Mt-red-meat/y" * MIN(1, "Crop balance (1)") )
+	* 1000
+	/
+	Population Mp
+	~	kg/p/y
+	~		|
+
+"Desired crop supply conv ag Mt-crop/y"=
+	"Desired crop supply Mt-crop/y" - "Crop supply reg ag Mt-crop/y"
+	~	Mt/y
+	~		|
+
+"Traditional use of crops ex red meat per person kg-crop/p/y"=
+	"Traditional use of crops ex red meat Mt/y" * 1000
+	/
+	Population Mp
+	~	kg/p/y
+	~		|
+
+"Traditional use of crops Mt/y"=
+	"Traditional use of crops per person kg-crop/p/y" * Population Mp / 1000
+	~	
+	~		|
+
+"Traditional use of feed for red meat Mt-crop/y"=
+	((("Traditional use of red meat per person kg-red-meat/p/y" / 1000) * Population Mp \
+		) - "Red meat from grazing land Mt-red-meat/y"
+	)*"kg-crop per kg-red-meat"
+	~	Mt/y
+	~		|
+
+"Crops for biofuel Mt-crop/y"=
+	"Biofuels use Mtoe/y" * Ton crops per toe biofuel
+	~	Mt/y
+	~		|
+
+Ton crops per toe biofuel=
+	0
+	~	t/toe
+	~	I think it should be around 4
+	|
+
+Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2=
+	12
+	~	Mkm2
+	~	220221 UG/ESMICON view: relevant Arctic is 12 - 11 Mkm2 1980 - 2020 (minus 9 %) and \
+		other galciers (except permafrost) is <1 Mkm2
+		Total area covered by ice and snow is 46 Mkm2
+		If we disregard Greenland 2.2 Mkm2 and Antarctica 14.2 Mkm2, the rest (that is \
+		likely to melt duirng this century) is some 30 Mkm2. It has declined by 10 \
+		% from 1980 to 2020.
+		(Onland ice and snow was 5000 Gha in 1980 and declined to 4600 Gha in 2018 \
+		(I believe HYDE))
+	|
+
+"Ice and snow cover excl G&A Mkm2"= INTEG (
+	-"Melting Mha/y",
+		Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2)
+	~	Gkm2
+	~	Total area covered by ice and snow is 46 Mkm2
+		If we disregard Greenland 2.2 Mkm2 and Antarctica 14.2 Mkm2, the rest \
+		(that is likely to melt duirng this century) is some 30 Mkm2. It has \
+		declined by 10 % from 1980 to 2020.
+	|
+
+GtCO2 per ppm=
+	7.9
+	~	GtCO2/ppm [7.8,8,0.01]
+	~	211102 changed from 1.8 to 7.92 as per ESMICON
+	|
+
+CO2 in atm in 1980 GtCO2=
+	2600
+	~	GtCO2
+	~	211103: changed from 600
+	|
+
+kg CH4 per $ of GDP=
+	0
+	~	
+	~		|
+
+CO2 in atmosphere GtCO2= INTEG (
+	"CO2 emissions GtCO2/y"+"CO2 from CH4 GtCO2/y"-"CO2 absorption GtCO2/y"+"CO2 from CH4 GtCO2/y"\
+		,
+		CO2 in atm in 1980 GtCO2)
+	~	GtC
+	~		|
+
+"CH4 breakdown GtCH4/y"=
+	CH4 in atmosphere GtCH4 / Life of CH4 in atm y
+	~	Gt/y
+	~		|
+
+Life of CH4 in atm y=
+	7.5
+	~	y [0,10,1]
+	~	was 11, so 7, so 8
+	|
+
+"Traditional use of red meat per person kg-red-meat/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(100,40)],(0,0),(6.1,6),(8.8,8.5),(14,13),(30,27),(40,32),(50,33),(100,25) \
+		))
+	~	
+	~	Equal to traditional use growing asymptotically towards ca 40 kg/p/y, \
+		minus "automatic" red-meat-use-index falling from 100% at 40 k$/p/y to 70% \
+		at 100 k$/p/y as a consequence of more educated eating habits
+	|
+
+"Traditional use of crops per person kg-crop/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(100,2000)],(0,400),(6.1,680),(8.7,780),(13.9,950),(20,1050),(30,1150),(40,\
+		1250),(60,1350),(100,1550) ))
+	~	kg/p/y
+	~	211029: Estimated from UG FAO. Disregarding biofuel use growing from 0 in \
+		2000 to 200 in 2020.
+	|
+
+"Urban expansion Mha/y"=
+	MAX(0, ( Indicated urban land Mha - Urban land Mha ) / Urban development time y)
+	~	Mha/y
+	~		|
+
+"Crop yield in reg ag t-crop/ha/y"=
+	5
+	~	t/ha/y [0,10,1]
+	~	5 (reduced from 7 on 220427 to get acceptable fertilizer forecast)
+	|
+
+"Change in soil quality in conv ag t-crop/ha/y/y"=
+	"ROC in soil quality in conv ag 1/y" * "Soil quality index in conv ag (1980=1)"
+	~	t/ha/y/y
+	~		|
+
+"Crop supply reg ag Mt-crop/y"=
+	"Crop yield in reg ag t-crop/ha/y" * Cropland Mha * "Fraction regenerative agriculture (1)"
+	~	Mt/y
+	~		|
+
+Indicated urban land Mha=
+	Population Mp * "Urban land per population ha/p"
+	~	Mha
+	~		|
+
+"Desired crop yield in conv ag t-crop/ha/y"=
+	"Desired crop supply conv ag Mt-crop/y" / ( Cropland Mha * ( 1 - "Fraction regenerative agriculture (1)"\
+		 ))
+	~	t/ha/y
+	~		|
+
+"Feed for red meat Mt-crop/y"=
+	"Red meat from feedlots Mt-red-meat/y" * "kg-crop per kg-red-meat"
+	~	Mt/y
+	~		|
+
+"kg-crop per kg-red-meat"=
+	24
+	~	kg/kg [1,30,1]
+	~	cattle 25, lamb 15, pork 6.4, poultry 3.3 (OWID)
+		One third each of 1) red meat (90% cattle, 10% lamb), 2) pork and 3) \
+		poultry
+	|
+
+"sFUeoSQ<0"=
+	-0.001
+	~	1 [-0.001,-0,0.0001]
+	~	was -0.001, so -0.0005, so 0, so 0.0005, so -0.0002
+	|
+
+"Sustainable fertiliser use kgN/ha/y"=
+	20
+	~	kgN/ha/y [0,40,5]
+	~		|
+
+"sGReoCR<0"=
+	0
+	~	 [-1,1,0.1]
+	~		|
+
+"Normal corporate credit risk 1/y"=
+	0.02 * ( 1 + "sGReoCR<0" * ( "Output growth rate 1/y" / 0.03 - 1 ))
+	~	1/y [0,0.2,0.01]
+	~		|
+
+Barren land Mha= INTEG (
+	"Cropland loss Mha/y",
+		3000)
+	~	Mha
+	~	From HYDE: Barren land 3.000 Mha i 2017
+	|
+
+Old growth forest in 1980 Mha=
+	2600
+	~	Mha
+	~	From Earth3: Sum of Northern forest 1000 (slowly growing at 0.3 %/y) and Southern \
+		forest 1600 (declinig at 1 %/y)
+		Similar to HYDE: Sum of Wild remote woodlands 1550 plus Seminatural remote \
+		woodlands 850
+	|
+
+"Fraction cleared for grazing (1)"=
+	0.1
+	~	1 [0,1,0.1]
+	~	Since grazing land data show a stable area, forest must have been removed \
+		(ca 10 Mha/y) to increase cropland (soya?) (+7 Mha/y?)and to replace \
+		cropland loss (3 Mha/y?).
+	|
+
+Old growth forest area Mha 1= INTEG (
+	-"New forestry land Mha/y"-"New grazing land Mha/y",
+		Old growth forest in 1980 Mha)
+	~	Mha
+	~		|
+
+"Potential red meat from grazing land Mt-red-meat/y"=
+	Grazing land Mha * "Grazing land yield kg-red-meat/ha/y" / 1000
+	~	Mt/y
+	~		|
+
+"sFUeoLER>0"=
+	0.02
+	~	1 [-0.1,0,0.01]
+	~	GUSTIMATE: 100 kgNP/ha/y halves cropland life from 250 to 125 years
+	|
+
+"Desired reserve capacity (1)"=
+	0.05
+	~	1 [0,0.3,0.01]
+	~	0.1 sounds more reasonable
+	|
+
+"sFBeoCLE<0"=
+	-0.03
+	~	1 [-0.1,0,0.01]
+	~	was 0.1, so 0.01,0.015, 0.02, 0.03, 0.005, - 0.004, so -0.04, so -0.05
+		JR guestimate, based on fact that cropland has only expanded by some 10% \
+		since 1980
+	|
+
+"Soil quality index in conv ag (1980=1)"= INTEG (
+	"Change in soil quality in conv ag t-crop/ha/y/y",
+		"Soil quality index in 1980 (1)")
+	~	t/ha/y
+	~		|
+
+Forestry land in 1980 Mha=
+	1100
+	~	Mha
+	~	From HYDE: Woodlands 3500 minus Wild remote 1550 and seminatural woodlands \
+		remote 850
+	|
+
+Cropland in 1980 Mha=
+	1450
+	~	Mha [1350,1450,10]
+	~	Was 1350 Mha - From Earth3, but similar to HYDE - rising to 1500 in 2020
+		211030: changed to 1420 from UG FAO
+	|
+
+"Urban land per population ha/p"=
+	0.05
+	~	1 [0.04,0.06,0.001]
+	~	From HYDE: 215, 285, 320 in 1980, 2000, 2017
+		Means 0.049, 0.048, 0.041 ha/p ie around 500 m2 per person or 200 p/km2
+	|
+
+"Soil quality index in 1980 (1)"=
+	1
+	~	t/ha/y
+	~		|
+
+Grazing land Mha= INTEG (
+	"New grazing land Mha/y",
+		Grazing land in 1980 Mha)
+	~	Mha
+	~		|
+
+Urban land Mha= INTEG (
+	"Urban expansion Mha/y",
+		Urban land in 1980 Mha)
+	~	Mha
+	~		|
+
+Grazing land in 1980 Mha=
+	3300
+	~	Mha
+	~	OWID and HYDE. Disregarding Rangeland 2.200,Pasture 0.8, forest converted \
+		to rangeland 300
+	|
+
+Urban land in 1980 Mha=
+	215
+	~	Mha
+	~	From HYDE: 215, 285, 320 in 1980, 2000, 2017
+		Means 0.049, 0.048, 0.041 ha/p ie around 500 m2 per person or 200 p/km2
+	|
+
+Urban development time y=
+	10
+	~	y
+	~	should be longer if we want to test urbanisation policies
+	|
+
+Global surface Mkm2=
+	510
+	~	Mkm2
+	~	Global surface is 510 Mkm2. Land surface is 150 Mkm2, some 30% of total.
+	|
+
+"Heat required to melt ice kJ/kg"=
+	333
+	~	kJ/kg
+	~	smeltevarnen er 6 kJ/mol og jeg gjetter at 1 mol er 1+1+16 = 18 g
+	|
+
+"sOWeoMR>0"=
+	1
+	~	1 [0,1,0.1]
+	~	was 0.01, 0.001
+	|
+
+"sEHeoOW>0"=
+	0.8
+	~	1 [0,1,0.05]
+	~	was 0.5, 0.7
+	|
+
+Ton per m3 ice=
+	0.95
+	~	t/m3
+	~		|
+
+CO2 concentration in 1980 ppm=
+	330
+	~	ppm
+	~		|
+
+Extra heat in 1980 ZJ=
+	0
+	~	ZJ [0,500,100]
+	~	220221 Changed definition so zero by definition
+	|
+
+"Past GDP per person k$/y"=
+	SMOOTHI("GDP per person k$/p/y" , Time to establish growth rate y, "GDP per person in 1980 k$/p/y"\
+		 * "Factor to avoid transient in growth rate (1)")
+	~	k$/p/y
+	~		|
+
+"RATE OF GROWTH IN GDP PER PERSON 1/y"=
+	(( "GDP per person k$/p/y" - "Past GDP per person k$/y" ) / "Past GDP per person k$/y"\
+		)
+	/
+	Time to establish growth rate y
+	~	1/y
+	~		|
+
+"Factor to avoid transient in growth rate (1)"=
+	0.93
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+Time to establish growth rate y=
+	4
+	~	y
+	~		|
+
+"Fraction of extra taxes paid by owners (1)"=
+	0.8
+	~	 [0,1,0.1]
+	~	0.5 in TLTL and 0.8 in GL
+	|
+
+"CO2 absorption GtCO2/y"=
+	( CO2 in atmosphere GtCO2 - CO2 in atm in 1850 GtCO2 ) / Life of extra CO2 in atm y
+	~	GtCO2/y
+	~		|
+
+Perception delay y=
+	5
+	~	y [0,10,1]
+	~		|
+
+"Govmnt share of GDP (1)"=
+	"Govmnt spending G$/y" / "National income G$/y"
+	~	
+	~		|
+
+CO2 in atm in 1850 GtCO2=
+	2200
+	~	GtCO2 [0,500,50]
+	~		|
+
+"Control: (C+G+S)/NI = 1"=
+	"Consumption share of GDP (1)" + "Govmnt share of GDP (1)" + "Savings share of GDP (1)"
+	~	1
+	~		|
+
+"Consumption per person G$/y"=
+	"Consumption demand G$/y" /  Population Mp
+	~	G$/y
+	~		|
+
+"Output Gu/y"=
+	"Optimal real output Gu/y" * "Shifts worked - index (1)" / "SWI in 1980 (1)"
+	~	Gu/y
+	~		|
+
+"Price Index (1980=1)"= INTEG (
+	"Change in Price Index 1/y",
+		"Price Index in 1980 (=1)")
+	~	dmnl
+	~		|
+
+"Price Index in 1980 (=1)"=
+	1
+	~	 [0,5,0.1]
+	~		|
+
+"10-yr govmnt interest rate 1/y"=
+	"Govmnt borrowing cost 1/y" + "Expected long term inflation 1/y"
+	~	1/y
+	~		|
+
+"Expected long term inflation 1/y"=
+	SMOOTHI("Perceived inflation CB 1/y", Inflation expectation formation time y, "Inflation in 1980 (1/y)"\
+		)
+	~	1/y
+	~		|
+
+Inflation expectation formation time y=
+	10
+	~	y [0,20,1]
+	~		|
+
+"Delivery delay - index (1)"= INTEG (
+	"Change in DDI 1/y",
+		1)
+	~	1
+	~		|
+
+"Corporate borrowing cost in 1980 1/y"=
+	"Normal signal rate 1/y" + "Normal basic bank margin 1/y" + "Normal bank operating margin 1/y"\
+		 + "Normal corporate credit risk 1/y"
+	~	1/y
+	~	220207 corrected an error!"Normal corporte credit risk" appeared twice in \
+		sum.
+	|
+
+"Excess demand (1)"=
+	"Total purchasing power G$/y" / "Optimal ouput - value G$/y"
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+"Public services per person in 1980 k$/p/y"=
+	0.58
+	~	k$/p/y
+	~		|
+
+"Demand pulse 2020-25 (1)"=
+	0 + "Pulse height (1)"* PULSE(2020,5)
+	~	1 [0,0.1,0.01]
+	~	was 0.01
+	|
+
+OCI in 1980=
+	7081
+	~	G$/y
+	~	was 307
+	|
+
+WFI in 1980=
+	13000
+	~	G$/y [10000,30000,1000]
+	~	was 1059
+		211127 changed from 14000
+		211126 changed from 19015
+	|
+
+"Permanent govmnt cash inflow G$/y"=
+	SMOOTHI("Govmnt cash inflow G$/y", Time to adjust budget y, GCI in 1980)
+	~	G$/y
+	~		|
+
+"Permanent owner cash inflow G$/y"=
+	SMOOTHI("Owner cash inflow G$/y", Time to adjust owner consumption y, OCI in 1980)
+	~	G$/y
+	~		|
+
+"Total purchasing power G$/y"=
+	"Worker cash inflow G$/y" + "Govmnt cash inflow G$/y" + "Owner cash inflow G$/y" - "Sales tax G$/y"
+	~	G$/y
+	~		|
+
+"Pulse height (1)"=
+	0
+	~	1 [0,0.1,0.01]
+	~	was 0.04
+	|
+
+Worker debt burden y=
+	Workers debt G$ / "Worker income after tax G$/y"
+	~	y
+	~		|
+
+GCI in 1980=
+	5400
+	~	G$/y [2000,6000,100]
+	~	was 276
+		211126 changed from 2576
+	|
+
+"Permanent worker cash inflow G$/y"=
+	SMOOTHI("Worker cash inflow G$/y", Time to adjust worker consumption y, WFI in 1980)
+	~	G$/y
+	~		|
+
+"Worker finance cost as share of income (1)"=
+	"Cash flow from workers to banks G$/y" / "Worker income after tax G$/y"
+	~	1
+	~		|
+
+"Owner consumption G$/y"=
+	"Permanent owner cash inflow G$/y" * "Owner consumptin fraction (1)"
+	~	G$/y
+	~		|
+
+"CLR in 1980 k$/j"=
+	41
+	~	k$/j [8,12,0.1]
+	~	was 10
+		220113 changed from 9.8 to 10 for China
+		211222 Equal to capacity (3750 cu) divided by Available work seekers (383 Mp) = 9.8 \
+		for China in 1980
+		was 41
+		211127 changed from 44.7 to get suitable amplitude for new lower savings \
+		slope. Equilibrium 40.3
+	|
+
+"sWSOeoFRA<0"=
+	-2.5
+	~	1 [-4,-0.1,0.1]
+	~	was -1, so -3, so -5, so -10, so -2.4, so -1, so -2
+	|
+
+"Investment in new capacity PIS G$/y"=
+	"Available capital G$/y" * "Fraction of available capital to new capacity (1)"
+	~	G$/y
+	~		|
+
+INV in 1980 Gu=
+	"Optimal output in 1980 Gu/y" * "SWI in 1980 (1)" * Desired inventory coverage y
+	~	Gu
+	~		|
+
+"sCBCeoFRA<0"=
+	-0.8
+	~	1 [-1,0,0.1]
+	~	as -0.5
+		211125 changed from -0.8 - after intro of PUS
+	|
+
+"CBC effect on flow to capacity addion (1)"=
+	1 + "sCBCeoFRA<0" * ("Corporate borrowing cost 1/y" / "Corporate borrowing cost in 1980 1/y"\
+		 - 1 )
+	~	1
+	~		|
+
+"sINVeoSWI<0"=
+	-0.6
+	~	1 [-0.8,-0.4,0.01]
+	~	was -0.5
+	|
+
+"sINVeoDDI<0"=
+	-0.6
+	~	1 [-0.6,-0.4,0.01]
+	~	was -0.2, so -0.46, so -0.48, so -0.51
+	|
+
+"Change in DDI 1/y"=
+	"ROC in DDI 1/y"* "Delivery delay - index (1)"
+	~	1/y
+	~		|
+
+"Sufficient relative inventory (1)"=
+	1
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+"Sales tax G$/y"=
+	"Sales tax workers G$/y" + "Sales tax owners G$/y"
+	~	G$/y
+	~		|
+
+"Effective purchasing power G$/y"=
+	SMOOTHI("Total purchasing power G$/y", Demand adjustment time y, "Demand in 1980 G$/y"\
+		) * 
+	( 1 +  "Demand pulse 2020-25 (1)")
+	~	G$/y [990,1010,1]
+	~		|
+
+"Desired shifts worked - index (1)"=
+	1 + "sINVeoSWI<0" * ("Perceived relative inventory (1)" / "Desired relative inventory (1)"\
+		 - 1 )
+	~	1
+	~		|
+
+"Available capital G$/y"=
+	"Total savings G$/y" + "Foreign capital inflow G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust shifts y=
+	0.24
+	~	y [0.2,0.3,0.001]
+	~	was 0.25
+	|
+
+"Shifts worked - index (1)"=
+	SMOOTH("Desired shifts worked - index (1)", Time to adjust shifts y)
+	~	1
+	~		|
+
+"ROC in DDI 1/y"=
+	0 + "sINVeoDDI<0" * ( "Perceived relative inventory (1)" / "Sufficient relative inventory (1)"\
+		 - 1 )
+	~	1/y
+	~		|
+
+"Desired relative inventory (1)"=
+	1
+	~	1
+	~		|
+
+"Foreign capital inflow G$/y"=
+	0
+	~	G$/y [0,500,50]
+	~		|
+
+Max workers debt burden y=
+	1
+	~	y [0,5,1]
+	~		|
+
+Max workers debt G$=
+	"Worker income G$/y" * Max workers debt burden y
+	~	G$
+	~		|
+
+"sEDeoFRA>0"=
+	5
+	~	1 [0,20,0.5]
+	~	210827 changed from: 1
+		was 0.2, so 0.05
+	|
+
+Time to observe excess demand y=
+	1
+	~	
+	~		|
+
+"Extra mult on CUC, to avoid initial transient in Investment share of GDP"=
+	1.7
+	~	1 [0.8,6,0.1]
+	~	Should be 1 in equilibrium
+	|
+
+"Excess demand in 1980 (1)"=
+	1
+	~	1 [0.8,1.1,0.01]
+	~	was 1.02, so .98, so .92, so 0.9, so 0.8, so 1, so 0.85
+	|
+
+"PCOR PIS cu/u/y"=
+	2.3
+	~	y [1,3.5,0.1]
+	~	was 2.5
+		211216 changed back from 2.3 to 2.5 to get slower growth
+		211125 changed from 2.5 (to get higher output - and lower pop growth in \
+		1980)
+	|
+
+"Excess demand effect on life of capacity (1)"=
+	1 + "sEDeoLOC>0" * ("Perceived excess demand (1)" / "Excess demand in 1980 (1)" - 1)
+	~	1
+	~		|
+
+CAP PIS in 1980 Gcu=
+	59250
+	~	Gcu [3000,4300,100]
+	~	was 4000
+		220113 changed from 3000 to 4000 to match China
+		was 70400, so 64520, so 59250, so 56000
+	|
+
+"Capacity addition PIS Gcu/y"=
+	Capacity under construction PIS Gcu / Construction time PIS y
+	~	Gcu/y
+	~		|
+
+"Capacity discard PIS Gcu/y"=
+	Capacity PIS Gcu / Life of capacity PIS y
+	~	Gcu/y
+	~		|
+
+Capacity PIS Gcu= INTEG (
+	"Capacity addition PIS Gcu/y"-"Capacity discard PIS Gcu/y",
+		CAP PIS in 1980 Gcu)
+	~	Gcu
+	~		|
+
+Capacity under construction PIS Gcu= INTEG (
+	"Capacity initiation PIS Gcu/y"-"Capacity addition PIS Gcu/y",
+		CUC PIS in 1980 Gcu)
+	~	Gcu
+	~	was 160
+	|
+
+Construction time PIS y=
+	1.5
+	~	y
+	~	was 2
+	|
+
+CUC PIS in 1980 Gcu=
+	( CAP PIS in 1980 Gcu / Life of capacity PIS in 1980 y ) * Construction time PIS y *\
+		 "Extra mult on CUC, to avoid initial transient in Investment share of GDP"
+	~	Gcu
+	~		|
+
+"ED effect on flow to capacity addition (1)"=
+	1 + "sEDeoFRA>0" * ( "Perceived excess demand (1)"/ "Excess demand in 1980 (1)" - 1 \
+		)
+	~	1
+	~		|
+
+"Output growth in 1980 1/y (to avoid transient)"=
+	0.06
+	~	1/y [0.02,0.08,0.001]
+	~	was 0.06
+	|
+
+"Output growth rate 1/y"=
+	SMOOTHI( ("Optimal real output Gu/y" - "Output last year G$/y" ) / "Output last year G$/y"\
+		 / 1, 1, "Output growth in 1980 1/y (to avoid transient)")
+	~	1/y
+	~		|
+
+"Output last year G$/y"=
+	SMOOTHI("Optimal real output Gu/y", 1, "Optimal output in 1980 Gu/y" / ( 1 + "Output growth in 1980 1/y (to avoid transient)"\
+		 ))
+	~	G$/y
+	~		|
+
+"Perceived excess demand (1)"=
+	SMOOTHI("Excess demand (1)", Time to observe excess demand y, 1)
+	~	1
+	~		|
+
+"ROC in embedded TFP 1/y"=
+	0.01
+	~	1/y [0,0.02,0.001]
+	~	was 0.007, was 0.009, so 0.004, so 0.008
+	|
+
+Kappa=
+	0.3
+	~	1 [0.3,0.7,0.05]
+	~		|
+
+Lambda=
+	1 - Kappa
+	~	1
+	~		|
+
+Life of capacity PIS in 1980 y=
+	15
+	~	y
+	~		|
+
+"Embedded TFP in 1980 (1)"=
+	1
+	~	1
+	~		|
+
+"sEDeoLOC>0"=
+	0.5
+	~	1 [0,2,0.1]
+	~	was 0.2, so 1
+	|
+
+Max govmnt debt G$=
+	"National income G$/y" * Max govmnt debt burden y
+	~	G$
+	~		|
+
+"Minimum relative inventory without inflation (1)"=
+	1.07
+	~	1 [0.9,1.1,0.01]
+	~	was 1.12, so 1.07, so 1
+	|
+
+"Savings share of GDP (1)"=
+	"Total savings G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Consumption share of GDP (1)"=
+	"Consumption demand G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Perceived inflation CB 1/y"=
+	SMOOTHI("Inflation rate 1/y", Inflation perception time CB y, "Inflation in 1980 (1/y)"\
+		)
+	~	1/y [-0.04,0.04,0.01]
+	~		|
+
+"Govmnt finance as share of NI (1)"=
+	( "Govmnt interest cost G$/y" + "Govmnt payback G$/y" ) / "National income G$/y"
+	~	
+	~		|
+
+"Inflation rate 1/y"=
+	"sINVeoIN<0" * ( "Perceived relative inventory (1)" / "Minimum relative inventory without inflation (1)"\
+		 - 1 )
+	~	1/y
+	~		|
+
+"Owner savings G$/y"=
+	"Permanent owner cash inflow G$/y" - "Owner consumption G$/y"
+	~	G$/y
+	~		|
+
+Govmnt debt burden y=
+	Govmnt debt G$ / "National income G$/y"
+	~	y
+	~		|
+
+Sales averaging time y=
+	1
+	~	y [0,1,0.1]
+	~	was 0.25, so 0.5
+	|
+
+"Normal (1)"=
+	1
+	~	1
+	~		|
+
+DDI in 1980 y=
+	1
+	~	y [0.9,1.1,0.01]
+	~	DD was 0.2
+	|
+
+"Perceived relative inventory (1)"=
+	SMOOTH(Inventory coverage y / Desired inventory coverage y, Inventory coverage perception time y\
+		)
+	~	1
+	~		|
+
+Sampling time y=
+	0.1
+	~	y
+	~	roughly 1 months
+	|
+
+"sINVeoIN<0"=
+	-0.26
+	~	1 [-0.5,0,0.01]
+	~	was - 0.2, so -0.01, so -0.5, so - 0.34, s=.1, so -0.2, so -0.3, so -0.26, \
+		so 0
+	|
+
+Demand adjustment time y=
+	1.2
+	~	y [0.9,1.3,0.01]
+	~	was 0.6, so 1, so 1.2
+	|
+
+Inventory coverage perception time y=
+	0.25
+	~	y [0.01,0.5,0.01]
+	~	was 0.25, was 0.5, was 0.1, so0.5, so 0.1, so 0.2
+	|
+
+Inventory Gu= INTEG (
+	"Output Gu/y" - "Deliveries Gu/y",
+		INV in 1980 Gu)
+	~	Gu
+	~		|
+
+"STD in fluctuation around normal (1)"=
+	0
+	~	1 [0,0.05,0.01]
+	~	was 0.01
+	|
+
+Desired inventory coverage y=
+	0.4
+	~	y [0,0.5,0.01]
+	~	was 0.25, so 0.25, so 0.4
+	|
+
+"Pink noise in sales (1)"=
+	RANDOM PINK NOISE("Normal (1)" ,"STD in fluctuation around normal (1)", Sampling time y\
+		, 1)
+	~	1
+	~		|
+
+"Change in Price Index 1/y"=
+	"Price Index (1980=1)" * "Inflation rate 1/y"
+	~	1/y
+	~		|
+
+"SWI in 1980 (1)"=
+	1
+	~	1 [0.7,1.3,0.05]
+	~		|
+
+Inventory coverage y=
+	Inventory Gu / "Recent sales Gu/y"
+	~	y
+	~		|
+
+Workers debt in 1980 G$=
+	18992 * Mult to avoid transient in worker finance
+	~	G$ [18000,23000,100]
+	~	was 1062
+		was 18992
+		equal to one year's income after tax 22140, somewhat reduced to avoid \
+		initial transient
+	|
+
+Govmnt debt in 1980 G$=
+	28087 * Mult to avoid transient in govmnt finance
+	~	G$ [26000,30000,100]
+	~	was 1500
+		was 28160
+		Equal to one year's national income 28160, somewhat reduced to avoid \
+		transient
+	|
+
+Mult to avoid transient in govmnt finance=
+	0.64
+	~	1 [0.5,0.8,0.01]
+	~	was 0.8
+		was 0.59, so 0.64
+		211126 changed from 0.65
+		was 0.7, so 0.6
+	|
+
+Mult to avoid transient in worker finance=
+	0.39
+	~	1 [0,1,0.01]
+	~	was 0.54
+		was 0.39, so 0.49
+		211126 changed from 0.54
+		was 0.7, so 0.6
+	|
+
+"Corporate borrowing cost 1/y"=
+	"Cost of capital for secured debt 1/y" + "Normal corporate credit risk 1/y"
+	~	1/y
+	~		|
+
+"Worker borrowing cost 1/y"=
+	"Cost of capital for secured debt 1/y"
+	~	1/y
+	~		|
+
+"Worker interest cost G$/y"=
+	Workers debt G$ * "Worker borrowing cost 1/y"
+	~	G$/y
+	~		|
+
+"Govmnt borrowing cost 1/y"=
+	"3m interest rate 1/y"
+	~	1/y
+	~		|
+
+Unemployment perception time CB y=
+	1
+	~	y [0,2,0.1]
+	~	was 1, so 0.5
+	|
+
+"Bank cash inflow from lending G$/y"=
+	"Cash flow from workers to banks G$/y" + "Cash flow from govmnt to banks G$/y"
+	~	G$/y
+	~		|
+
+"Sales tax owners G$/y"=
+	"Owner consumption G$/y" * "Sales tax rate (1)"
+	~	G$/y
+	~		|
+
+"Sales tax rate (1)"=
+	0.03
+	~	1 [0,0.2,0.005]
+	~	In US 1980-2020 3%. Much higher in countries with VAT around 20 %
+		In PUS=0.22 was 0.08
+	|
+
+"Sales tax workers G$/y"=
+	"Worker consumption demand G$/y" * "Sales tax rate (1)"
+	~	G$/y
+	~		|
+
+"Worker consumption demand G$/y"=
+	"Permanent worker cash inflow G$/y" * "Worker consumption fraction (1)"
+	~	G$/y
+	~		|
+
+"Govmnt purchases G$/y"=
+	"Permanent govmnt cash inflow G$/y" * "Government consumption fraction (1)"
+	~	G$/y
+	~		|
+
+"Consumption demand G$/y"=
+	"Worker consumption demand G$/y" - "Sales tax workers G$/y"
+	+ 
+	"Owner consumption G$/y" - "Sales tax owners G$/y"
+	~	G$/y
+	~		|
+
+"Govmnt investment in public capacity G$/y"=
+	"Permanent govmnt cash inflow G$/y" - "Govmnt purchases G$/y"
+	~	G$/y
+	~		|
+
+"Govmnt spending G$/y"=
+	"Govmnt purchases G$/y" + "Govmnt investment in public capacity G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust budget y=
+	1
+	~	y
+	~		|
+
+"Worker savings G$/y"=
+	"Permanent worker cash inflow G$/y" - "Worker consumption demand G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust owner consumption y=
+	1
+	~	y
+	~		|
+
+Time to adjust worker consumption y=
+	1
+	~	y
+	~		|
+
+"sUNeoWSO<0"=
+	-0.035
+	~	 [-0.05,-0.02,0.001]
+	~		|
+
+"Worker consumption fraction (1)"=
+	0.9
+	~	1 [0,1,0.05]
+	~	was 0.6
+		220112 changed from 0.85 to 0.6 for China
+		was 0.95
+		
+		211126 changed from 0.95 to get total savings above 0.3
+		was 0.95, so 0.8
+	|
+
+"Cash flow from govmnt to banks G$/y"=
+	"Govmnt interest cost G$/y" + "Govmnt payback G$/y" - "Govmnt new debt G$/y"
+	~	G$/y
+	~		|
+
+"Cash flow from workers to banks G$/y"=
+	"Worker interest cost G$/y" + "Workers payback G$/y" - "Workers new debt G$/y"
+	~	G$/y
+	~		|
+
+"Workers new debt G$/y"=
+	MAX(0, ( Max workers debt G$ - Workers debt G$ ) / Workers drawdown period y)
+	~	G$/y
+	~		|
+
+Owner savings fraction in 1980=
+	0.9
+	~	1 [0,1,0.1]
+	~	was 0.7
+		220112 changed from 0.9 to 0.7 for China
+		211216 changed back from 0.9 to 0.8 to give reasonable growth in GDP 1980 to 2020 \
+		after intro of inequity
+		211126 changed from 0.8 to get total savings rate above 0.3
+		was 0.66 so 0.9, 0.75, so 0.72, so 0.64
+	|
+
+"Extra transfer of govmnt budget to workers (1)"=
+	0.2
+	~	1 [0,0.5,0.1]
+	~	0 in TLTL and 0.2 in GL
+		on top of 0.3 in all runs
+	|
+
+"sGDPeoOSR<0"=
+	-0.06
+	~	1 [-0.1,0,0.005]
+	~	was 0
+		220112 changed from -0.13 to 0 to prove that declinig growth rate with rising GDPpp \
+		is not caused by savings rate
+		2112nn changed to -0.05 to avoid end of capitalism
+		211205 changed from 0.055 to -0.6 to match DC data correctly
+		211126 changed from -0.17 to fit DC f(GDPpp)
+		was -0.07, so -0.15, so -0.14, so -0.05
+	|
+
+Workers debt G$= INTEG (
+	"Workers new debt G$/y"-"Workers payback G$/y",
+		Workers debt in 1980 G$
+		)
+	~	G$
+	~		|
+
+Workers drawdown period y=
+	10
+	~	 [0,10,1]
+	~	Was 2
+	|
+
+"Govmnt cash inflow G$/y"=
+	"Govmnt net income G$/y" - "Cash flow from govmnt to banks G$/y"
+	~	G$/y
+	~		|
+
+"Owner consumptin fraction (1)"=
+	1 - "Owner savings fraction (1)"
+	~	1
+	~		|
+
+"Government consumption fraction (1)"=
+	0.75
+	~	 [0,1,0.05]
+	~	was 0.85
+	|
+
+"Workers payback G$/y"=
+	Workers debt G$ / Workers payback period y
+	~	G$/y
+	~		|
+
+"Worker cash inflow G$/y"=
+	"Worker income after tax G$/y" -  "Cash flow from workers to banks G$/y"
+	~	G$/y
+	~		|
+
+"Worker income after tax G$/y"=
+	"Worker income G$/y" - "Worker taxes G$/y" + "Transfer payments G$/y"
+	~	G$/y
+	~		|
+
+Workers payback period y=
+	20
+	~	y
+	~		|
+
+"Total savings G$/y"=
+	"Owner savings G$/y" + "Worker savings G$/y"
+	~	G$/y
+	~		|
+
+Govmnt drawdown period y=
+	10
+	~	y [0,10,1]
+	~	was 2
+	|
+
+Govmnt payback period y=
+	200
+	~	y [0,1000,100]
+	~	was 100, so 1000 (did not matter),
+	|
+
+"3m interest rate 1/y"=
+	"Central bank signal rate 1/y" + "Normal basic bank margin 1/y"
+	~	1/y
+	~		|
+
+Finance sector response time y=
+	1
+	~	y [0,2,0.1]
+	~	was 0.5
+	|
+
+"Change in signal rate 1/yy"=
+	( "Indicated signal rate 1/y" - "Central bank signal rate 1/y" ) / Signal rate adjustment time y
+	~	1/y/y
+	~		|
+
+"sUNeoSR<0"=
+	-1.5
+	~	1/yy [-2,0,0.01]
+	~	was -0.5, so -1
+	|
+
+"Normal bank operating margin 1/y"=
+	0.015
+	~	1/y
+	~		|
+
+"Normal basic bank margin 1/y"=
+	0.005
+	~	1/y [0,0.01,0.001]
+	~		|
+
+"sINeoSR>0"=
+	0.7
+	~	1 [0,1,0.01]
+	~	Should be 1? Was 0, so 0.2
+	|
+
+"Normal signal rate 1/y"=
+	0.02
+	~	1/y
+	~		|
+
+"Unemployment target (1)"=
+	0.05
+	~	1
+	~		|
+
+"Inflation in 1980 (1/y)"=
+	0.02
+	~	1/y
+	~		|
+
+Signal rate adjustment time y=
+	1
+	~	 [0,2,0.1]
+	~	was 0.3
+	|
+
+"Cost of capital for secured debt 1/y"=
+	SMOOTHI("3m interest rate 1/y" + "Normal bank operating margin 1/y", Finance sector response time y\
+		, "3m interest rate 1/y" + "Normal bank operating margin 1/y")
+	~	1/y
+	~		|
+
+Inflation perception time CB y=
+	1
+	~	y [0,2,0.1]
+	~		|
+
+"Inflation target 1/y"=
+	0.02
+	~	1/y [0,0.05,0.01]
+	~		|
+
+"Indicated signal rate 1/y"=
+	"Normal signal rate 1/y" * ( 1
+	+
+	"sINeoSR>0" * ("Perceived inflation CB 1/y" / "Inflation target 1/y" - 1)
+	+
+	"sUNeoSR<0" * ("Perceived unemployment CB (1)" / "Unemployment target (1)" - 1)
+	)
+	~	1/y
+	~		|
+
+"Population growth rate 1/y"=
+	"Birth rate 1/y" - "Death rate 1/y"
+	~	1/y
+	~		|
+
+"Aged 0-20 in 1980 Mp"=
+	2170
+	~	Mp [1950,2200,10]
+	~	was 2050, so 2170, so 491
+		211202 changed to 2050 from 2170
+		211127 changed from 2050
+		was 2025
+	|
+
+"Aged 0-20 years Mp"= INTEG (
+	"Births Mp/y"-"Passing 20 Mp/y",
+		"Aged 0-20 in 1980 Mp")
+	~	Mp
+	~	was 2025
+	|
+
+"Aged 20-40 in 1980 Mp"=
+	1100
+	~	Mp [1100,1300,20]
+	~	was 1220, so 1100, so 249
+		211202 changed from 1100 back to 1220
+		211127 changed from 1220
+		was1283
+	|
+
+"Aged 20-40 years Mp"= INTEG (
+	"Passing 20 Mp/y"-"Passing 40 Mp/y",
+		"Aged 20-40 in 1980 Mp")
+	~	Mp
+	~	was 1283
+	|
+
+LEmax=
+	85
+	~	y [70,100,1]
+	~	Maximum LE in 1980
+	|
+
+"Birth rate 1/y"=
+	"Births Mp/y" / Population Mp
+	~	1/y
+	~		|
+
+Time to adapt to higher income y=
+	10
+	~	y [1,20,1]
+	~	was 3
+	|
+
+"sLEeoPa>0"=
+	0.75
+	~	1
+	~	was 0.65, so 0.75, so 0.3
+	|
+
+"Pensioners per worker p/p"=
+	On pension Mp / "Aged 20-pension age Mp"
+	~	1
+	~		|
+
+"Aged 20-pension age Mp"=
+	"Aged 20-40 years Mp" + "Aged 40-60 Mp" + "Aged 60 + Mp" - On pension Mp
+	~	Mp
+	~		|
+
+On pension Mp=
+	"Aged 60 + Mp" * (Life expectancy y - Pension age y ) / ( Life expectancy y - 60 )
+	~	Mp
+	~		|
+
+"Fraction achieving desired family size (1)"=
+	0.8
+	~	1 [0,1,0.1]
+	~		|
+
+Order=
+	10
+	~	 [1,20,1]
+	~		|
+
+DNC in 1980=
+	4.3
+	~	1 [4,5,0.1]
+	~	was 4.5, so 4.2
+		211202 changed to 4.5 from 4.2
+		211126 changed from 4.5 to get pop to 6000 in 2000
+		DF in 1980 was 4.7 so 5.0 so 4.9 so 4.4, so 4.2, so 4.4
+	|
+
+"DNCalfa<0"=
+	0
+	~	1/k$/p/y [-0.02,0.04,0.001]
+	~	was 0.02
+		220113 Changed from 0 to 0.02 to avoid too rapid decline in pop towards 2100.
+		Rate of decline of Minimum DF was 0.015, AND THEN 0.05 so 0.001, so 0.007
+	|
+
+"Fraction women (1)"=
+	0.5
+	~	1 [0.4,0.5,0.01]
+	~		|
+
+DNCmin=
+	1.2
+	~	1 [0,2,0.1]
+	~	was 1.6, so 1.5
+		211202 changed from 1.5 to 1.6
+		211129 changed from 1.2 to compensate for change in age structure
+	|
+
+"Death rate 1/y"=
+	"Deaths Mp/y" / Population Mp
+	~	1/y
+	~		|
+
+LE at 60 y=
+	Life expectancy y - 60
+	~	y
+	~		|
+
+Pension age in 1980 y=
+	62
+	~	y [60,90,1]
+	~	220113 Changed back from 67 to 62, assuming that people under 20 also participate in \
+		the workforce.
+		220109 changed from 62 to 67 to get sufficient labour force (ie over 500 \
+		Mp)
+	|
+
+"Dependency ratio p/p"=
+	( "Aged 0-20 years Mp" + "Aged 60 + Mp" ) / ( "Aged 20-40 years Mp" + "Aged 40-60 Mp"\
+		 )
+	~	1
+	~		|
+
+Population Mp=
+	"Aged 0-20 years Mp" + "Aged 20-40 years Mp" + "Aged 40-60 Mp" + "Aged 60 + Mp"
+	~	Mp
+	~		|
+
+"Output u/y"=
+	0
+	~	u/y
+	~		|
+
+DNCgamma=
+	0.14
+	~	1/k$ [0,0.4,0.01]
+	~	was 0.12, so 0.17
+		211129 changed from 0.13 to 0.12 to compensate for new PUS and CLR
+		211127 changed from 0.22 at the same time as changing initial values of age groups
+		was 0.12, so 0.17, so 0.33, so 0.4, so 0.25, so 0.2, so 0.16
+	|
+
+LE in 1980=
+	67
+	~	y [61,74,1]
+	~	was 64
+		220113 changed from 67 to 62 to fit China
+		LE in 1980
+	|
+
+Fertile period y=
+	20
+	~	y
+	~		|
+
+LEgamma=
+	0.15
+	~	1/k$/p/y
+	~	Rate of increase in LE
+	|
+
+"GDP per person in 1980 k$/p/y"=
+	6.4
+	~	k$/p/y [1,5,0.1]
+	~	was 6.1
+	|
+
+LEalfa=
+	0.001
+	~	1/k$/p/y [0,0.002,0.0001]
+	~	Rate of increase in max LE after 1980
+	|
+
+Job creation delay y=
+	0.9
+	~	 [0,2,0.1]
+	~	was 1, so 0.8, so 0.7
+	|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 2100
+	~	Year
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 1980
+	~	Year
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  = 
+        TIME STEP
+	~	Year [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 0.015625
+	~	Year [0,?]
+	~	The time step for the simulation.
+	|
+
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Overview 
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+12,1,0,556,-192,408,126,3,135,0,8,-1,0,0,0,-1--1--1,0-0-0,|20||0-0-0,0,0,0,0,0,0
+This is the Earth4All-global jr model of a modern capitalist economy with endogenous distribution and an active state (the "Human World"). It is coupled to simple models of energy/climate and food/land (two important elements of the "Natural World"). The model is an early example of a (dynamic and causal)  global integrated assessment model, made to study the evolution of human wellbeing within planetary boundaries in the 21st century. Jorgen Randers 220501. Contact: jorgen.randers@bi.no 
+12,2,1246944,835,1635,279,272,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+10-year_wave
+12,3,1509570,1430,1636,277,271,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+4-year_cycle
+12,4,591206,2238,2967,278,267,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Financial_cycle
+10,5,"sCBCeoFRA<0",928,696,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,6,"sWSOeoFRA<0",783,697,65,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,7,"Extra transfer of govmnt budget to workers (1)",2360,1996,68,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,8,0,1900,-198,266,116,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|18||255-0-0,0,0,0,0,0,0
+THE MODEL IS TYPICALLY UPDATED EVERY 1-2 MONTHS. THIS IS THE mov220501 VERSION WHICH EQUALS THE mov220327 VERSION WITH A FEW MINOR CHANGES MADE IN DARK BLUE. ALL CHANGES MADE SINCE THE mov220226 VERSION ARE MARKED RED. POLICY HANDLES ARE PINK. IMPORTANT CROSSLINKS ARE ORANGE. JR 220501
+12,9,0,3241,2332,462,313,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Inequity_emissions_land_use_1980-2100
+10,10,"Fraction of extra taxes paid by owners (1)",375,1847,99,28,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,11,"Extra general tax rate from 2022 (1)",1976,1997,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,12,"sOWeoLoCO2>0",309,702,69,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,13,"sOWeoACY<0",631,693,61,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,14,"sCO2CeoACY>0",463,701,69,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,15,"sGDPeoOSR<0",1070,698,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,16,"sIIEeoROTA<0",295,727,74,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,17,656736,846,2237,276,260,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Growth_1980-2020
+12,18,0,1301,-222,305,96,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|18|B|0-0-128,0,0,0,0,0,0
+This version of the model (mov220501 E4A-global jr ) is used to illustrate the two scenarios described in the "Earth for All" book, to be published September 1, 2022: the Too-Little-Too-Late scenario (TLTL) and the Giant Leap (GL) scenarios. Details will become available in a Technical Report on www.clubofrome.org/Earth4All
+10,19,"Extra general tax rate from 2022 (1)",1340,247,74,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,20,"Extra transfer of govmnt budget to workers (1)",1342,402,103,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,21,"Fraction of govmnt debt cancelled in 2022 1/y",1329,-70,73,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,22,"Goal for extra income from commons (share of NI)",1354,483,103,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,23,"Goal for extra normal LPR (1)",651,739,79,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,24,Normal reform delay y,177,270,53,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,25,395926,781,329,423,307,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+1._Main_trends
+12,26,330226,1430,2239,274,262,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Economic_development__1980_to_2020
+10,27,"Fraction of extra taxes paid by owners (1)",1335,329,76,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,28,"sOWeoTFP<0",464,732,57,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,29,"sOWeoCOC>0",305,762,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,30,"Extra domestic ROTA from 2022 1/y",835,728,74,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,31,"Goal for renewable el fraction (1)",1554,402,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,32,"Goal for fraction new electrification (1)",1551,329,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,33,"Goal for fraction of CO2-sources with CCS (1)",1563,493,78,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,34,"Exogenous introduction period?",172,112,51,26,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,35,Exogenous introduction period y,177,188,56,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,36,"Goal for crop waste reduction (1)",1536,5,69,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,37,"Goal for fraction regenerative agriculture (1)",1557,100,95,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,38,"Goal for fraction new red meat (1)",1559,170,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,39,"Unconventional stimulus in PIS from 2022 (share of GDP)",1330,12,88,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,40,"Unconventional stimulus in PUS from 2022 (share of GDP)",1340,95,107,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,41,"Max imported ROTA from 2022 1/y",1337,173,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,42,"Goal for extra fertility reduction (1)",1355,560,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,43,"Extra empowerment tax from 2022 (share of NI)",1360,626,82,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,44,"Extra pension tax from 2022 (share of NI)",1358,706,77,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,45,461158,2102,328,436,300,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+2._Human_footprint
+12,46,395940,807,1043,427,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+3._Consumption
+12,47,330378,1696,1040,415,277,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+4._Wellbeing
+12,48,330234,2564,1033,392,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+5._Turnarounds
+10,49,"Direct air capture of CO2 in 2100 GtCO2/y",1552,699,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,50,"Extra ROC in energy productivity after 2022 1/y",1550,257,73,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,51,"Extra rate of decline in N2O per kg fertilizer from 2022 1/y",1554,569,83,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,52,"Extra rate of decline in CH4 pr kg crop after 2022 1/y",1551,637,87,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,53,"Extra ROC in food sector productivity from 2022 1/y",1537,-70,83,28,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Population
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Aged 0-20 years Mp",960,218,43,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"Aged 20-40 years Mp",1158,221,43,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,"Aged 40-60 Mp",1311,226,40,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Aged 60 + Mp",1497,223,40,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,5,48,800,216,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,6,8,1,4,0,0,22,0,0,0,-1--1--1,,1|(889,219)|
+1,7,8,5,100,0,0,22,0,0,0,-1--1--1,,1|(830,219)|
+11,8,48,856,219,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,9,"Births Mp/y",856,244,38,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,10,12,2,4,0,0,22,0,0,0,-1--1--1,,1|(1094,219)|
+1,11,12,1,100,0,0,22,0,0,0,-1--1--1,,1|(1032,219)|
+11,12,12410,1067,219,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,13,"Passing 20 Mp/y",1067,251,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,14,16,3,4,0,0,22,0,0,0,-1--1--1,,1|(1260,221)|
+1,15,16,2,100,0,0,22,0,0,0,-1--1--1,,1|(1219,221)|
+11,16,12300,1244,221,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,17,"Passing 40 Mp/y",1244,253,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,18,20,4,4,0,0,22,0,0,0,-1--1--1,,1|(1437,222)|
+1,19,20,3,100,0,0,22,0,0,0,-1--1--1,,1|(1378,222)|
+11,20,12102,1412,222,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,21,"Passing 60 Mp/y",1412,255,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,22,48,1608,224,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,25,22,4,0,0,22,0,0,0,-1--1--1,,1|(1585,224)|
+1,24,25,4,100,0,0,22,0,0,0,-1--1--1,,1|(1549,224)|
+11,25,48,1567,224,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,26,"Deaths Mp/y",1567,243,42,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,27,Population Mp,1193,442,47,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,1,27,0,0,0,0,0,128,0,-1--1--1,,1|(1079,333)|
+1,29,2,27,0,0,0,0,0,128,0,-1--1--1,,1|(1175,333)|
+1,30,3,27,0,0,0,0,0,128,0,-1--1--1,,1|(1251,335)|
+1,31,4,27,0,0,0,0,0,128,0,-1--1--1,,1|(1341,335)|
+10,32,"Dependency ratio p/p",1059,108,44,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,33,1,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1008,164)|
+1,34,4,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1286,167)|
+1,35,2,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1108,164)|
+1,36,3,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1191,170)|
+10,37,Fertile period y,700,256,48,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,38,"Birth rate 1/y",1037,455,47,11,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,39,27,38,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1127,441)|
+10,40,Desired no of children 1,857,421,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,41,9,38,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(939,353)|
+10,42,"Fraction women (1)",693,224,63,17,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Death rate 1/y",1356,457,50,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,44,27,43,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1277,442)|
+1,45,25,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1468,331)|
+10,46,"Fraction achieving desired family size (1)",689,319,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,47,DNCmin,726,432,30,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,DNC in 1980,731,393,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,DNCgamma,722,479,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,50,"DNCalfa<0",791,506,38,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,51,47,40,0,0,0,0,0,128,0,-1--1--1,,1|(777,427)|
+1,52,48,40,0,0,0,0,0,128,0,-1--1--1,,1|(787,404)|
+1,53,49,40,0,0,0,0,0,128,0,-1--1--1,,1|(773,456)|
+1,54,50,40,0,0,0,0,0,128,0,-1--1--1,,1|(816,473)|
+10,55,LE in 1980,1719,335,36,11,8,3,0,16,0,0,0,0,-1--1--1,0-0-0,|12|U|255-0-0,0,0,0,0,0,0
+10,56,LEmax,1757,371,24,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,57,LEgamma,1748,409,33,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,58,LEalfa,1708,430,22,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,59,Life expectancy y,1609,383,55,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,60,56,59,0,0,0,0,0,128,0,-1--1--1,,1|(1705,374)|
+1,61,55,59,0,0,0,0,0,128,0,-1--1--1,,1|(1670,356)|
+1,62,57,59,0,0,0,0,0,128,0,-1--1--1,,1|(1696,399)|
+1,63,58,59,0,0,0,0,0,128,0,-1--1--1,,1|(1665,410)|
+10,64,LE at 60 y,1605,314,34,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,65,59,64,0,0,0,0,0,128,0,-1--1--1,,1|(1607,355)|
+1,66,64,26,0,0,0,0,0,128,0,-1--1--1,,1|(1589,284)|
+1,67,9,13,1,0,0,0,0,128,0,-1--1--1,,1|(986,312)|
+1,68,13,17,1,0,0,0,0,128,0,-1--1--1,,1|(1151,296)|
+1,69,17,21,1,0,0,0,0,128,0,-1--1--1,,1|(1342,292)|
+10,70,Order,1199,103,21,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,71,70,13,0,0,0,0,0,128,1,-1--1--1,,1|(1137,171)|
+1,72,70,17,0,0,0,0,0,128,1,-1--1--1,,1|(1219,171)|
+1,73,70,21,0,0,0,0,0,128,1,-1--1--1,,1|(1299,174)|
+10,74,"GDP per person in 1980 k$/p/y",864,562,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"Effective GDP per person k$/p/y",1154,594,54,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,76,75,40,1,0,45,12,18,64,0,-1--1--1,|12|B|255-0-0,1|(950,524)|
+1,77,75,59,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(1499,464)|
+1,78,74,40,1,0,0,0,0,128,0,-1--1--1,,1|(857,492)|
+10,79,"Aged 20-40 in 1980 Mp",720,138,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,80,79,2,0,0,0,0,0,128,1,-1--1--1,,1|(934,177)|
+10,81,"Aged 0-20 in 1980 Mp",655,180,43,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,82,81,1,0,0,0,0,0,128,1,-1--1--1,,1|(800,197)|
+10,83,On pension Mp,1662,177,50,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,84,4,83,0,0,0,0,0,128,0,-1--1--1,,1|(1572,201)|
+10,85,Pension age y,1722,248,44,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,86,85,83,1,0,0,0,0,128,0,-1--1--1,,1|(1720,210)|
+10,87,"Pensioners per worker p/p",1627,104,53,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,88,2,92,1,0,0,0,0,128,0,-1--1--1,,1|(1301,145)|
+1,89,3,92,1,0,0,0,0,128,0,-1--1--1,,1|(1384,149)|
+1,90,4,92,0,0,0,0,0,128,0,-1--1--1,,1|(1448,164)|
+1,91,83,92,0,0,0,0,0,128,0,-1--1--1,,1|(1543,143)|
+10,92,"Aged 20-pension age Mp",1395,102,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,93,92,87,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1505,102)|
+1,94,83,87,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1649,150)|
+10,95,"GDP per person in 1980 k$/p/y",1614,467,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,96,95,59,0,0,0,0,0,128,0,-1--1--1,,1|(1611,427)|
+10,97,Observed fertility 1,843,336,32,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,98,42,9,0,0,0,0,0,128,0,-1--1--1,,1|(780,234)|
+1,99,37,9,0,0,0,0,0,128,0,-1--1--1,,1|(776,250)|
+1,100,97,9,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(834,300)|
+1,101,2,9,1,0,0,0,0,128,0,-1--1--1,,1|(999,344)|
+10,102,"GDP per person k$/p/y",1221,505,57,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,103,102,75,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(1214,582)|
+10,104,Time to adapt to higher income y,1314,596,53,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,105,104,75,0,0,0,0,0,128,0,-1--1--1,,1|(1241,595)|
+1,106,59,85,1,0,0,0,0,128,0,-1--1--1,,1|(1683,316)|
+10,107,"sLEeoPa>0",1772,306,38,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,108,107,85,0,0,0,0,0,128,0,-1--1--1,,1|(1751,282)|
+10,109,Pension age in 1980 y,1800,193,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,110,109,85,0,0,0,0,0,128,0,-1--1--1,,1|(1761,220)|
+1,111,55,85,0,0,0,0,0,128,0,-1--1--1,,1|(1719,298)|
+1,112,59,83,1,0,0,0,0,128,0,-1--1--1,,1|(1675,266)|
+12,113,789498,1478,906,251,267,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Population_and_workforce
+10,114,"Population growth rate 1/y",1564,528,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,43,114,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1441,486)|
+1,116,38,114,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1288,489)|
+10,117,"sOWeoLE<0",2063,393,44,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,118,Time,2054,295,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,119,Perceived warming deg C,1724,542,54,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,120,Observed warming deg C,2156,360,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,121,"Warming effect on life expectancy (1)",1928,330,70,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,122,21,26,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1473,290)|
+1,123,70,26,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1372,168)|
+10,124,"Cost of Max fertility reduction (share of GDP)",238,298,81,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,125,"Cost of extra fertility reduction (share of GDP)",478,304,61,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,126,124,125,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(361,300)|
+1,127,74,75,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1005,577)|
+10,128,Extra pension age in 2022 y,1964,118,57,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,129,Extra pension age y,1927,193,44,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,130,Goal for extra pension age y,2121,182,50,50,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,131,130,129,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(2028,186)|
+1,132,128,129,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(1948,149)|
+1,133,129,85,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(1829,218)|
+10,134,"Aged 40-60 in 1980 Mp",809,107,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,135,"Aged 60+ in 1980 Mp",906,81,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,136,134,3,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1056,165)|
+1,137,135,4,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1195,149)|
+10,138,"Passing 20 in 1980 Mp/y",395,181,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,139,"Passing 40 in 1980 Mp/y",436,134,42,19,8,3,0,4,0,0,0,0,-1--1--1,-1--1--1,|12||255-0-0,0,0,0,0,0,0
+10,140,"Passing 60 in 1980 Mp/y",521,92,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,141,"Dying in 1980 Mp/y",636,74,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,142,141,26,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1096,157)|
+1,143,140,21,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(954,170)|
+1,144,139,17,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(827,191)|
+1,145,138,13,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(718,214)|
+12,146,461778,391,747,228,199,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Fertility_vs_GDPpp
+1,147,40,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(851,385)|
+1,148,46,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(777,328)|
+10,149,Observed warming in 2022 deg C,2183,312,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,150,"SSP2 family action from 2022? (1)",2140,557,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,151,"Fertility multiplier (1)",1892,638,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,152,150,151,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2021,595)|
+10,153,"Life expectancy multipler (1)",1902,484,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,154,150,153,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2022,521)|
+10,155,"Max life expectancy multiplier (1)",2064,488,64,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,156,155,153,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1982,486)|
+10,157,Time,1959,566,26,11,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,158,157,153,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1937,534)|
+1,159,157,151,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1933,592)|
+1,160,117,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2010,368)|
+1,161,120,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2056,346)|
+1,162,149,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2057,320)|
+1,163,118,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2018,304)|
+1,164,121,59,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1767,355)|
+10,165,"Max fertility multiplier (1)",2082,637,41,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,166,165,151,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(2001,637)|
+1,167,151,40,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1375,529)|
+1,168,153,59,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1752,432)|
+10,169,"Extra fertility reduction (1)",541,404,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,170,"Goal for extra fertility reduction (1)",384,406,54,54,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,171,170,169,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(461,405)|
+1,172,169,40,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(690,411)|
+1,173,169,125,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(516,364)|
+12,174,0,204,144,141,75,3,135,0,11,-1,0,0,0,255-0-255,0-0-0,|16||255-0-255,0,0,0,0,0,0
+TO SIMULATE POPULATION TURNAROUND: Adjust Goal for extra fertility reduction. You may want to also change other pink policy handles.
+10,175,"GDP G$/y",1071,502,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,176,27,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1201,463)|
+1,177,175,102,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1132,502)|
+10,178,Introduction period for policy y,496,481,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,179,178,169,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(514,448)|
+10,180,Introduction period for policy y,1944,256,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,181,180,129,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1937,231)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Labour market
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Hiring/firing delay y",1004,114,37,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Unemployment rate (1)",1319,-30,48,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,Workforce in 1980 Mp,1662,267,43,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,4,"Unemployment rate in 1980 (1)",1422,-77,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,"Perceived unemployment rate (1)",1294,-150,51,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Unemployment perception time y,1165,-58,55,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,7,6,5,0,0,0,0,0,128,0,-1--1--1,,1|(1218,-96)|
+1,8,4,5,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1370,-106)|
+10,9,"Acceptable unemployment rate (1)",1162,-211,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,10,Time,2861,1354,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,11,"Optimal capital labour ratio kcu/ftj",784,100,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,12,11,13,1,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(808,146)|
+10,13,Optimal workforce Mp,843,186,47,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Indicated wage effect on optimal CLR (1)",872,-191,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,15,"sWSOeoCLR>0",808,-246,54,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,16,15,14,0,0,0,0,0,128,0,-1--1--1,,1|(829,-227)|
+10,17,"Wage effect on optimal CLR (1)",791,-46,49,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,18,Time to change tooling y,915,-108,49,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,19,14,17,1,0,0,0,0,128,0,-1--1--1,,1|(822,-139)|
+1,20,18,17,1,0,0,0,0,128,0,-1--1--1,,1|(869,-101)|
+1,21,17,11,1,0,0,0,0,128,0,-1--1--1,,1|(778,18)|
+10,22,"Worker share of output (1)",1071,-419,46,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,23,48,1261,-419,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,24,26,22,4,0,0,22,0,0,0,-1--1--1,,1|(1145,-406)|
+1,25,26,23,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1179,-419)|
+11,26,48,1179,-406,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,27,"Change in wso 1/y",1179,-387,58,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,28,48,881,-417,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,29,31,28,4,0,0,22,0,0,0,-1--1--1,,1|(919,-417)|
+1,30,31,22,100,0,0,22,0,0,0,-1--1--1,,1|(992,-417)|
+11,31,48,953,-417,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,32,"Long-term erosion of wso 1/y",953,-390,59,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,33,"WSO in 1980 (1)",1064,-291,56,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,34,33,22,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1066,-340)|
+1,35,33,14,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(981,-248)|
+10,36,"sWSOeoFRA<0",2367,-450,65,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,37,"sCBCeoFRA<0",2217,-454,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,38,"Real wage erosion rate 1/y",808,-344,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,39,38,32,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,-364)|
+1,40,22,26,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1132,-453)|
+1,41,22,31,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(997,-458)|
+10,42,"sWSOeoLPR>0",1499,-474,53,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Labour participation rate (1)",1573,-87,52,38,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,44,"Time to enter/leave labor market y",1657,-180,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,45,44,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1628,-148)|
+1,46,42,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1485,-442)|
+10,47,Available workforce Mp,1502,147,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"Normal LPR (1)",1465,-398,52,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,49,33,48,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1257,-342)|
+10,50,"Aged 20-pension age Mp",1701,-56,60,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,51,43,47,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1558,47)|
+1,52,50,74,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1687,-15)|
+1,53,48,72,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1532,-335)|
+10,54,"Normal LPR in 1980 (1)",1334,-426,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,55,54,48,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1391,-414)|
+10,56,"Perceived surplus workforce (1)",1388,-288,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,57,"sPUNeoLPR>0",1417,-209,51,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,5,56,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1346,-256)|
+1,59,57,56,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1406,-237)|
+10,60,Workforce Mp,1126,179,40,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,61,48,986,190,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,62,64,60,4,0,0,22,0,0,0,-1--1--1,,1|(1065,186)|
+1,63,64,61,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1014,186)|
+11,64,48,1039,186,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,65,"Change in workforce Mp/y",1039,213,53,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,66,1,64,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1021,150)|
+1,67,13,65,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(973,224)|
+1,68,3,60,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1399,223)|
+1,69,60,65,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1106,222)|
+10,70,"GDP per person k$/p/y",500,473,58,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,71,GDP per person in 1980,627,511,58,19,8,130,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,72,"Indicated labour participation rate (1)",1566,-247,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,73,72,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1582,-184)|
+10,74,Working age population Mp,1657,33,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,75,74,47,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1589,100)|
+10,76,"ROC in WSO - Table 1/y",1221,-307,52,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,77,9,76,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1187,-253)|
+1,78,76,27,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1201,-344)|
+1,79,9,56,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1267,-247)|
+10,80,Unemployed Mp,1291,130,54,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,81,60,80,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1249,164)|
+1,82,47,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1380,86)|
+10,83,"Normal hours worked kh/ftj/y",867,406,38,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,84,"Hours worked mult from GDPpp (1)",687,442,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,85,"Normal hours worked in 1980 kh/ftj/y",924,472,71,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,86,85,83,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(905,450)|
+1,87,84,83,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(777,406)|
+10,88,"Labour use Gph/y",1250,493,57,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,83,168,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(954,382)|
+1,90,60,88,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1283,335)|
+10,91,"Persons per full-time job p/ftj",692,211,53,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,92,91,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(763,199)|
+10,93,"sTIeoNHW<0",574,396,47,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,94,93,84,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(614,412)|
+1,95,71,84,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(651,481)|
+1,96,70,84,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(586,454)|
+10,97,"Labour use in 1980 Gph/y",1174,314,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,98,3,97,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1425,289)|
+1,99,85,171,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(925,403)|
+1,100,80,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1315,67)|
+1,101,2,5,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1326,-82)|
+10,102,Time to adjust hours worked y,775,341,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,103,102,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(809,365)|
+10,104,"Wage rate $/ph",521,-372,53,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,105,48,681,-377,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,106,108,104,4,0,0,22,0,0,0,-1--1--1,,1|(598,-377)|
+1,107,108,105,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(652,-377)|
+11,108,48,628,-377,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,109,"Change in wage rate $/ph/y",628,-350,51,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,110,"Wage rate in 1980 $/ph",520,-277,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,111,110,104,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(520,-311)|
+12,112,48,343,-373,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,113,115,112,4,0,0,22,0,0,0,-1--1--1,,1|(378,-373)|
+1,114,115,104,100,0,0,22,0,0,0,-1--1--1,,1|(442,-373)|
+11,115,48,410,-373,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,116,"Wage rate erosion $/ph/y",410,-346,59,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,117,"Wage rate erosion rate 1/y",329,-279,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,118,76,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(930,-327)|
+1,119,117,116,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(363,-308)|
+1,120,104,115,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(433,-395)|
+1,121,104,128,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(461,-283)|
+10,122,"Output Gu/y",455,-4,49,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,123,"Labour use Gph/y",525,-53,41,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,124,"Labour productivity $/ph",365,-98,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,125,122,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(418,-41)|
+1,126,123,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(458,-71)|
+1,127,104,108,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(612,-409)|
+10,128,"Wage share (1)",355,-194,53,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,129,"Inflation rate 1/y",154,-296,45,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,130,129,117,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(227,-288)|
+1,131,124,128,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(362,-136)|
+10,132,"Price per unit $/u",348,284,47,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,133,CAP PUS in 1980 Gcu,953,945,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,134,Capacity PIS Gcu,953,945,48,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,135,Capacity Gcu,678,129,53,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,136,135,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(745,152)|
+12,137,2558378,2062,-114,297,309,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+New_Labor_market:_10-year_wave
+10,138,"ROC in ECLR 1/y",504,339,59,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,139,"CLR in 1980 kcu/ftj",396,85,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,140,139,142,0,0,0,0,0,128,1,-1--1--1,,1|(400,130)|
+10,141,"ROC in ECLR in 1980 1/y",391,408,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,142,"Embedded CLR kcu/ftj",408,197,47,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,143,48,402,305,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,144,146,142,4,0,0,22,0,0,0,-1--1--1,,1|(402,238)|
+1,145,146,143,100,0,0,22,0,0,0,-1--1--1,,1|(402,281)|
+11,146,48,402,259,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,147,"Change in embedded CLR kcu/ftj/y",478,259,68,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,138,147,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(477,307)|
+1,149,142,147,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(474,208)|
+10,150,"Cost per unit in 1980 $/u",572,-110,55,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,151,"Optimal output in 1980 Gu/y",674,-148,60,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,152,"Labour use in 1980 Gph/y",684,-219,48,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,153,"Labour productivity in 1980 $/ph",520,-192,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,153,110,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(520,-227)|
+1,155,150,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(549,-145)|
+1,156,151,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(605,-167)|
+1,157,152,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(616,-208)|
+1,158,33,110,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(791,-284)|
+10,159,"Price per unit $/u",326,11,47,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,160,159,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(342,-36)|
+10,161,"Fraction of inflation compensated (1)",179,-366,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,162,161,117,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(247,-325)|
+1,163,22,14,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(972,-306)|
+1,164,142,11,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(562,40)|
+10,165,"sGDPppeoFRACA<0",1874,-456,82,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,166,FRACA min,2052,-453,50,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,167,91,168,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(907,255)|
+10,168,"Average hours worked kh/y",1056,389,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,168,88,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1168,420)|
+10,170,"Persons per full-time job in 1980 p/ftj",710,264,66,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,171,"Average hours worked in 1980 kh/y",928,322,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,172,170,171,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(811,290)|
+1,173,171,97,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1055,317)|
+1,174,22,48,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1272,-482)|
+10,175,"Average gross income per worker k$/p/y",191,-221,78,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,176,"Average hours worked kh/y",190,-147,52,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,177,104,175,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(392,-258)|
+1,178,176,175,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(190,-177)|
+10,179,"Participation (1)",1494,228,55,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,180,5,179,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1394,40)|
+1,181,43,179,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1531,77)|
+10,182,"Extra normal LPR from 2022 (1)",1606,-429,58,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,183,"Goal for extra normal LPR (1)",1709,-517,52,52,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,184,183,182,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1654,-470)|
+1,185,182,48,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1538,-414)|
+10,186,GDPppeoROCCLR,277,475,66,9,8,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,187,70,186,0,0,0,0,0,128,0,-1--1--1,,1|(399,473)|
+1,188,71,186,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(463,494)|
+10,189,"sGDPppeoROCCLR<0",1469,-13,78,9,8,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,190,189,186,0,0,0,0,0,128,0,-1--1--1,,1|(879,228)|
+1,191,186,138,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(344,348)|
+1,192,141,138,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(447,373)|
+12,193,14681756,203,199,150,150,3,12,0,0,1,0,0,0,0,0,0,0,0,0
+CLR_vs_GDPpp
+1,194,5,76,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1273,-232)|
+1,195,56,72,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1486,-279)|
+1,196,47,80,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1377,166)|
+10,197,"10-yr loop delay y",992,-18,45,33,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,198,197,18,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(952,-64)|
+1,199,197,1,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(997,48)|
+1,200,197,6,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(1066,-34)|
+10,201,Introduction period for policy y,1674,-365,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,202,201,182,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1645,-392)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Output
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Capacity PIS Gcu,926,-90,37,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,762,-92,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,2,4,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(798,-92)|
+1,4,5,1,100,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(862,-92)|
+11,5,48,830,-92,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"Capacity discard PIS Gcu/y",830,-65,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,7,Life of capacity PIS y,725,12,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,8,1,5,1,0,0,0,0,64,0,-1--1--1,,1|(857,-112)|
+1,9,7,6,1,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(781,-21)|
+10,10,Capacity under construction PIS Gcu,924,72,51,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,11,13,1,4,0,0,22,0,0,0,-1--1--1,,1|(922,-41)|
+1,12,13,10,100,0,0,22,0,0,0,-1--1--1,,1|(922,18)|
+11,13,19222,922,-12,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,14,"Capacity addition PIS Gcu/y",986,-12,56,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,15,48,921,169,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,16,18,10,4,0,0,22,0,0,0,-1--1--1,,1|(923,114)|
+1,17,18,15,100,0,0,22,0,0,0,-1--1--1,,1|(923,150)|
+11,18,48,923,133,8,6,33,3,0,0,2,0,0,0,0,0,0,0,0,0
+10,19,"Capacity initiation PIS Gcu/y",858,133,57,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,20,Construction time PIS y,1048,-107,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,10,14,0,0,0,0,0,64,0,-1--1--1,,1|(953,30)|
+10,22,CUC PIS in 1980 Gcu,855,4,40,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,23,20,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(957,-54)|
+10,24,"PCOR PIS cu/u/y",719,-261,57,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,22,10,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(879,28)|
+10,26,"Excess demand effect on life of capacity (1)",556,-9,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,"sEDeoLOC>0",445,-59,47,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,26,0,0,0,0,0,128,0,-1--1--1,,1|(484,-40)|
+10,29,"Available capital G$/y",330,49,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,30,"Investment in new capacity PIS G$/y",685,157,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,31,29,30,1,0,0,0,0,128,0,-1--1--1,,1|(454,112)|
+1,32,26,7,1,0,0,0,0,128,0,-1--1--1,,1|(636,24)|
+10,33,CAP PIS in 1980 Gcu,930,-158,39,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,33,1,0,0,0,0,0,64,1,-1--1--1,,1|(928,-134)|
+10,35,Life of capacity PIS in 1980 y,772,79,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,36,33,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(895,-83)|
+1,37,35,7,0,0,0,0,0,128,0,-1--1--1,,1|(752,50)|
+1,38,35,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(807,46)|
+10,39,"Optimal output in 1980 Gu/y",791,-314,55,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,40,24,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(743,-279)|
+1,41,33,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(865,-230)|
+10,42,"Excess demand (1)",676,-453,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Output growth rate 1/y",1349,-446,40,28,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,44,"Output last year G$/y",1219,-445,47,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,45,44,43,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1264,-447)|
+1,46,39,53,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(909,-326)|
+10,47,"ED effect on flow to capacity addition (1)",401,-97,66,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"sEDeoFRA>0",324,-158,46,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,49,48,47,0,0,0,0,0,128,0,-1--1--1,,1|(352,-135)|
+10,50,"Extra mult on CUC, to avoid initial transient in Investment share of GDP",1244,9,92,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,51,50,22,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(1030,6)|
+10,52,"Excess demand in 1980 (1)",347,-224,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,53,"Optimal real output Gu/y",1026,-340,40,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,54,"Embedded TFP in 1980 (1)",1260,-261,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,55,Kappa,913,-264,23,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,56,Lambda,912,-318,27,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,57,55,53,0,0,0,0,0,128,0,-1--1--1,,1|(957,-294)|
+1,58,56,53,0,0,0,0,0,128,0,-1--1--1,,1|(955,-326)|
+1,59,55,56,0,0,0,0,0,128,0,-1--1--1,,1|(912,-284)|
+1,60,1,53,1,0,0,0,0,128,0,-1--1--1,,1|(1010,-165)|
+1,61,33,53,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(974,-242)|
+10,62,"Output growth in 1980 1/y (to avoid transient)",1300,-530,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,63,62,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1318,-498)|
+1,64,62,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1268,-497)|
+1,65,52,47,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(372,-166)|
+1,66,53,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1109,-385)|
+1,67,53,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1180,-390)|
+1,68,39,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1001,-377)|
+10,69,"Total savings G$/y",259,-357,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,70,"Perceived excess demand (1)",478,-243,40,42,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Time to observe excess demand y,560,-325,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,72,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(534,-299)|
+1,73,70,47,1,0,0,0,0,128,0,-1--1--1,,1|(435,-183)|
+1,74,70,26,1,0,0,0,0,128,0,-1--1--1,,1|(495,-150)|
+1,75,30,19,1,0,0,0,0,128,0,-1--1--1,,1|(775,156)|
+1,76,42,70,1,0,0,0,0,128,0,-1--1--1,,1|(562,-408)|
+1,77,52,26,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(446,-121)|
+10,78,"Fraction of available capital to new capacity (1)",570,255,49,39,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,79,"Foreign capital inflow G$/y",186,21,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,80,79,29,1,0,0,0,0,128,0,-1--1--1,,1|(265,46)|
+1,81,78,30,1,0,0,0,0,128,0,-1--1--1,,1|(633,200)|
+1,82,69,29,1,0,0,0,0,128,0,-1--1--1,,1|(218,-157)|
+10,83,"WSO effect on flow to capacity addition (1)",356,183,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,84,"sWSOeoFRA<0",320,248,54,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,83,0,0,0,0,0,128,0,-1--1--1,,1|(333,225)|
+10,86,"sCBCeoFRA<0",399,381,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,87,"CBC effect on flow to capacity addion (1)",426,321,71,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,88,86,87,0,0,0,0,0,128,0,-1--1--1,,1|(408,361)|
+10,89,"Corporate borrowing cost 1/y",214,347,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,90,89,87,0,0,0,0,0,128,0,-1--1--1,,1|(311,335)|
+1,91,83,78,1,0,0,0,0,128,0,-1--1--1,,1|(449,229)|
+1,92,87,78,1,0,0,0,0,128,0,-1--1--1,,1|(487,292)|
+10,93,"Corporate borrowing cost in 1980 1/y",210,277,73,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,94,93,87,0,0,0,0,0,128,0,-1--1--1,,1|(313,297)|
+10,95,"Total purchasing power G$/y",416,-351,54,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,96,95,42,1,0,0,0,0,128,0,-1--1--1,,1|(554,-439)|
+1,97,47,78,1,0,0,0,0,128,0,-1--1--1,,1|(388,33)|
+12,98,0,1452,322,321,289,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Output:_Long_term_growth
+10,99,"Govmnt investment in public capacity G$/y",1483,-172,73,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,100,99,151,1,0,0,0,0,128,0,-1--1--1,,1|(1610,-153)|
+10,101,"Optimal ouput - value G$/y",874,-441,51,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,102,53,101,1,0,0,0,0,128,0,-1--1--1,,1|(937,-414)|
+1,103,101,42,1,0,0,0,0,128,0,-1--1--1,,1|(778,-467)|
+10,104,"Deliveries Gu/y",486,-514,43,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,105,"National income G$/y",344,-452,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,106,"Output Gu/y",794,-558,47,21,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,107,"GDP G$/y",1662,-72,60,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,108,"Indicated TFP (1)",1500,-77,53,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,109,"Embedded TFP (1)",1261,-187,42,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,110,48,1265,-75,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,111,113,109,4,0,0,22,0,0,0,-1--1--1,,1|(1269,-140)|
+1,112,113,110,100,0,0,22,0,0,0,-1--1--1,,1|(1269,-95)|
+11,113,48,1269,-114,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,114,"Effect of capacity renewal 1/y",1333,-114,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,115,54,109,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1260,-234)|
+1,116,108,114,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1415,-86)|
+1,117,14,118,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1117,-45)|
+10,118,"Capacity renewal rate 1/y",1159,-86,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,119,1,118,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1104,-71)|
+1,120,118,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1230,-103)|
+1,121,109,114,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1347,-175)|
+1,122,109,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1123,-238)|
+10,123,"sOWeoCOC>0",1024,452,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,124,Time,1060,269,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,125,Observed warming deg C,948,360,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,126,"OWeoCOC (1)",1028,222,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,127,125,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(986,293)|
+1,128,123,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1025,343)|
+1,129,124,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1048,251)|
+1,130,126,173,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1024,202)|
+10,131,Investment planning time y,655,374,40,32,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,132,131,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(619,323)|
+10,133,"FRA in 1980 (1)",542,364,43,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,134,Capacity PUS Gcu,1775,-380,37,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,135,48,1611,-382,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,136,138,135,4,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(1647,-382)|
+1,137,138,134,100,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(1711,-382)|
+11,138,48,1679,-382,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,139,"Capacity discard PUS Gcu/y",1679,-355,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,140,Life of capacity PUS y,1574,-278,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,134,138,1,0,0,0,0,64,0,-1--1--1,,1|(1706,-402)|
+10,142,Capacity under construction PUS Gcu,1778,-212,56,35,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,143,145,134,4,0,0,22,0,0,0,-1--1--1,,1|(1771,-331)|
+1,144,145,142,100,0,0,22,0,0,0,-1--1--1,,1|(1771,-271)|
+11,145,13444,1771,-302,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,146,"Capacity addition PUS Gcu/y",1835,-302,56,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,147,48,1774,-82,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,150,142,4,0,0,22,0,0,0,-1--1--1,,1|(1771,-164)|
+1,149,150,147,100,0,0,22,0,0,0,-1--1--1,,1|(1771,-115)|
+11,150,48,1771,-146,8,6,33,3,0,0,2,0,0,0,0,0,0,0,0,0
+10,151,"Capacity initiation PUS Gcu/y",1706,-146,57,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,152,Construction time PUS y,1897,-397,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,153,142,146,0,0,0,0,0,64,0,-1--1--1,,1|(1807,-259)|
+10,154,CUC PUS in 1980 Gcu,1704,-286,44,19,8,131,0,16,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,155,152,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1806,-344)|
+1,156,154,142,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1728,-261)|
+10,157,CAP PUS in 1980 Gcu,1779,-448,42,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,158,157,134,0,0,0,0,0,64,1,-1--1--1,,1|(1777,-424)|
+10,159,Life of capacity PUS in 1980 y,1621,-211,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,160,157,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1744,-373)|
+1,161,159,140,0,0,0,0,0,128,0,-1--1--1,,1|(1601,-238)|
+1,162,159,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1656,-243)|
+1,163,134,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1144,-300)|
+1,164,50,154,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1474,-139)|
+1,165,157,53,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1408,-394)|
+1,166,157,39,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1298,-382)|
+10,167,"Embedded labour productivity in 1980 k$/p/y",1437,-368,64,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,168,39,167,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1102,-339)|
+10,169,"PCOR PUS cu/u/y",815,-216,60,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,170,169,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(805,-254)|
+10,171,"Jobs in 1980 M-ftj",1026,-302,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,172,"Jobs in 1980 M-ftj",1437,-321,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,173,"Cost of capacity $/cu",1016,161,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,174,173,19,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(945,148)|
+10,175,"Cost of capacity in 1980 $/cu",890,208,54,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,176,175,173,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(980,194)|
+10,177,"Jobs in 1980 M-ftj",1449,-476,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,178,177,167,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1444,-433)|
+10,179,"Off-balance-sheet govmnt inv in PUS (share of GDP)",1921,-69,85,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,180,179,151,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1820,-105)|
+10,181,"Off-balance sheet govmnt inv in PIS (share of GDP)",751,252,67,35,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,182,181,19,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(806,189)|
+10,183,"GDP G$/y",650,125,45,24,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,184,183,19,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(741,127)|
+1,185,107,151,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1677,-98)|
+1,186,173,151,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1354,10)|
+10,187,"Cost per unit in 1980 $/u",674,-409,49,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,188,"Price per unit $/u",817,-377,50,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,189,187,188,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(738,-395)|
+1,190,188,101,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(884,-387)|
+10,191,Capacity Gcu,1107,-186,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,192,1,191,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1018,-138)|
+1,193,134,191,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1447,-285)|
+10,194,"WSO in 1980 (1)",102,174,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,195,"Worker share of output (1)",121,114,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,196,194,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(214,177)|
+10,197,"Labour use Gph/y",1066,-552,41,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,198,"Labour use in 1980 Gph/y",1129,-499,48,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,199,197,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1047,-452)|
+1,200,198,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1081,-425)|
+10,201,"Wage share (1)",269,94,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,202,201,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(308,133)|
+10,203,"FRACA mult from GDPpp - Table (1)",669,512,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||0-255-0,0,0,0,0,0,0
+10,204,"FRACA mult from GDPpp - Line (1)",432,458,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,205,"sGDPppeoFRACA<0",211,473,72,9,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,206,GDP per person in 1980,309,558,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||160-160-160,0,0,0,0,0,0
+10,207,"GDP per person k$/p/y",445,593,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||192-192-192,0,0,0,0,0,0
+1,208,205,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(322,466)|
+1,209,206,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(366,512)|
+1,210,207,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(439,532)|
+1,211,204,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(489,372)|
+1,212,133,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(551,322)|
+10,213,FRACA min,269,406,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,214,213,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(332,425)|
+10,215,Observed warming in 2022 deg C,897,275,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,216,215,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(965,247)|
+10,217,Time,722,315,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,218,"Unconventional stimulus in PIS from 2022 (share of GDP)",813,401,67,67,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,219,217,181,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(727,301)|
+1,220,218,181,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(779,319)|
+10,221,"Unconventional stimulus in PUS from 2022 (share of GDP)",1940,-181,70,70,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,222,221,179,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1927,-106)|
+10,223,Time,1927,-16,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,224,223,179,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1925,-31)|
+10,225,"Investment share of GDP (1)",1608,-14,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,226,99,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1540,-98)|
+1,227,107,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1643,-52)|
+1,228,30,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1138,73)|
+10,229,"Shifts worked - index (1)",956,-505,55,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,230,"GDP G$/y",629,-557,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,231,"sOWeoLOC<0",728,-121,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,232,Time,573,-93,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,233,Observed warming deg C,630,-192,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,234,"OWeoLOC (1)",671,-54,50,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,235,233,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(649,-125)|
+1,236,231,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(704,-92)|
+1,237,232,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(614,-76)|
+10,238,Observed warming in 2022 deg C,570,-141,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,239,238,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(619,-98)|
+1,240,234,7,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(690,-30)|
+1,241,234,159,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1139,-130)|
+1,242,20,14,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1020,-65)|
+1,243,140,139,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1620,-312)|
+1,244,152,146,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1869,-355)|
+10,245,"Margin in 1980 (1)",675,-361,47,24,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,246,245,188,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(737,-367)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Demand
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Owner income G$/y",988,-138,47,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Worker income G$/y",550,-143,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,3,"Owner operating income after tax G$/y",1147,134,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Worker income after tax G$/y",474,159,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,"Income tax owners (1)",906,-376,36,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,6,"Income tax workers (1)",614,-373,39,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,7,"Govmnt net income G$/y",864,137,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,8,6,32,0,0,0,0,0,128,0,-1--1--1,,1|(574,-301)|
+1,9,5,31,0,0,0,0,0,128,0,-1--1--1,,1|(918,-302)|
+1,10,2,4,1,0,0,0,0,128,0,-1--1--1,,1|(479,3)|
+1,11,1,3,1,0,0,0,0,128,0,-1--1--1,,1|(1066,-37)|
+10,12,"Worker cash inflow G$/y",456,616,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,13,"Owner cash inflow G$/y",1294,530,39,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Govmnt cash inflow G$/y",821,643,42,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,15,3,13,1,0,0,0,0,128,0,-1--1--1,,1|(1306,345)|
+10,16,"Owner savings fraction (1)",1397,652,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,17,"Worker savings G$/y",551,845,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,18,"Owner savings G$/y",1245,882,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,19,"Govmnt purchases G$/y",808,820,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,20,"Total savings G$/y",1154,1009,53,18,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,18,20,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1210,953)|
+1,22,16,122,0,0,0,0,0,128,0,-1--1--1,,1|(1360,677)|
+10,23,"Effective GDP per person k$/p/y",1574,604,79,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,24,23,16,0,0,0,0,0,128,0,-1--1--1,,1|(1476,630)|
+10,25,Owner savings fraction in 1980,1475,716,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,26,"sGDPeoOSR<0",1455,558,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,27,25,16,0,0,0,0,0,128,0,-1--1--1,,1|(1441,688)|
+1,28,26,16,0,0,0,0,0,128,0,-1--1--1,,1|(1432,595)|
+10,29,"GDP per person in 1980 k$/p/y",1572,658,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,30,29,16,0,0,0,0,0,128,0,-1--1--1,,1|(1486,655)|
+10,31,"Owner taxes G$/y",933,-221,58,11,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,32,"Worker taxes G$/y",528,-215,44,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,33,31,3,1,0,0,0,0,128,0,-1--1--1,,1|(1061,-98)|
+1,34,32,4,1,0,0,0,0,128,0,-1--1--1,,1|(414,-105)|
+1,35,31,104,1,0,0,0,0,128,0,-1--1--1,,1|(859,-101)|
+1,36,32,104,1,0,0,0,0,128,0,-1--1--1,,1|(633,-169)|
+10,37,"Worker consumption demand G$/y",411,785,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,38,"Owner consumption G$/y",1159,815,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,39,13,134,1,0,0,0,0,128,0,-1--1--1,,1|(1179,635)|
+10,40,"Consumption demand G$/y",391,1003,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,41,Max govmnt debt burden y,628,210,44,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,42,Max workers debt burden y,453,228,56,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,Max govmnt debt G$,634,264,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,44,Govmnt debt G$,801,395,41,38,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,45,48,647,381,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,46,48,44,4,0,0,22,0,0,0,-1--1--1,,1|(741,377)|
+1,47,48,45,100,0,0,22,0,0,0,-1--1--1,,1|(684,377)|
+11,48,48,717,377,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,49,"Govmnt new debt G$/y",717,415,39,30,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,50,48,948,414,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,51,53,50,4,0,0,22,0,0,0,-1--1--1,,1|(923,414)|
+1,52,53,44,100,0,0,22,0,0,0,-1--1--1,,1|(869,414)|
+11,53,48,902,414,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,54,"Govmnt payback G$/y",902,446,49,24,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,55,41,43,1,0,0,0,0,128,0,-1--1--1,,1|(640,249)|
+1,56,44,54,1,0,0,0,0,128,0,-1--1--1,,1|(860,380)|
+10,57,Govmnt payback period y,898,322,55,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,58,Govmnt drawdown period y,642,322,54,40,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,59,57,53,0,0,0,0,0,128,0,-1--1--1,,1|(899,367)|
+10,60,"Cash flow from govmnt to banks G$/y",823,544,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,61,49,60,1,0,0,0,0,128,0,-1--1--1,,1|(733,497)|
+1,62,54,60,1,0,0,0,0,128,0,-1--1--1,,1|(893,509)|
+1,63,7,14,1,0,0,0,0,128,0,-1--1--1,,1|(1070,406)|
+1,64,60,14,1,0,0,0,0,128,0,-1--1--1,,1|(860,609)|
+10,65,"Govmnt interest cost G$/y",797,479,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,66,44,65,0,0,0,0,0,128,0,-1--1--1,,1|(799,439)|
+1,67,65,60,0,0,0,0,0,128,0,-1--1--1,,1|(806,505)|
+10,68,Govmnt debt in 1980 G$,810,292,49,19,8,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,69,68,44,0,0,0,0,0,64,1,-1--1--1,,1|(807,327)|
+10,70,Max workers debt G$,339,273,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Workers debt G$,411,386,41,37,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,72,48,266,369,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,73,75,71,4,0,0,22,0,0,0,-1--1--1,,1|(353,370)|
+1,74,75,72,100,0,0,22,0,0,0,-1--1--1,,1|(300,370)|
+11,75,48,330,370,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,76,"Workers new debt G$/y",330,405,44,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,77,48,558,368,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,78,80,77,4,0,0,22,0,0,0,-1--1--1,,1|(532,375)|
+1,79,80,71,100,0,0,22,0,0,0,-1--1--1,,1|(478,375)|
+11,80,48,510,375,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,81,"Workers payback G$/y",510,413,52,30,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,82,70,75,1,0,0,0,0,128,0,-1--1--1,,1|(316,325)|
+1,83,71,75,1,0,0,0,0,128,0,-1--1--1,,1|(382,336)|
+1,84,71,81,1,0,0,0,0,128,0,-1--1--1,,1|(493,319)|
+10,85,Workers payback period y,533,312,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,86,Workers drawdown period y,238,327,54,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,87,86,75,0,0,0,0,0,128,0,-1--1--1,,1|(301,356)|
+1,88,85,80,0,0,0,0,0,128,0,-1--1--1,,1|(522,343)|
+10,89,"Cash flow from workers to banks G$/y",434,536,74,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,90,76,89,1,0,0,0,0,128,0,-1--1--1,,1|(345,489)|
+1,91,81,89,1,0,0,0,0,128,0,-1--1--1,,1|(514,491)|
+10,92,"Worker interest cost G$/y",410,464,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,93,71,92,0,0,0,0,0,128,0,-1--1--1,,1|(410,427)|
+1,94,92,89,0,0,0,0,0,128,0,-1--1--1,,1|(419,493)|
+10,95,Workers debt in 1980 G$,425,297,53,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,96,95,71,0,0,0,0,0,64,1,-1--1--1,,1|(420,325)|
+1,97,42,70,1,0,0,0,0,128,0,-1--1--1,,1|(399,233)|
+1,98,89,12,1,0,0,0,0,128,0,-1--1--1,,1|(474,592)|
+1,99,4,12,1,0,0,0,0,128,0,-1--1--1,,1|(594,404)|
+1,100,17,20,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(844,924)|
+1,101,12,126,0,0,0,0,0,128,0,-1--1--1,,1|(444,648)|
+10,102,"Transfer payments G$/y",673,92,46,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,103,"Extra transfer of govmnt budget to workers (1)",96,24,60,60,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"Govmnt gross income G$/y",804,38,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,105,104,7,0,0,0,0,0,128,0,-1--1--1,,1|(829,81)|
+1,106,104,102,0,0,0,0,0,128,0,-1--1--1,,1|(745,61)|
+1,107,102,7,0,0,0,0,0,128,0,-1--1--1,,1|(764,112)|
+1,108,102,4,0,0,0,0,0,128,0,-1--1--1,,1|(582,122)|
+1,109,60,155,1,0,0,0,0,128,0,-1--1--1,,1|(975,561)|
+1,110,89,155,1,0,0,0,0,128,0,-1--1--1,,1|(724,598)|
+10,111,"Worker consumption fraction (1)",287,731,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,112,37,17,0,0,0,0,0,128,0,-1--1--1,,1|(474,812)|
+1,113,111,37,0,0,0,0,0,128,0,-1--1--1,,1|(342,755)|
+10,114,"Government consumption fraction (1)",667,737,66,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,114,19,0,0,0,0,0,128,0,-1--1--1,,1|(738,778)|
+10,116,"Govmnt investment in public capacity G$/y",988,887,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,117,38,18,1,0,0,0,0,128,0,-1--1--1,,1|(1199,834)|
+1,118,19,116,0,0,0,0,0,128,0,-1--1--1,,1|(890,850)|
+1,119,37,40,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(395,845)|
+1,120,38,40,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(774,908)|
+10,121,"Govmnt spending G$/y",801,1006,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,122,"Owner consumptin fraction (1)",1312,710,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,123,"Sales tax rate (1)",240,804,40,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,"Sales tax workers G$/y",285,874,53,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,125,Time to adjust worker consumption y,330,627,59,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,126,"Permanent worker cash inflow G$/y",425,706,46,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,127,125,126,0,0,0,0,0,128,0,-1--1--1,,1|(367,658)|
+10,128,"Permanent govmnt cash inflow G$/y",820,716,55,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,129,126,37,0,0,0,0,0,128,0,-1--1--1,,1|(418,744)|
+1,130,37,124,0,0,0,0,0,128,0,-1--1--1,,1|(361,820)|
+1,131,123,124,0,0,0,0,0,128,0,-1--1--1,,1|(257,831)|
+10,132,"Sales tax owners G$/y",417,875,46,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,133,38,132,0,0,0,0,0,128,0,-1--1--1,,1|(788,844)|
+10,134,"Permanent owner cash inflow G$/y",1187,717,40,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,135,134,38,0,0,0,0,0,128,0,-1--1--1,,1|(1174,762)|
+10,136,"Sales tax owners G$/y",947,-82,50,26,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,137,"Sales tax workers G$/y",665,-74,49,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,138,137,104,0,0,0,0,0,128,0,-1--1--1,,1|(728,-23)|
+1,139,136,104,0,0,0,0,0,128,0,-1--1--1,,1|(876,-23)|
+10,140,Time to adjust budget y,676,646,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,14,128,0,0,0,0,0,128,0,-1--1--1,,1|(820,666)|
+1,142,128,19,0,0,0,0,0,128,0,-1--1--1,,1|(814,767)|
+1,143,19,121,0,0,0,0,0,128,0,-1--1--1,,1|(804,906)|
+1,144,116,121,0,0,0,0,0,128,0,-1--1--1,,1|(900,942)|
+1,145,140,128,0,0,0,0,0,128,0,-1--1--1,,1|(733,673)|
+10,146,Time to adjust owner consumption y,1092,649,52,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,147,146,134,0,0,0,0,0,128,0,-1--1--1,,1|(1132,678)|
+1,148,126,17,0,0,0,0,0,128,0,-1--1--1,,1|(488,776)|
+1,149,128,116,0,0,0,0,0,128,0,-1--1--1,,1|(904,802)|
+1,150,134,18,1,0,0,0,0,128,0,-1--1--1,,1|(1259,821)|
+1,151,2,70,1,0,0,0,0,128,0,-1--1--1,,1|(390,60)|
+1,152,124,40,0,0,0,0,0,128,0,-1--1--1,,1|(337,938)|
+1,153,132,40,0,0,0,0,0,128,0,-1--1--1,,1|(404,935)|
+1,154,123,132,0,0,0,0,0,128,0,-1--1--1,,1|(318,835)|
+10,155,"Bank cash inflow from lending G$/y",1112,549,57,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,156,"Worker finance cost as share of income (1)",123,285,81,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,157,89,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(283,414)|
+10,158,"Govmnt finance as share of NI (1)",1169,363,66,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,159,"Consumption share of GDP (1)",235,1005,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,160,40,159,0,0,0,0,0,128,0,-1--1--1,,1|(328,1003)|
+1,161,65,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(970,425)|
+1,162,54,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1022,408)|
+10,163,"Savings share of GDP (1)",984,1005,52,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,164,20,163,0,0,0,0,0,128,0,-1--1--1,,1|(1075,1007)|
+10,165,"Control: (C+G+S)/NI = 1",194,1079,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,166,159,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(218,1035)|
+1,167,14,186,1,0,0,0,0,128,0,-1--1--1,,1|(1066,618)|
+1,168,13,186,0,0,0,0,0,128,0,-1--1--1,,1|(1311,555)|
+10,169,"Worker borrowing cost 1/y",254,517,42,40,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,170,"Govmnt borrowing cost 1/y",652,525,47,40,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,171,169,92,0,0,0,0,0,128,0,-1--1--1,,1|(321,493)|
+1,172,170,65,0,0,0,0,0,128,0,-1--1--1,,1|(716,504)|
+10,173,Mult to avoid transient in worker finance,124,151,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,174,173,95,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(267,220)|
+10,175,Mult to avoid transient in govmnt finance,1140,213,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,176,175,68,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(970,252)|
+10,177,"National income G$/y",760,-319,55,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,178,Worker debt burden y,107,223,45,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,179,71,178,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(262,306)|
+10,180,Govmnt debt burden y,1144,282,46,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,181,44,180,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(963,341)|
+10,182,"National income G$/y",232,946,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,183,182,159,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(232,968)|
+1,184,182,163,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(603,974)|
+1,185,163,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(597,1040)|
+10,186,"Total purchasing power G$/y",1339,592,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,187,"Sales tax G$/y",566,922,46,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,188,124,187,1,0,0,0,0,128,0,-1--1--1,,1|(417,912)|
+1,189,132,187,0,0,0,0,0,128,0,-1--1--1,,1|(490,897)|
+1,190,187,186,0,0,0,0,0,128,0,-1--1--1,,1|(936,763)|
+1,191,4,178,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(294,189)|
+1,192,4,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(306,218)|
+10,193,"National income G$/y",871,194,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,194,193,180,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1006,237)|
+1,195,193,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1013,275)|
+10,196,"Bank cash inflow as share of NI (1)",1169,483,70,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,197,155,196,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1135,521)|
+1,198,12,186,1,0,0,0,0,128,0,-1--1--1,,1|(883,604)|
+10,199,WFI in 1980,516,690,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,200,GCI in 1980,937,697,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,201,OCI in 1980,1068,744,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,202,199,126,1,0,0,0,0,128,0,-1--1--1,,1|(500,712)|
+1,203,200,128,1,0,0,0,0,128,0,-1--1--1,,1|(911,720)|
+1,204,201,134,1,0,0,0,0,128,0,-1--1--1,,1|(1100,707)|
+1,205,122,38,0,0,0,0,0,128,0,-1--1--1,,1|(1241,758)|
+10,206,"Consumption per person G$/y",790,1085,60,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,207,40,206,0,0,0,0,0,128,0,-1--1--1,,1|(575,1040)|
+10,208,Population Mp,559,1112,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,209,208,206,0,0,0,0,0,128,0,-1--1--1,,1|(665,1099)|
+12,210,2361004,1547,1026,280,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Distribution_of_national_income
+10,211,"Govmnt share of GDP (1)",584,1003,53,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,212,121,211,0,0,0,0,0,128,0,-1--1--1,,1|(697,1004)|
+1,213,182,211,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(403,973)|
+1,214,211,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(397,1039)|
+10,215,"Fraction of extra taxes paid by owners (1)",299,-244,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,216,187,7,0,1,0,0,0,64,0,-1--1--1,,1|(710,540)|
+10,217,"Income tax rate owners in 1980 (1)",966,-499,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,218,"Extra general tax rate from 2022 (1)",67,-498,52,52,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,219,Time,149,-416,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,220,"Basic income tax rate workers (1)",558,-502,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,221,220,6,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(582,-444)|
+10,222,"Extra general tax from 2022 G$/y",291,-442,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,223,"Govmnt net income as share of NI (1)",990,38,68,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,224,7,223,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(921,91)|
+10,225,"INEQUALITY INDEX (1980=1)",1259,-68,60,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,226,4,240,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(813,66)|
+1,227,3,240,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1152,55)|
+10,228,"Govmnt stimulus from 2022 (share of NI)",712,164,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,229,228,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(713,270)|
+10,230,"Worker share of output (1)",774,-497,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,231,44,49,1,0,0,0,0,64,0,-1--1--1,,1|(761,453)|
+1,232,58,49,0,0,0,0,0,64,0,-1--1--1,,1|(678,367)|
+1,233,43,49,0,0,0,0,0,64,0,-1--1--1,,1|(668,327)|
+10,234,Workforce Mp,142,760,58,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,235,"Worker disposable income k$/p/y",153,644,67,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,236,126,235,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(306,679)|
+1,237,234,235,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(146,712)|
+10,238,"Inequality in 1980 (1)",1243,17,39,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,239,238,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1249,-19)|
+10,240,"Inequality (1)",1159,-28,42,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,241,240,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1192,-42)|
+10,242,"Income from commons from 2022 G$/y",1158,-174,73,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,243,242,104,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(987,-72)|
+10,244,Time,1275,-200,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,245,48,1053,373,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,246,248,245,4,0,0,22,0,0,0,-1--1--1,,1|(1028,373)|
+1,247,248,44,100,0,0,22,0,0,0,-1--1--1,,1|(921,373)|
+11,248,48,1007,373,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,249,"Cancellation of debt G$/y",1007,400,48,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,250,44,249,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(895,347)|
+10,251,"Fraction of govmnt debt cancelled in 2022 1/y",1400,274,64,64,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,252,251,249,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1204,336)|
+1,253,218,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(170,-473)|
+1,254,219,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(199,-426)|
+1,255,244,242,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1246,-195)|
+10,256,"Goal for extra income from commons (share of NI)",1181,-285,61,61,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,257,256,242,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1166,-217)|
+12,258,0,1599,-236,272,250,3,156,0,0,1,0,0,0,0,0,0,0,0,0
+Income_inequity
+10,259,"Basic income tax rate owners (1)",1027,-424,68,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,260,"Income tax rate owners in 2022 (1)",1153,-489,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,261,217,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(991,-467)|
+1,262,260,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1096,-460)|
+1,263,259,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(967,-401)|
+1,264,193,196,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1014,333)|
+1,265,193,223,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(925,121)|
+1,266,193,43,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(751,228)|
+1,267,193,48,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(792,287)|
+10,268,"Extra taxes for TAs from 2022 G$/y",270,-373,62,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,269,"Fraction of extra TA cost paid by extra taxes (1)",84,-302,81,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,270,269,268,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(169,-336)|
+10,271,"Goal for extra taxes from 2022 G$/y",430,-366,63,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,272,222,271,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(353,-408)|
+1,273,215,32,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(413,-230)|
+1,274,215,31,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(608,-234)|
+10,275,"Goal for income tax rate owners (1)",1224,-419,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,276,275,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1134,-422)|
+1,277,177,6,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(685,-347)|
+1,278,177,5,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(836,-349)|
+1,279,230,6,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(699,-440)|
+1,280,230,5,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(834,-442)|
+1,281,177,1,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,-229)|
+1,282,177,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(655,-232)|
+1,283,230,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(649,-327)|
+1,284,230,1,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(890,-324)|
+1,285,177,222,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(531,-379)|
+10,286,Time,262,-312,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,287,286,268,0,0,0,0,0,64,0,-1--1--1,,1|(264,-332)|
+10,288,"Cost of TAs G$/y",262,-312,45,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,289,"Extra cost of TAs from 2022 G$/y",85,-375,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,290,289,268,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(170,-375)|
+1,291,268,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(342,-371)|
+10,292,"Extra empowerment tax from 2022 (share of NI)",365,-521,55,55,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,293,"Extra pension tax from 2022 (share of NI)",226,-533,56,56,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,294,293,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(263,-481)|
+1,295,292,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(322,-476)|
+10,296,"Owner tax rate (1)",766,-161,59,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,297,31,296,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(856,-194)|
+10,298,"Worker tax rate (1)",302,-153,52,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,299,32,298,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(425,-188)|
+1,300,2,298,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(433,-148)|
+1,301,1,296,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(889,-148)|
+1,302,177,242,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(952,-249)|
+10,303,"Fraction transferred in 1980 (1)",222,-46,63,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,304,"Goal for fraction of govmnt budget to workers (1)",278,17,61,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,305,103,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(179,20)|
+1,306,303,304,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(240,-25)|
+10,307,Time,269,75,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,308,307,304,0,0,0,0,3,64,0,255-0-255,|12||0-0-0,1|(270,61)|
+10,309,Introduction period for policy y,1221,-117,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,310,309,242,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1194,-141)|
+10,311,"Govmnt gross income (as share of NI)",592,-15,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,312,177,311,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(677,-170)|
+1,313,104,311,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(716,16)|
+10,314,Time to implement new taxes y,128,-194,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,315,"Fraction of govmnt budget to workers (1)",325,-95,52,32,3,131,0,3,0,0,0,0,0-0-128,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,316,"Extra taxes from 2022 G$/y",440,-296,50,29,3,131,0,3,0,0,0,0,0-0-128,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,317,314,316,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(281,-245)|
+1,318,314,315,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(212,-152)|
+1,319,304,315,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(297,-31)|
+1,320,315,102,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(495,-4)|
+1,321,271,316,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(432,-343)|
+1,322,316,32,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(483,-256)|
+1,323,316,31,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(675,-261)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Inventory
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Inventory Gu,709,284,47,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,1011,290,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,1,4,0,0,22,0,0,0,-1--1--1,,1|(814,292)|
+1,4,5,2,100,0,0,22,0,0,0,-1--1--1,,1|(943,292)|
+11,5,48,879,292,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"Output Gu/y",879,311,40,11,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,7,48,350,290,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,8,10,7,4,0,0,22,0,0,0,-1--1--1,,1|(419,289)|
+1,9,10,1,100,0,0,22,0,0,0,-1--1--1,,1|(576,289)|
+11,10,48,484,289,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,11,"Deliveries Gu/y",484,308,48,11,40,131,0,2,-1,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,12,"Recent sales Gu/y",572,370,42,31,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,13,Sales averaging time y,487,448,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,14,11,12,1,0,0,0,2,64,0,-1--1--1,|12||0-0-0,1|(541,332)|
+1,15,13,12,0,0,0,0,0,64,0,-1--1--1,,1|(517,419)|
+10,16,Inventory coverage y,676,440,35,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,17,Desired inventory coverage y,737,535,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,1,16,1,0,0,0,0,64,0,-1--1--1,,1|(699,363)|
+10,19,"Effective purchasing power G$/y",551,228,44,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,20,"Inflation rate 1/y",877,743,51,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,21,Inventory coverage perception time y,568,550,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,22,"Perceived relative inventory (1)",611,660,59,35,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,23,16,22,1,0,0,0,0,128,0,-1--1--1,,1|(662,506)|
+1,24,21,22,0,0,0,0,0,128,0,-1--1--1,,1|(583,590)|
+10,25,"sINVeoIN<0",792,781,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,26,25,20,0,0,0,0,0,128,0,-1--1--1,,1|(827,764)|
+1,27,22,20,1,0,0,0,0,128,0,-1--1--1,,1|(682,692)|
+10,28,"Price Index (1980=1)",1053,692,40,20,3,3,0,0,0,0,0,0,0,0,0,0,0,0
+12,29,48,1048,788,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,30,32,28,4,0,0,22,0,0,0,-1--1--1,,1|(1053,728)|
+1,31,32,29,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1053,768)|
+11,32,48,1053,751,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,33,"Change in Price Index 1/y",1111,751,50,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,28,33,1,0,0,0,0,128,0,-1--1--1,,1|(1118,696)|
+1,35,17,41,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(780,448)|
+10,36,"Demand pulse 2020-25 (1)",457,161,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,37,36,19,0,0,0,0,3,128,0,160-160-160,|12||0-0-0,1|(491,185)|
+10,38,"Demand in 1980 G$/y",776,206,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,39,38,19,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(665,216)|
+10,40,"SWI in 1980 (1)",913,408,53,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,41,INV in 1980 Gu,788,360,52,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,42,41,1,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(764,337)|
+1,43,19,11,0,0,0,0,0,128,0,-1--1--1,,1|(515,271)|
+10,44,"National income G$/y",223,269,57,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,45,Demand adjustment time y,615,141,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,46,45,19,0,0,0,0,0,128,0,-1--1--1,,1|(590,174)|
+1,47,38,12,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(686,277)|
+10,48,"Normal (1)",253,83,36,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,"STD in fluctuation around normal (1)",218,189,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,50,Sampling time y,219,128,50,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,51,"Pink noise in sales (1)",357,178,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,52,48,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(295,121)|
+1,53,49,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(289,183)|
+1,54,50,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(275,148)|
+1,55,51,11,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(457,243)|
+1,56,40,41,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(857,386)|
+10,57,Time,479,355,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,58,57,11,0,0,0,0,0,64,0,-1--1--1,,1|(480,338)|
+10,59,DDI in 1980 y,386,393,39,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,60,40,38,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(850,316)|
+1,61,40,6,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(898,366)|
+1,62,17,22,0,0,0,0,0,128,0,-1--1--1,,1|(686,584)|
+1,63,20,33,1,0,0,0,0,128,0,-1--1--1,,1|(958,749)|
+10,64,"Minimum relative inventory without inflation (1)",632,741,68,31,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,65,64,20,0,0,0,0,0,128,0,-1--1--1,,1|(756,741)|
+10,66,"Optimal real output Gu/y",1064,348,57,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,67,66,6,1,0,0,0,0,128,0,-1--1--1,,1|(987,321)|
+10,68,"Desired shifts worked - index (1)",943,601,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,69,"sINVeoSWI<0",888,650,50,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,70,"Shifts worked - index (1)",1017,469,48,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Time to adjust shifts y,1051,557,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,72,22,68,1,0,0,0,0,128,0,-1--1--1,,1|(761,641)|
+10,73,"Desired relative inventory (1)",868,545,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,74,73,68,0,0,0,0,0,128,0,-1--1--1,,1|(899,568)|
+1,75,69,68,0,0,0,0,0,128,0,-1--1--1,,1|(905,634)|
+1,76,68,70,1,0,0,0,0,128,0,-1--1--1,,1|(1007,530)|
+1,77,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(1038,523)|
+1,78,70,6,1,0,0,0,0,128,0,-1--1--1,,1|(974,385)|
+10,79,"ROC in DDI 1/y",292,559,53,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,80,"sINVeoDDI<0",340,624,49,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,81,"Delivery delay - index (1)",264,409,52,33,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,82,48,258,520,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,83,85,81,4,0,0,22,0,0,0,-1--1--1,,1|(262,456)|
+1,84,85,82,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(262,497)|
+11,85,48,262,476,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,86,"Change in DDI 1/y",315,476,45,28,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,87,81,86,1,0,0,0,0,128,0,-1--1--1,,1|(327,419)|
+10,88,"Sufficient relative inventory (1)",434,543,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,22,79,1,0,0,0,0,128,0,-1--1--1,,1|(381,608)|
+1,90,80,79,0,0,0,0,0,128,0,-1--1--1,,1|(320,597)|
+1,91,88,79,0,0,0,0,0,128,0,-1--1--1,,1|(369,550)|
+1,92,79,86,1,0,0,0,0,128,0,-1--1--1,,1|(304,511)|
+1,93,59,11,0,0,0,0,0,128,0,-1--1--1,,1|(435,349)|
+10,94,"Total purchasing power G$/y",431,42,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,95,94,19,1,0,0,0,0,128,0,-1--1--1,,1|(517,88)|
+10,96,"Optimal output in 1980 Gu/y",844,493,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,97,96,38,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(811,356)|
+1,98,96,41,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(816,428)|
+12,99,0,1397,402,222,246,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Inventory:_4-year_cycle
+10,100,"Pulse height (1)",396,111,49,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,101,100,36,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(415,127)|
+1,102,10,113,1,0,0,0,0,128,0,-1--1--1,,1|(441,259)|
+1,103,81,11,1,0,0,0,0,128,0,-1--1--1,,1|(361,339)|
+10,104,"GDP G$/y",904,166,37,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,105,"Price Index in 1980 (=1)",1060,635,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,106,105,28,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1057,656)|
+10,107,"Price per unit $/u",736,96,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,108,107,11,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(610,201)|
+1,109,107,38,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(753,144)|
+1,110,5,104,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(861,239)|
+1,111,107,104,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(822,132)|
+1,112,12,16,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(624,405)|
+10,113,"Sales G$/y",347,237,31,21,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,114,113,44,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(263,234)|
+1,115,107,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(540,166)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Finance
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Finance sector response time y,624,388,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"Perceived inflation CB 1/y",693,-70,47,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,"Indicated signal rate 1/y",470,61,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Central bank signal rate 1/y",509,252,43,39,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,5,48,502,136,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,6,8,4,4,0,0,22,0,0,0,-1--1--1,,1|(500,199)|
+1,7,8,5,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(500,159)|
+11,8,48,500,180,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,9,"Change in signal rate 1/yy",560,180,52,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,10,4,9,1,0,0,0,0,128,0,-1--1--1,,1|(582,225)|
+10,11,"3m interest rate 1/y",507,348,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,12,"Cost of capital for secured debt 1/y",506,468,55,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,13,"Normal basic bank margin 1/y",331,306,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Normal bank operating margin 1/y",332,395,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,15,4,11,0,0,0,0,0,128,0,-1--1--1,,1|(508,303)|
+1,16,11,12,0,0,0,0,0,128,0,-1--1--1,,1|(506,393)|
+1,17,13,11,0,0,0,0,0,128,0,-1--1--1,,1|(418,326)|
+1,18,14,12,0,0,0,0,0,128,0,-1--1--1,,1|(407,426)|
+1,19,12,43,1,0,0,0,0,128,0,-1--1--1,,1|(533,502)|
+10,20,"sUNeoSR<0",325,19,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,20,3,0,0,0,0,0,128,0,-1--1--1,,1|(384,36)|
+1,22,1,12,0,0,0,0,0,128,0,-1--1--1,,1|(581,416)|
+1,23,3,9,1,0,0,0,0,128,0,-1--1--1,,1|(451,164)|
+10,24,"sINeoSR>0",607,48,39,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,2,3,1,0,0,0,0,128,0,-1--1--1,,1|(570,-46)|
+1,26,24,3,0,0,0,0,0,128,0,-1--1--1,,1|(550,52)|
+10,27,Inflation perception time CB y,727,-150,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,2,0,0,0,0,0,128,0,-1--1--1,,1|(714,-122)|
+10,29,"Normal signal rate 1/y",342,93,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,29,3,0,0,0,0,0,128,0,-1--1--1,,1|(396,79)|
+10,31,Signal rate adjustment time y,608,116,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,32,31,9,0,0,0,0,0,128,0,-1--1--1,,1|(588,142)|
+10,33,"Inflation in 1980 (1/y)",834,-66,52,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,34,33,2,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(767,-68)|
+10,35,"Inflation target 1/y",608,-1,44,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,36,"Unemployment target (1)",321,-46,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,37,36,3,0,0,0,0,0,128,0,-1--1--1,,1|(389,3)|
+10,38,"Perceived unemployment CB (1)",462,-64,64,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,39,Unemployment perception time CB y,396,-157,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,40,39,38,0,0,0,0,0,128,0,-1--1--1,,1|(420,-122)|
+10,41,"Govmnt borrowing cost 1/y",762,354,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,42,"Worker borrowing cost 1/y",736,494,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Corporate borrowing cost 1/y",605,581,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,11,41,0,0,0,0,0,128,0,-1--1--1,,1|(622,350)|
+10,45,"Normal corporate credit risk 1/y",371,530,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,46,12,42,0,0,0,0,0,128,0,-1--1--1,,1|(611,479)|
+1,47,45,43,0,0,0,0,0,128,0,-1--1--1,,1|(480,553)|
+10,48,"Inflation rate 1/y",868,-147,43,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,49,48,2,0,0,0,0,0,128,0,-1--1--1,,1|(788,-113)|
+10,50,"Corporate borrowing cost in 1980 1/y",190,461,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,51,45,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(287,497)|
+12,52,0,1306,160,344,300,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Finance:_Interest_rates
+10,53,"10-yr govmnt interest rate 1/y",791,210,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,54,29,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(268,270)|
+1,55,13,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(265,378)|
+1,56,14,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(267,425)|
+10,57,"Expected long term inflation 1/y",800,68,51,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,58,Inflation expectation formation time y,866,-14,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,59,58,57,0,0,0,0,0,128,0,-1--1--1,,1|(842,15)|
+1,60,33,57,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(820,-13)|
+1,61,2,57,1,0,0,0,0,128,0,-1--1--1,,1|(726,7)|
+1,62,41,53,0,0,0,0,0,128,0,-1--1--1,,1|(774,288)|
+10,63,"Output growth rate 1/y",295,596,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,64,63,45,1,0,0,0,0,128,0,-1--1--1,,1|(357,558)|
+10,65,"sGReoCR<0",182,534,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,66,65,45,0,0,0,0,0,128,0,-1--1--1,,1|(261,532)|
+1,67,29,4,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(409,157)|
+10,68,"Unemployment rate (1)",600,-199,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,69,68,38,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(541,-142)|
+1,70,38,3,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(438,-9)|
+1,71,35,3,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(534,14)|
+1,72,57,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(795,138)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Public sector
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Public services per person k$/p/y",796,160,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Population Mp,670,105,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,3,2,1,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(717,125)|
+10,4,"Govmnt purchases G$/y",73,190,55,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,5,"Productivity of public purchases (1)",420,233,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Infrastructure purchases ratio y,240,307,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,7,4,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(140,277)|
+1,8,6,5,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(322,284)|
+10,9,"Value of public services supplied G$/y",582,152,62,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,10,4,9,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(375,150)|
+1,11,5,9,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(501,199)|
+10,12,"GDP G$/y",622,235,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,13,"State capacity (fraction of GDP)",752,239,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,14,9,13,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(672,191)|
+1,15,12,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(674,236)|
+1,16,9,1,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(682,155)|
+10,17,"TFP excluding effect of 5TAs (1)",1157,408,44,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,18,48,1006,408,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,19,21,17,4,0,0,22,0,0,0,-1--1--1,,1|(1088,407)|
+1,20,21,18,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1034,407)|
+11,21,48,1058,407,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,22,"Change in TFP 1/y",1058,446,38,31,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,17,22,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1107,467)|
+10,24,"TFP in 1980 (1)",1257,409,38,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,25,"Reduction in TFP from unprofitable activity (1)",949,648,62,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,26,"TFP including effect of 5TAs (1)",1158,594,64,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,"Indicated TFP (1)",939,569,50,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,28,26,27,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1048,581)|
+10,29,Infrastructure purchases ratio in 1980 y,254,226,56,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,29,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(323,228)|
+10,31,"sIPReoVPSS>0",414,312,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,32,31,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(415,283)|
+1,33,24,17,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1216,408)|
+12,34,0,946,55,199,54,8,135,0,11,-1,0,0,0,0-0-255,0-0-0,|18||0-0-255,0,0,0,0,0,0
+ROTA = Rate of technological advance TFP = Total Factor productivity 1          ROC = Rate of change 1/y                    5TAs = 5 Turnarounds
+10,35,"State capacity in 1980 (fraction of GDP)",707,320,57,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,36,13,40,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(801,288)|
+1,37,35,40,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(775,334)|
+10,38,"Rate of technological advance 1/y",914,449,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,39,"Domestic ROTA in 1980 1/y",881,268,59,20,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,40,"Domestic rate of technological advance 1/y",870,357,70,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,41,40,38,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(890,401)|
+1,42,39,40,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,301)|
+10,43,"sSCeoROTA>0",713,385,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,43,40,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(775,373)|
+1,45,38,22,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(999,493)|
+1,46,17,26,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1157,502)|
+10,47,"Govmnt spending G$/y",76,68,60,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,48,Investment planning time y,873,711,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||160-160-160,0,0,0,0,0,0
+10,49,Construction time PIS y,1021,724,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,50,48,25,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(894,692)|
+1,51,49,25,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(997,699)|
+10,52,"National income G$/y",804,571,57,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,53,Capacity PUS Gcu,78,358,51,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,54,53,6,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(150,335)|
+10,55,"Reduction in ROTA from inequality 1/y",604,461,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,56,"sIIEeoROTA<0",392,393,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,57,"INEQUALITY INDEX (1980=1)",365,456,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,58,57,55,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(480,457)|
+1,59,56,55,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(478,420)|
+1,60,55,38,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(750,455)|
+10,61,"Imported ROTA 1/y",1042,304,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,62,"Max imported ROTA from 2022 1/y",1085,164,56,56,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,63,"GDPpp of technology leader k$/p/y",1301,262,70,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,64,"GDP per person k$/p/y",1211,195,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,65,62,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1060,244)|
+1,66,64,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1132,245)|
+1,67,63,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1170,282)|
+10,68,"GDP G$/y",248,24,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,69,Govmnt spending as share of GDP,263,81,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,70,68,69,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(252,41)|
+1,71,47,69,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(160,73)|
+10,72,"Cost of TAs G$/y",63,659,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,73,25,26,0,0,0,0,0,64,0,-1--1--1,,1|(1045,622)|
+10,74,"Productivity loss from unprofitable activity (1)",618,734,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"Fraction unprofitable activity in TAs (1)",453,817,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,76,75,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(528,778)|
+1,77,74,25,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(768,684)|
+10,78,"Extra cost of TAs as share of GDP (1)",432,693,66,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,79,"GDP G$/y",272,626,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,80,72,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(125,675)|
+1,81,79,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(335,652)|
+10,82,"Extra domestic ROTA from 2022 1/y",944,190,72,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,82,40,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(958,285)|
+10,84,Time,870,404,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,85,84,40,0,0,0,0,0,64,0,-1--1--1,,1|(870,396)|
+10,86,Time,1134,347,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,87,86,61,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(1102,332)|
+10,88,Population Mp,61,130,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,89,"Public spending per person k$/p/y",244,131,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,90,88,89,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(142,130)|
+1,91,47,89,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(152,97)|
+10,92,"sOWeoTFP<0",567,638,48,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,93,Time,624,520,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,94,Observed warming deg C,475,591,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,95,OWeoTFP,711,568,37,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,96,94,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(594,579)|
+1,97,92,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(632,606)|
+1,98,93,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(660,540)|
+10,99,Observed warming in 2022 deg C,452,538,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,100,99,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(589,553)|
+1,101,95,27,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(811,568)|
+10,102,"xExtra cost of TAs as share of GDP (1)",588,860,69,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,103,"xExtra TA cost in 2022 (share of GDP)",783,826,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"xExtra TA cost in 2100 (share of GDP)",762,887,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,105,103,102,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(692,840)|
+1,106,104,102,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(682,874)|
+1,107,78,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(514,710)|
+10,108,"Cost of TAs in 2022 G$/y",62,728,47,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,109,"Extra cost of TAs from 2022 G$/y",214,700,57,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,110,108,109,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(170,715)|
+1,111,109,78,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(319,692)|
+1,112,61,38,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(964,367)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Climate
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,CO2 in atmosphere GtCO2,370,326,58,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,188,329,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,1,4,0,0,22,0,0,0,-1--1--1,,1|(286,329)|
+1,4,5,2,100,0,0,22,0,0,0,-1--1--1,,1|(223,329)|
+11,5,48,255,329,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"CO2 emissions GtCO2/y",255,356,49,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,7,48,556,326,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,8,10,7,4,0,0,22,0,0,0,-1--1--1,,1|(523,328)|
+1,9,10,1,100,0,0,22,0,0,0,-1--1--1,,1|(458,328)|
+11,10,48,494,328,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,11,"CO2 absorption GtCO2/y",494,358,53,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,12,Life of extra CO2 in atm y,568,424,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,13,1,11,1,0,0,0,3,192,0,0-0-255,|14||0-0-0,1|(452,385)|
+1,14,12,11,1,0,45,14,19,192,0,0-0-255,|14|B|255-0-0,1|(528,360)|
+10,15,CO2 in atm in 1850 GtCO2,625,360,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,16,15,11,0,0,0,0,0,128,0,-1--1--1,,1|(570,359)|
+10,17,CO2 in atm in 1980 GtCO2,436,242,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,17,1,0,0,0,0,3,128,1,192-192-192,|14||0-0-255,1|(412,272)|
+10,19,Perception delay y,351,-331,58,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,20,4325960,2077,146,398,329,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Climate
+10,21,Extra heat in surface ZJ,883,-271,49,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,22,"Melting rate surface 1/y",990,-521,39,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,23,"Heat required to melt ice kJ/kg",1131,-310,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,24,Extra heat in 1980 ZJ,729,-311,40,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,24,21,0,0,0,0,0,128,1,-1--1--1,,1|(794,-293)|
+10,26,CO2 concentration in 1980 ppm,132,24,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,Global surface Mkm2,1373,-143,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,28,Amount of ice in 1980 Mkm3,1132,-425,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,29,Ton per m3 ice,1154,-355,48,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,30,"Melting rate surface in 1980 1/y",710,-523,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,31,30,22,0,0,0,0,0,128,0,-1--1--1,,1|(855,-522)|
+10,32,CH4 in atmosphere GtCH4,764,505,54,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,33,48,574,503,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,36,33,4,0,0,22,0,0,0,-1--1--1,,1|(614,504)|
+1,35,36,32,100,0,0,22,0,0,0,-1--1--1,,1|(683,504)|
+11,36,48,651,504,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,37,"CH4 breakdown GtCH4/y",651,531,55,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,38,48,381,465,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,39,41,1,4,0,0,22,0,0,0,-1--1--1,,1|(376,385)|
+1,40,41,38,100,0,0,22,0,0,0,-1--1--1,,1|(376,441)|
+11,41,48,376,420,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,42,"CO2 from CH4 GtCO2/y",436,420,52,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,43,36,42,1,0,0,0,0,128,0,-1--1--1,,1|(545,471)|
+10,44,Life of CH4 in atm y,585,590,44,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,45,32,37,1,0,0,0,0,128,0,-1--1--1,,1|(729,555)|
+1,46,44,37,0,0,0,0,0,128,0,-1--1--1,,1|(616,561)|
+10,47,CH4 in atm in 1980 GtCH4,799,426,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,48,47,32,0,0,0,0,0,128,1,-1--1--1,,1|(786,454)|
+1,49,32,253,1,0,0,0,0,128,0,-1--1--1,,1|(703,425)|
+10,50,CO2 concentration in atm ppm,380,147,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,51,1,50,1,0,0,0,0,128,0,-1--1--1,,1|(359,227)|
+10,52,"Ice and snow cover excl G&A Mkm2",1314,-330,46,37,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,53,48,1312,-445,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,54,56,52,36,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1316,-378)|
+1,55,56,53,68,0,0,22,2,64,0,-1--1--1,|12||0-0-0,1|(1316,-419)|
+11,56,48,1316,-395,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,57,"Melting Mha/y",1371,-395,46,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,58,52,57,1,0,0,0,0,128,0,-1--1--1,,1|(1400,-327)|
+10,59,GtCO2 per ppm,462,197,53,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+12,60,48,856,-392,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,61,63,60,4,0,0,22,0,0,0,-1--1--1,,1|(856,-363)|
+1,62,63,21,100,0,0,22,0,0,0,-1--1--1,,1|(856,-315)|
+11,63,48,856,-336,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,64,"Extra cooling from ice melt ZJ/y",923,-336,59,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,65,28,64,0,0,0,0,0,64,0,-1--1--1,,1|(1033,-383)|
+1,66,23,64,0,0,0,0,0,64,0,-1--1--1,,1|(1036,-321)|
+1,67,22,184,0,0,0,0,0,64,0,-1--1--1,,1|(978,-478)|
+1,68,29,64,0,0,0,0,0,64,0,-1--1--1,,1|(1050,-346)|
+12,69,48,1106,-266,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,70,72,69,4,0,0,22,0,0,0,-1--1--1,,1|(1058,-266)|
+1,71,72,21,100,0,0,22,0,0,0,-1--1--1,,1|(970,-266)|
+11,72,48,1014,-266,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,73,"Heat to space ZJ/y",1014,-232,39,26,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,74,"Albedo in 1980 (1)",1461,-240,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,75,74,155,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1309,-202)|
+10,76,Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2,1470,-314,89,28,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,77,76,52,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1377,-323)|
+10,78,Warming in 1980 deg C,386,-246,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,79,Perceived warming deg C,265,-261,40,27,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,80,19,79,0,0,0,0,0,128,0,-1--1--1,,1|(323,-308)|
+1,81,78,22,0,0,0,0,3,64,0,192-192-192,|12||0-0-0,1|(682,-381)|
+10,82,Observed warming deg C,521,-317,49,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,78,82,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(446,-278)|
+1,84,21,82,1,0,0,0,0,128,0,-1--1--1,,1|(752,-367)|
+1,85,24,82,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(636,-313)|
+1,86,82,79,1,0,0,0,0,128,0,-1--1--1,,1|(386,-301)|
+1,87,82,22,1,0,0,0,0,128,0,-1--1--1,,1|(839,-512)|
+10,88,"CO2 from energy and industry GtCO2/y",206,573,66,35,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,89,88,6,1,0,0,0,0,128,0,-1--1--1,,1|(173,432)|
+10,90,kg CH4 per $ of GDP,1497,395,58,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,91,48,957,509,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,92,94,32,4,0,0,22,0,0,0,-1--1--1,,1|(847,509)|
+1,93,94,91,100,0,0,22,0,0,0,-1--1--1,,1|(917,509)|
+11,94,48,882,509,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,95,"CH4 emissions GtCH4/y",882,536,48,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,96,N2O in atmosphere GtN2O,1343,341,54,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,97,Life of N2O in atm y,1118,441,47,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,98,96,168,1,0,0,0,0,128,0,-1--1--1,,1|(1322,385)|
+1,99,97,168,0,0,0,0,0,128,0,-1--1--1,,1|(1173,410)|
+10,100,N2O in atm in 1980 GtN2O,1393,259,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,101,100,96,0,0,0,0,0,128,1,-1--1--1,,1|(1374,289)|
+10,102,kg N2O emission per kg fertiliser,1433,513,56,19,8,3,0,6,0,0,0,0,-1--1--1,255-255-255,|12||0-0-128,0,0,0,0,0,0
+10,103,"Rate of decline in N2O per kg fertiliser 1/y",1305,626,74,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,Time,1253,497,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,105,104,102,0,0,0,0,0,64,0,-1--1--1,,1|(1320,502)|
+12,106,48,1536,345,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,107,109,96,4,0,0,22,0,0,0,-1--1--1,,1|(1426,345)|
+1,108,109,106,100,0,0,22,0,0,0,-1--1--1,,1|(1496,345)|
+11,109,48,1461,345,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,110,"N2O emissions GtN2O/y",1461,372,49,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,111,96,227,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1266,233)|
+10,112,"Natural N2O emissions GtN2O/y",1371,445,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,113,"Man-made N2O emissions GtN2O/y",1546,439,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,114,112,110,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1410,412)|
+1,115,113,110,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1532,410)|
+10,116,"Fertilizer use Mt/y",1562,621,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,117,103,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1363,574)|
+1,118,104,112,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1295,477)|
+10,119,kg N2O per kg fertilizer in 1980,1242,562,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,119,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1328,539)|
+1,121,102,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1483,479)|
+1,122,116,113,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1589,540)|
+10,123,"Forcing from CO2 in 1980 W/m2",285,26,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,kg CH4 emission per kg crop,897,681,55,19,8,3,0,6,0,0,0,0,-1--1--1,255-255-255,|12||0-0-128,0,0,0,0,0,0
+10,125,"Rate of decline in CH4 per kg crop 1/y",848,753,73,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,126,Time,732,670,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,127,126,124,0,0,0,0,0,64,0,-1--1--1,,1|(792,673)|
+10,128,"Natural CH4 emissions GtCH4/y",842,616,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,129,"Man-made CH4 emissions GtCH4/y",998,619,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,130,125,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(867,722)|
+1,131,126,128,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(772,650)|
+10,132,kg CH4 per kg crop in 1980,722,725,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,133,132,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(799,705)|
+1,134,124,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(940,653)|
+1,135,128,95,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(875,586)|
+1,136,129,95,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(932,596)|
+10,137,"Demand for red meat Mt-red-meat/y",1655,521,73,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,138,"Crop supply (after 20 % waste) Mt-crop/y",1168,716,56,34,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,139,138,129,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1060,673)|
+10,140,tCO2 per tCH4,450,489,51,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,140,42,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(445,465)|
+12,142,48,858,-128,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,143,145,21,4,0,0,22,0,0,0,-1--1--1,,1|(856,-216)|
+1,144,145,142,100,0,0,22,0,0,0,-1--1--1,,1|(856,-157)|
+11,145,48,856,-184,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,146,"Extra warming from forcing ZJ/y",925,-184,61,27,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,147,48,676,-272,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,150,147,4,0,0,22,0,0,0,-1--1--1,,1|(720,-272)|
+1,149,150,21,100,0,0,22,0,0,0,-1--1--1,,1|(800,-272)|
+11,150,48,760,-272,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,151,"Heat to deep ocean ZJ/y",760,-245,42,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,152,21,151,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(820,-223)|
+10,153,"Transfer rate for heat going to abyss 1/y",626,-147,67,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,82,153,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(523,-222)|
+10,155,"Transfer rate for heat going to space 1/y",1128,-157,67,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,156,"Transfer rate surface-abyss in 1980 1/y",618,-231,70,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,156,153,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(621,-191)|
+10,158,"Transfer rate surface-space in 1980 1/y",1263,-101,71,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,159,158,155,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1191,-130)|
+1,160,155,73,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1045,-182)|
+1,161,21,73,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(931,-221)|
+10,162,"Albedo ice and snow (1)",1498,-138,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,163,GtN2O per ppm,1154,233,43,18,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+12,164,48,1181,345,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,165,167,164,4,0,0,22,0,0,0,-1--1--1,,1|(1214,347)|
+1,166,167,96,100,0,0,22,0,0,0,-1--1--1,,1|(1269,347)|
+11,167,48,1243,347,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,168,"N2O breakdown GtN2O/y",1243,374,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,169,Observed warming deg C,1095,-99,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,170,169,155,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1118,-131)|
+10,171,"Albedo global average (1)",1596,-172,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,172,27,146,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1163,-161)|
+1,173,171,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1534,-202)|
+10,174,"Albedo (1)",1288,-244,36,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,175,27,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1332,-192)|
+1,176,162,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1391,-191)|
+1,177,171,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1444,-206)|
+1,178,174,155,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1246,-199)|
+1,179,52,174,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1314,-274)|
+1,180,76,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1466,-279)|
+1,181,27,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1411,-186)|
+1,182,162,74,0,0,0,0,3,64,0,192-192-192,|12||0-0-0,1|(1482,-182)|
+1,183,22,56,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1205,-462)|
+10,184,"Melting rate deep ice 1/y",962,-423,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,185,184,64,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(945,-385)|
+10,186,"Surface vs deep rate (1)",1077,-471,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,187,186,184,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1025,-449)|
+1,188,153,151,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(769,-198)|
+10,189,"GHG EMISSIONS GtCO2e/y",872,305,68,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,190,6,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(547,331)|
+1,191,95,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,427)|
+1,192,110,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1182,340)|
+10,193,"tCO2e/tCO2",802,358,43,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,194,"tCO2e/tCH4",930,358,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,195,"tCO2e/tN2O",1061,286,43,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,196,193,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(825,339)|
+1,197,194,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(910,340)|
+1,198,195,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(985,293)|
+10,199,"sOWeoLoCO2>0",230,687,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,200,Time,424,620,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,201,Observed warming deg C,352,732,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,202,OWeoLoCO2,308,622,47,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,203,201,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(331,679)|
+1,204,199,202,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(263,659)|
+1,205,200,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(383,620)|
+10,206,Life of extra CO2 in atm in 1980 y,364,542,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,207,206,12,1,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(475,508)|
+1,208,202,12,1,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(457,548)|
+10,209,"CO2 emissions from LULUC GtCO2/y",294,482,58,31,8,130,0,3,-1,0,0,0,192-192-192,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,210,209,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(248,429)|
+10,211,"Risk of extreme heat event (1)",492,-439,57,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,212,Ice and snow cover Mha,1428,-484,43,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,213,52,212,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1372,-410)|
+10,214,"Water vapor concentration g/kg",425,-156,59,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,215,"Water vapour feedback W/m2",517,-66,52,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,216,"Forcing from CH4 W/m2",678,137,49,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,217,"Forcing from CO2 W/m2",450,46,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,218,214,215,1,0,0,0,0,128,0,-1--1--1,,1|(432,-104)|
+10,219,"Water vapour concentration 1980 g/kg",255,-126,78,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,220,"sWVeoWVF>0",364,-27,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,221,"CH4 forcing per ppm W/m2/ppm",791,204,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,222,221,216,0,0,0,0,0,128,0,-1--1--1,,1|(747,178)|
+1,223,216,273,1,0,0,0,0,128,0,-1--1--1,,1|(721,24)|
+10,224,"sOWeoWV>0",284,-194,48,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,225,224,214,0,0,0,0,0,128,0,-1--1--1,,1|(338,-178)|
+10,226,"Forcing from N2O W/m2",937,67,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,227,N2O concentration in atm ppm,1138,157,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,228,227,226,1,0,0,0,0,128,0,-1--1--1,,1|(1077,119)|
+10,229,"N2O forcing per ppm W/m2/ppm",943,132,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,230,229,226,0,0,0,0,0,128,0,-1--1--1,,1|(941,106)|
+1,231,226,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(859,-8)|
+10,232,"Total man-made forcing W/m2",812,-79,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,233,219,214,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(342,-140)|
+1,234,220,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(429,-43)|
+10,235,"Water vapor feedback in 1980 W/m2",252,-79,72,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,236,235,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(387,-72)|
+1,237,219,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(392,-94)|
+1,238,215,232,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(647,-54)|
+10,239,"Forcing from other gases W/m2",618,51,48,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,240,239,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(707,-36)|
+1,241,232,146,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(892,-124)|
+1,242,82,214,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(455,-253)|
+1,243,50,217,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(402,95)|
+10,244,Time,960,190,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,245,244,229,0,0,0,0,0,64,0,-1--1--1,,1|(954,171)|
+1,246,82,211,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(508,-371)|
+1,247,78,214,0,0,0,0,0,64,0,-1--1--1,,1|(402,-207)|
+10,248,Observed warming in 2022 deg C,366,-390,68,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,249,CO2 concentration in 2022 ppm,296,73,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,250,Observed warming in 2022 deg C,464,679,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,251,250,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(381,648)|
+1,252,217,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(596,-34)|
+10,253,CH4 concentration in atm ppm,656,258,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,254,253,216,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(653,205)|
+10,255,GtCH4 per ppm,728,315,37,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,256,Mass of atmosphere Zt,957,242,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,257,CH4 conc in 1980 ppm,966,431,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,258,256,257,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(960,329)|
+1,259,47,257,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,427)|
+10,260,N2O conc in 1980 ppm,1552,254,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,261,256,260,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1249,247)|
+1,262,100,260,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1467,256)|
+10,263,Time,600,118,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,264,263,239,0,0,0,0,0,64,0,-1--1--1,,1|(604,99)|
+10,265,Time,791,242,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,266,265,221,0,0,0,0,0,64,0,-1--1--1,,1|(791,234)|
+1,267,163,227,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1148,202)|
+1,268,255,253,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(697,290)|
+1,269,59,50,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(433,179)|
+10,270,"CO2 forcing per ppm W/m2/ppm",509,132,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,271,263,270,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(574,121)|
+1,272,270,217,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(483,94)|
+10,273,"Man-made forcing W/m2",781,-23,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,274,273,232,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(792,-44)|
+10,275,"Warming from extra heat deg/ZJ",716,-415,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,276,275,82,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(613,-385)|
+10,277,"Direct air capture of CO2 GtCO2/y",259,282,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,278,"Direct air capture of CO2 in 2100 GtCO2/y",139,117,53,53,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,279,278,277,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(203,205)|
+10,280,"Cost of air capture G$/y",269,195,42,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,281,277,5,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(257,305)|
+10,282,"Cost of CCS $/tCO2",260,131,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,283,282,280,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(262,156)|
+1,284,277,280,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(262,245)|
+10,285,Introduction period for policy y,95,286,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,286,285,277,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(171,284)|
+10,287,Time,259,320,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,288,287,277,0,0,0,0,0,64,0,-1--1--1,,1|(259,312)|
+10,289,"CO2 per GDP (kgCO2/$)",77,375,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,290,6,289,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(172,364)|
+10,291,"GDP G$/y",64,442,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,292,291,289,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(68,419)|
+10,293,"Extra rate of decline in N2O per kg fertilizer from 2022 1/y",1475,690,90,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,294,293,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1454,603)|
+10,295,"Extra rate of decline in CH4 pr kg crop after 2022 1/y",1036,756,87,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,296,295,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(964,717)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Other performance indicators
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"RATE OF GROWTH IN GDP PER PERSON 1/y",592,71,79,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"GDP per person k$/p/y",109,66,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,3,"Past GDP per person k$/y",396,111,44,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,Time to establish growth rate y,396,205,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,5,2,1,1,0,0,0,0,128,0,-1--1--1,,1|(353,40)|
+1,6,2,3,1,0,0,0,0,128,0,-1--1--1,,1|(252,88)|
+1,7,3,1,1,0,0,0,0,128,0,-1--1--1,,1|(469,96)|
+1,8,4,3,0,0,0,0,0,128,0,-1--1--1,,1|(396,173)|
+1,9,4,1,0,0,0,0,0,128,0,-1--1--1,,1|(481,146)|
+10,10,"GDP per person in 1980 k$/p/y",256,156,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,11,10,3,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(326,133)|
+10,12,"Factor to avoid transient in growth rate (1)",90,136,72,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,13,12,3,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(250,123)|
+12,14,0,1258,317,341,297,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Other_performance_indicators
+10,15,"Cost of food G$/y",196,339,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,16,"Cost of energy G$/y",189,444,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,17,"Cost of food and energy TAs G$/y",382,375,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,15,17,0,0,0,0,0,128,0,-1--1--1,,1|(277,354)|
+1,19,16,17,0,0,0,0,0,128,0,-1--1--1,,1|(277,412)|
+10,20,"Cost of TAs G$/y",592,377,57,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,17,20,0,0,0,0,0,128,0,-1--1--1,,1|(479,375)|
+10,22,"Fraction below 15 k$/p/y (1)",628,541,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,23,"Logistic k (1)",440,536,43,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,24,"Inequality (1)",94,512,46,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,25,"Inequity effect on logistic k (1)",265,531,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,26,24,25,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(168,519)|
+1,27,25,23,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(351,532)|
+1,28,23,22,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(519,537)|
+10,29,"sINEeoLOK<0",153,580,51,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,30,29,25,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(193,562)|
+10,31,"Normal k (1)",353,580,42,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,32,31,23,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(389,561)|
+10,33,"GDP per person k$/p/y",529,473,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,34,33,22,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(572,503)|
+10,35,"Population below 15 k$/p/y Mp",797,544,66,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,36,Population Mp,729,471,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,37,36,35,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(754,498)|
+1,38,22,35,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(702,542)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Food and land use
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Crop demand Mt-crop/y",731,400,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Forestry land Mha,1777,667,46,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,Grazing land Mha,1588,543,49,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,Cropland Mha,1771,808,44,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,Barren land Mha,1792,949,43,24,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Urban land Mha,1984,810,42,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,7,"Potential red meat from grazing land Mt-red-meat/y",1398,233,87,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,8,"Grazing land yield kg-red-meat/ha/y",1344,307,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,9,3,7,1,0,0,0,0,128,0,-1--1--1,,1|(1537,400)|
+10,10,"Soil quality index in conv ag (1980=1)",645,1148,59,44,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,11,13,5,4,0,0,22,0,0,0,-1--1--1,,1|(1785,905)|
+1,12,13,4,100,0,0,22,0,0,0,-1--1--1,,1|(1785,853)|
+11,13,7856,1785,880,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,14,"Cropland loss Mha/y",1838,880,45,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,15,4,13,1,0,0,0,0,128,0,-1--1--1,,1|(1746,860)|
+1,16,18,4,4,0,0,22,0,0,0,-1--1--1,,1|(1785,759)|
+1,17,18,2,100,0,0,22,0,0,0,-1--1--1,,1|(1785,709)|
+11,18,7548,1785,730,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,19,"Cropland expansion Mha/y",1848,730,55,19,40,3,0,2,-1,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,20,22,6,4,0,0,22,0,0,0,-1--1--1,,1|(1919,811)|
+1,21,22,4,100,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1849,811)|
+11,22,7988,1890,811,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,23,"Urban expansion Mha/y",1890,838,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,24,Urban development time y,1996,903,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,6,23,1,0,0,0,0,128,0,-1--1--1,,1|(1959,846)|
+10,26,"Fertilizer effect on erosion rate (1)",1450,1046,57,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,27,"Old growth removal rate 1/y",1685,411,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,35,1,0,0,0,0,128,0,-1--1--1,,1|(1747,423)|
+10,29,Old growth forest area Mha 1,1780,545,49,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,32,3,4,0,0,22,0,0,0,-1--1--1,,1|(1660,548)|
+1,31,32,29,100,0,0,22,0,0,0,-1--1--1,,1|(1713,548)|
+11,32,7372,1690,548,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,33,"New grazing land Mha/y",1690,588,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,34,"Fraction cleared for grazing (1)",1465,418,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,35,"Old growth removal Mha/y",1769,468,48,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,36,38,2,4,0,0,22,0,0,0,-1--1--1,,1|(1783,625)|
+1,37,38,29,100,0,0,22,0,0,0,-1--1--1,,1|(1783,587)|
+11,38,7350,1783,605,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,39,"New forestry land Mha/y",1856,605,58,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,40,29,35,1,0,0,0,0,128,0,-1--1--1,,1|(1831,491)|
+1,41,35,32,1,0,0,0,0,128,0,-1--1--1,,1|(1692,506)|
+1,42,35,38,1,0,0,0,0,128,0,-1--1--1,,1|(1712,519)|
+10,43,"Cropland expansion rate 1/y",1369,670,49,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,43,18,1,0,0,0,0,128,0,-1--1--1,,1|(1572,685)|
+1,45,4,18,1,0,0,0,0,128,0,-1--1--1,,1|(1754,750)|
+10,46,"Demand for red meat per person kg-red-meat/p/y",980,51,81,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,47,"Crop yield in reg ag t-crop/ha/y",446,435,63,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"CO2 release from forest cut GtCO2/y",1857,225,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,"sFBeoCLE<0",1265,609,45,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,50,49,43,0,0,0,0,0,128,0,-1--1--1,,1|(1295,627)|
+10,51,"Soil quality index in 1980 (1)",625,1050,50,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,52,51,10,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(631,1083)|
+10,53,"sFUeoLER>0",1336,998,45,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,54,53,26,0,0,0,0,0,128,0,-1--1--1,,1|(1376,1015)|
+10,55,Grazing land in 1980 Mha,1478,547,36,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,56,55,3,0,0,0,0,0,128,1,-1--1--1,,1|(1519,545)|
+10,57,Old growth forest in 1980 Mha,1944,537,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,57,29,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1861,540)|
+10,59,Forestry land in 1980 Mha,1610,662,50,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,60,59,2,0,0,0,0,0,128,1,-1--1--1,,1|(1688,663)|
+10,61,Urban land in 1980 Mha,1984,747,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,62,61,6,0,0,0,0,0,128,1,-1--1--1,,1|(1984,768)|
+10,63,Cropland in 1980 Mha,1645,807,50,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,64,63,4,0,0,0,0,0,128,1,-1--1--1,,1|(1704,807)|
+10,65,"Urban land per population ha/p",1993,1047,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,66,"Red meat from feedlots Mt-red-meat/y",1012,222,74,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,67,8,7,1,0,0,0,0,128,0,-1--1--1,,1|(1374,273)|
+1,68,7,148,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1303,187)|
+10,69,"Feed for red meat Mt-crop/y",880,283,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,70,"Grazing land yied in 1980 kg-red-meat/ha/y",1308,379,74,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,71,70,8,0,0,0,0,0,128,0,-1--1--1,,1|(1322,349)|
+10,72,"Average crop yield t-crop/ha/y",884,908,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,73,"Fertilizer use Mt/y",317,691,46,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,74,24,23,1,0,0,0,0,128,0,-1--1--1,,1|(1937,874)|
+10,75,"Crop supply (after 20 % waste) Mt-crop/y",1136,951,63,32,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,76,4,75,1,0,0,0,0,128,0,-1--1--1,,1|(1417,926)|
+1,77,72,75,1,0,0,0,0,128,0,-1--1--1,,1|(1000,948)|
+10,78,"Crop balance (1)",987,697,50,21,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,79,48,476,1144,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,80,82,10,4,0,0,22,0,0,0,-1--1--1,,1|(561,1146)|
+1,81,82,79,100,0,0,22,0,0,0,-1--1--1,,1|(505,1146)|
+11,82,48,530,1146,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,83,"Change in soil quality in conv ag t-crop/ha/y/y",530,1180,59,26,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,84,"Desired reserve capacity (1)",1049,617,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,159,0,0,0,0,0,128,0,-1--1--1,,1|(1111,638)|
+12,86,0,2601,136,361,324,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Food_and_land_use
+10,87,Population Mp,434,111,49,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,88,Population Mp,1841,1065,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,89,0,3432,786,430,317,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Land_yield_and_fertility
+10,90,"Sustainable fertiliser use kgN/ha/y",340,968,56,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,91,"ROC in soil quality in conv ag 1/y",468,1021,64,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,92,90,91,0,0,0,0,0,128,0,-1--1--1,,1|(393,990)|
+10,93,"sFUeoSQ<0",564,962,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,94,93,91,0,0,0,0,0,128,0,-1--1--1,,1|(536,979)|
+12,95,0,3418,136,424,312,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Food_demand_and_supply
+10,96,"Traditional use of crops per person kg-crop/p/y",542,65,75,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,97,"Traditional use of red meat per person kg-red-meat/p/y",780,56,89,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,98,"kg-crop per kg-red-meat",886,210,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,99,97,46,0,0,0,0,0,128,0,-1--1--1,,1|(877,54)|
+1,100,98,69,0,0,0,0,0,128,0,-1--1--1,,1|(883,241)|
+1,101,66,69,1,0,0,0,0,128,0,-1--1--1,,1|(944,245)|
+1,102,69,1,1,0,0,0,0,128,0,-1--1--1,,1|(801,336)|
+10,103,Indicated urban land Mha,1965,966,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,104,88,103,0,0,0,0,0,128,0,-1--1--1,,1|(1892,1023)|
+1,105,65,103,0,0,0,0,0,128,0,-1--1--1,,1|(1981,1013)|
+1,106,103,23,0,0,0,0,0,128,0,-1--1--1,,1|(1931,908)|
+10,107,"Crop use per person t-crop/p/y",846,750,59,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,108,"Traditional fertilizer use in conv ag kgN/ha/y",545,828,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,109,91,82,1,0,0,0,0,128,0,-1--1--1,,1|(480,1070)|
+1,110,10,82,1,0,0,0,0,128,0,-1--1--1,,1|(562,1092)|
+1,111,10,72,1,0,0,0,0,128,0,-1--1--1,,1|(843,1042)|
+10,112,"Sustainable fertiliser use kgN/ha/y",1309,1153,68,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,113,112,26,0,0,0,0,0,128,0,-1--1--1,,1|(1373,1103)|
+10,114,"Fraction regenerative agriculture (1)",320,505,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,115,"Crop supply reg ag Mt-crop/y",519,509,47,31,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,116,47,115,0,0,0,0,0,128,0,-1--1--1,,1|(471,461)|
+10,117,"Desired crop supply conv ag Mt-crop/y",641,566,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,118,115,117,1,0,0,0,0,128,0,-1--1--1,,1|(611,518)|
+10,119,"Desired crop yield in conv ag t-crop/ha/y",663,746,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,117,119,1,0,0,0,0,128,0,-1--1--1,,1|(634,645)|
+1,121,1,153,1,0,0,0,0,128,0,-1--1--1,,1|(719,445)|
+10,122,Cropland Mha,543,606,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,123,122,119,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(594,666)|
+1,124,114,73,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(318,591)|
+1,125,114,72,1,0,0,0,0,128,0,-1--1--1,,1|(544,735)|
+1,126,122,73,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(445,642)|
+1,127,122,115,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(535,574)|
+1,128,114,115,1,0,0,0,0,128,0,-1--1--1,,1|(434,502)|
+1,129,119,108,0,0,0,0,0,128,0,-1--1--1,,1|(609,783)|
+1,130,119,72,1,0,0,0,0,128,0,-1--1--1,,1|(748,838)|
+10,131,"Crop yield in reg ag t-crop/ha/y",851,821,68,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,132,131,72,0,0,0,0,0,128,0,-1--1--1,,1|(864,857)|
+1,133,114,119,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(485,621)|
+10,134,"GDP per person k$/p/y",483,-44,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,135,134,97,0,0,0,0,0,128,0,-1--1--1,,1|(624,4)|
+1,136,134,96,0,0,0,0,0,128,0,-1--1--1,,1|(508,5)|
+10,137,CO2 concentration in atm ppm,1159,1078,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,138,CO2 concentration in atm ppm,1163,346,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,139,138,8,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1251,327)|
+10,140,"Biofuels use Mtoe/y",470,361,40,40,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,141,140,146,0,0,0,0,0,128,0,-1--1--1,,1|(525,363)|
+10,142,Time,376,333,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,143,142,140,0,0,0,0,0,64,0,-1--1--1,,1|(409,342)|
+10,144,Ton crops per toe biofuel,599,421,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,145,144,146,0,0,0,0,0,128,0,-1--1--1,,1|(602,401)|
+10,146,"Crops for biofuel Mt-crop/y",610,368,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,147,146,1,0,0,0,0,0,128,0,-1--1--1,,1|(668,383)|
+10,148,"Red meat from grazing land Mt-red-meat/y",1189,183,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,149,148,66,1,0,0,0,0,128,0,-1--1--1,,1|(1105,183)|
+10,150,"Traditional use of crops ex red meat Mt/y",647,248,61,32,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,151,96,170,0,0,0,0,0,128,0,-1--1--1,,1|(561,106)|
+1,152,150,1,0,0,0,0,0,128,0,-1--1--1,,1|(688,324)|
+10,153,"Desired crop supply Mt-crop/y",703,472,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,153,117,0,0,0,0,0,128,0,-1--1--1,,1|(675,513)|
+1,155,153,78,1,0,0,0,0,128,0,-1--1--1,,1|(803,618)|
+10,156,"Red meat supply per person kg-red-meat/p/y",877,-61,76,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,148,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1038,66)|
+1,158,66,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(947,87)|
+10,159,"Perceived crop balance (1)",1185,665,48,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,160,78,159,1,0,0,0,0,128,0,-1--1--1,,1|(1082,665)|
+1,161,159,43,1,0,0,0,0,128,0,-1--1--1,,1|(1276,653)|
+10,162,"Crop balance (1)",839,-4,48,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,163,162,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(853,-26)|
+1,164,87,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(648,28)|
+10,165,"Traditional use of crops ex red meat per person kg-crop/p/y",389,180,84,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,166,87,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(417,136)|
+1,167,150,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(536,220)|
+10,168,"Traditional use of feed for red meat Mt-crop/y",745,152,64,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,148,168,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(969,168)|
+10,170,"Traditional use of crops Mt/y",588,158,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,171,170,150,0,0,0,0,0,128,0,-1--1--1,,1|(609,191)|
+1,172,87,170,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(501,132)|
+1,173,97,168,0,0,0,0,0,128,0,-1--1--1,,1|(766,95)|
+1,174,87,168,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(575,130)|
+1,175,98,168,0,0,0,0,0,128,0,-1--1--1,,1|(831,189)|
+1,176,168,150,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(704,192)|
+10,177,Observed warming deg C,860,1129,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,178,177,249,0,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(877,1084)|
+10,179,"Fertilizer productivity index (1980=1)",334,866,67,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,180,"ROC in fertilizer productivity 1/y",224,785,50,50,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,181,180,179,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(280,826)|
+1,182,179,185,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(405,881)|
+10,183,Time,203,872,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,184,183,179,0,0,0,0,1,64,0,255-128-192,|12||0-0-0,1|(241,870)|
+10,185,"Fertilizer use in conv ag kgN/ha/y",478,899,55,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,186,108,185,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(520,854)|
+1,187,185,91,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(466,941)|
+1,188,185,73,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(398,796)|
+1,189,185,26,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(944,1092)|
+10,190,"ROC in food sector productivity 1/y",210,279,52,52,2,131,0,3,0,0,0,0,128-0-64,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,191,190,193,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(324,274)|
+1,192,142,193,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(401,313)|
+10,193,"Food sector productivity index (1980=1)",459,268,57,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,194,193,150,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(544,260)|
+12,195,0,204,-30,157,109,3,135,0,10,0,0,0,0,-1--1--1,0-0-0,|18||255-0-255,0,0,0,0,0,0
+TO SIMULATE FOOD TURNAROUND: Adjust Goals for crop waste, reg ag, and new red meat. You may want to change other pink policy handles
+10,196,"Demand for red meat Mt-red-meat/y",1078,117,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,197,46,196,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1022,81)|
+1,198,196,66,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1048,164)|
+1,199,87,196,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(739,114)|
+1,200,196,148,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1126,147)|
+10,201,Observed warming deg C,1344,345,54,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,202,201,8,0,1,0,0,0,64,0,-1--1--1,,1|(1344,326)|
+10,203,"Fertilizer cost reduction G$/y",1476,1356,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,204,"Cost of regenerative agriculture G$/y",1136,1343,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,205,"Extra cost of reg ag $/ha/y",932,1344,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,206,205,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1021,1343)|
+10,207,"GDP G$/y",1235,1559,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,208,"Cost of new electrification G$/y",1337,1378,65,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,209,"Cost of CCS G$/y",1337,1378,47,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,210,Regenerative agriculture area Mha,227,589,75,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,211,"Demand for fossil fuel for non-el use before NE Mtoe/y",1158,1283,85,28,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,212,Regenerative agriculture area Mha,1135,1278,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,213,"Cost per ton fertilizer $/t",1553,1286,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,214,213,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1519,1316)|
+1,215,204,224,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1198,1370)|
+1,216,212,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1135,1303)|
+1,217,203,224,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1388,1375)|
+10,218,"Cost index for Regenerative agriculture (1)",736,1282,76,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,219,"Cost reduction per doubling in Regenerative agriculture (1)",601,1389,89,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,220,219,218,0,0,0,0,0,128,0,-1--1--1,,1|(662,1340)|
+1,221,218,205,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,1315)|
+10,222,"Extra cost of reg ag in 2022 $/ha/y",940,1277,70,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,223,222,205,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(936,1303)|
+10,224,"Extra cost of Food Turnaround G$/y",1275,1403,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,225,"Extra cost of Food Turnaround as share of GDP (1)",1414,1482,73,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,226,224,225,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1329,1434)|
+1,227,207,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1297,1531)|
+10,228,"Amount of fertilizer saved in reg ag kgN/ha/y",1398,1285,79,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,229,228,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1431,1315)|
+1,230,212,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1309,1317)|
+1,231,112,228,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1349,1213)|
+10,232,"Crop use Mt/y",1000,812,51,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,233,75,232,1,0,0,0,0,128,0,-1--1--1,,1|(1045,884)|
+1,234,2,19,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1862,701)|
+10,235,FFLReoOGRR,1519,462,50,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,236,235,27,1,0,0,0,0,128,0,-1--1--1,,1|(1593,434)|
+10,237,"sFFLReoOGRR<0",1371,466,62,9,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,238,237,235,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1444,464)|
+10,239,"Fraction forestry land remaining (1)",1408,617,68,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,240,2,239,1,0,0,0,0,128,0,-1--1--1,,1|(1549,600)|
+1,241,239,235,1,0,0,0,0,128,0,-1--1--1,,1|(1431,521)|
+10,242,"OGRR in 1980 1/y",1648,346,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,243,242,27,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1662,372)|
+10,244,"Threshold FFLR (1)",1326,535,48,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,245,244,235,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1424,497)|
+10,246,"CO2 release per ha of forest cut tCO2/ha",1773,304,59,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,247,"CO2 absorption in forestry land GtCO2/y",1979,303,57,35,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,248,"CO2 absorption in forestry land tCO2/ha/y",2074,397,58,37,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,249,"Warming effect on land yield (1)",901,1028,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,250,"CO2 effect on land yield (1)",1004,990,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,251,"sCO2CeoACY>0",1140,1025,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,252,249,72,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(893,974)|
+1,253,250,72,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(949,952)|
+10,254,"sOWeoACY<0",991,1089,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,255,254,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(957,1066)|
+1,256,251,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1088,1011)|
+10,257,Time,1004,1056,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,258,257,250,0,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(1004,1034)|
+1,259,257,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(975,1048)|
+1,260,137,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1087,1037)|
+10,261,"Cost of food G$/y",1096,1473,58,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,262,"Agriculture as fraction of GDP (1)",1106,1557,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,263,262,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1101,1517)|
+1,264,207,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1171,1519)|
+10,265,"Cost of fertilizer G$/y",931,1476,51,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,266,"Fertilizer use Mt/y",875,1425,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,267,266,265,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(897,1445)|
+1,268,213,265,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1254,1376)|
+1,269,204,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1117,1405)|
+1,270,265,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1003,1475)|
+10,271,"Extra CO2 absorption in reg ag GtCO2/y",128,665,77,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,272,"CO2 absorbed in reg ag tCO2/ha/y",121,534,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,273,122,210,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(400,598)|
+1,274,114,210,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(278,542)|
+1,275,210,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(183,622)|
+1,276,272,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(125,592)|
+10,277,"CO2 emissions from LULUC GtCO2/y",1826,86,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,278,35,48,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1855,372)|
+1,279,248,247,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2030,353)|
+1,280,246,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1814,265)|
+1,281,2,247,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2013,519)|
+1,282,19,48,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1936,580)|
+1,283,48,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1843,163)|
+1,284,247,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1901,193)|
+10,285,"Extra CO2 absorption in reg ag GtCO2/y",1987,155,76,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,286,285,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1912,124)|
+10,287,"Loss of forest land Mha/y",1765,1127,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,288,"Loss of cropland Mha/y",1936,1121,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,289,35,287,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1767,790)|
+1,290,19,287,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1807,921)|
+1,291,14,288,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1883,994)|
+1,292,23,288,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1911,972)|
+10,293,CO2 concentration in 2022 ppm,1136,1152,69,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,294,293,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1070,1071)|
+10,295,Observed warming in 2022 deg C,993,1144,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,296,295,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(951,1091)|
+1,297,34,39,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1653,508)|
+1,298,34,33,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1571,498)|
+10,299,"Acceptable loss of forestry land (1)",1560,753,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,300,59,239,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1524,643)|
+1,301,299,18,1,0,0,0,0,128,0,-1--1--1,,1|(1678,750)|
+1,302,244,299,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1441,643)|
+1,303,239,299,1,0,0,0,0,128,0,-1--1--1,,1|(1439,692)|
+10,304,Total forest area Mha,2054,646,59,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,305,29,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1908,592)|
+1,306,2,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1902,657)|
+10,307,"Land erosion rate 1/y",1619,980,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,308,"Land erosion rate in 1980 1/y",1460,950,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,309,308,307,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1543,965)|
+1,310,307,13,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1716,932)|
+1,311,26,307,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1548,1012)|
+10,312,"sFBeoCLE<0",2131,154,54,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,313,"SSP2 land management action from 2022? (1)",2443,662,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,314,"Land erosion multiplier (1)",2215,767,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,315,313,314,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2335,711)|
+10,316,"Old growth removal rate multiplier (1)",2194,608,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,317,313,316,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2319,635)|
+10,318,"Cropland expansion multiplier (1)",2211,693,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,319,313,318,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2328,677)|
+10,320,"Forest absorption multipler (1)",2187,530,57,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,321,313,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2321,599)|
+10,322,"Max forest absorption multiplier (1)",2360,520,53,33,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,323,322,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2282,524)|
+1,324,316,35,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1983,538)|
+1,325,318,18,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1976,712)|
+1,326,314,307,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1923,870)|
+1,327,320,248,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2142,477)|
+10,328,Time,2308,788,29,16,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,329,"SSP2 land management action from 2022? (1)",2132,-129,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,330,328,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2251,666)|
+1,331,328,316,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2255,705)|
+1,332,328,318,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2266,746)|
+1,333,328,314,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2274,780)|
+1,334,232,78,1,0,0,0,0,128,0,-1--1--1,,1|(977,761)|
+10,335,"Warming effect on land yield (1)",1627,185,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,336,"CO2 effect on land yield (1)",1635,239,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,337,232,107,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(939,787)|
+10,338,Population Mp,774,646,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,339,338,107,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(802,688)|
+10,340,"FOOD FOOTPRINT INDEX (1980=1)",949,434,74,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,341,"Fertilizer use in 1980 Mt/y",430,728,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,342,341,347,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(721,627)|
+1,343,73,346,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(597,603)|
+1,344,4,346,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1326,661)|
+1,345,63,347,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1341,667)|
+10,346,Food footprint,880,514,46,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,347,Food footprint in 1980,1027,523,48,24,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,348,346,340,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(905,483)|
+1,349,347,340,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(990,481)|
+10,350,"Crop waste reduction (1)",1143,792,42,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,351,"Goal for crop waste reduction (1)",1289,778,51,51,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,352,351,350,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1218,783)|
+1,353,350,232,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1082,799)|
+10,354,"Fraction new red meat (1)",1253,45,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,355,"Goal for fraction new red meat (1)",1398,-13,53,53,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,356,355,354,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1330,14)|
+1,357,354,196,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1171,79)|
+10,358,"Goal for fraction regenerative agriculture (1)",274,398,57,57,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,359,358,114,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(300,461)|
+10,360,Regenerative agriculture area Mha,286,1284,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,361,"Number of doublings in reg ag (1)",509,1288,67,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,362,360,361,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(392,1285)|
+10,363,Experience gained before 2022 Mha,331,1372,58,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,364,363,361,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(413,1332)|
+1,365,361,218,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(611,1285)|
+10,366,Normal reform delay y,1180,463,53,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,367,"Fertilizer use per person kg/p/y",732,697,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,368,73,367,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(514,693)|
+1,369,338,367,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(760,662)|
+1,370,335,70,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1473,278)|
+1,371,336,70,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1477,306)|
+1,372,335,247,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1795,242)|
+1,373,336,247,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1804,271)|
+10,374,Introduction period for policy y,1200,864,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,375,374,350,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1175,833)|
+10,376,Introduction period for policy y,1340,98,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,377,376,354,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1302,76)|
+10,378,Introduction period for policy y,168,469,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,379,378,114,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(236,484)|
+10,380,"Extra ROC in food sector productivity from 2022 1/y",134,185,85,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,381,380,193,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(298,228)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Wellbeing - trust and tension
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Average wellbeing perception delay y,1054,-147,53,30,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Average wellbeing from global warming (1)",804,265,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,3,"sGWeoAW<0",747,332,47,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,4,3,2,1,0,0,0,0,128,0,-1--1--1,,1|(760,308)|
+10,5,"Average wellbeing from disposable income (1)",435,-37,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,6,"AVERAGE WELLBEING INDEX (1)",682,-110,74,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,7,5,6,1,0,0,0,0,128,0,-1--1--1,,1|(550,-84)|
+10,8,"Past AWI (1)",1041,-210,40,23,3,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,9,1,8,0,0,0,0,0,128,0,-1--1--1,,1|(1048,-175)|
+10,10,"Observed rate of progress 1/y",1172,-56,47,38,3,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,11,6,8,1,0,0,0,0,128,0,-1--1--1,,1|(856,-209)|
+1,12,8,10,1,0,0,0,0,128,0,-1--1--1,,1|(1144,-163)|
+1,13,6,10,1,0,0,0,0,128,0,-1--1--1,,1|(922,-132)|
+1,14,1,10,0,0,0,0,0,128,0,-1--1--1,,1|(1102,-108)|
+10,15,Perceived warming deg C,987,319,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,16,15,2,0,0,0,0,0,128,0,-1--1--1,,1|(907,296)|
+12,17,0,1854,-19,351,309,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Material_and_social_cond
+12,18,0,1844,600,339,301,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Average_Wellbeing_Index
+10,19,"Average wellbeing from inequality (1)",629,270,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,20,"sIIeoAW<0",668,370,39,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,21,20,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(652,330)|
+10,22,"Worker disposable income k$/p/y",232,-23,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,23,22,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(322,-28)|
+10,24,"Inequality (1)",449,335,44,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,25,24,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(527,306)|
+10,26,"Threshold disposable income k$/p/y",257,60,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,27,26,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(339,14)|
+10,28,"Diminishing return disposable income (1)",438,46,52,33,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,29,28,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(436,4)|
+10,30,"Average wellbeing from public spending (1)",507,125,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,31,"Threshold public spending k$/p/y",345,223,53,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,32,"Diminishing return public spending (1)",509,207,49,38,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,33,"Public spending per person k$/p/y",246,161,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,34,33,30,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(365,144)|
+1,35,31,30,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(421,168)|
+1,36,32,30,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(508,163)|
+1,37,30,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(582,11)|
+1,38,19,6,1,0,0,0,0,64,0,-1--1--1,,1|(637,89)|
+10,39,"Threshold inequality (1)",564,358,42,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,40,39,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(591,319)|
+10,41,Threshold warming deg C,921,364,49,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,42,41,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(867,318)|
+10,43,"Average wellbeing from progress (1)",950,190,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,44,43,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(797,96)|
+10,45,"Threshold progress rate 1/y",1079,146,51,25,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,46,10,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1169,115)|
+1,47,45,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1023,164)|
+10,48,"sROPeoAW>0",1065,262,50,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,49,48,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1019,233)|
+10,50,"AWI in 1980 (1)",923,-257,54,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,51,50,8,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(969,-238)|
+10,52,"Social tension (1)",1272,333,55,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,53,10,52,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1295,234)|
+10,54,"Acceptable progress 1/y",1222,239,40,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,55,54,52,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1245,283)|
+1,56,2,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(700,91)|
+10,57,"Min wellbeing from global warming (1)",791,394,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,58,57,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(796,336)|
+10,59,"Indicated social trust (1)",854,522,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,60,"GDP per person k$/p/y",188,333,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,61,Public spending as share of GDP,340,393,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,62,33,61,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(289,270)|
+1,63,60,61,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(257,360)|
+10,64,"Satisfactory public spending (1)",297,454,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,65,61,67,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(403,447)|
+1,66,64,67,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(379,479)|
+10,67,"Public spending effect on social trust (1)",478,511,69,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,68,"Inequity effect on social trust (1)",662,474,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,69,24,68,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(553,403)|
+10,70,"Acceptable inequality (1)",502,437,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,71,70,68,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(568,451)|
+1,72,68,59,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(770,518)|
+1,73,67,59,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(609,534)|
+10,74,"Social trust (1)",1046,489,40,20,3,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,75,59,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(948,505)|
+10,76,Time to establish social trust y,946,437,54,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,77,76,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(988,459)|
+10,78,Normal reform delay y,1171,439,48,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,79,"Social trust in 1980 (1)",985,569,43,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,80,79,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1010,535)|
+10,81,"Social trust effect on reform delay (1)",1187,522,65,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,82,"Social tension effect on reform delay (1)",1301,431,73,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,74,81,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1118,507)|
+1,84,52,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1283,371)|
+1,85,82,97,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1336,489)|
+1,86,81,97,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1267,544)|
+1,87,78,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1260,496)|
+10,88,"Social tension in 1980 (1)",1412,319,52,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,89,79,81,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1068,549)|
+10,90,"sSTReoRD<0",1149,591,46,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,91,90,81,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1162,567)|
+1,92,88,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1361,370)|
+10,93,"sSTEeoRD>0",1450,474,45,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,94,93,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1395,458)|
+10,95,"sPPReoSTE<0",1154,287,49,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,96,95,52,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1205,307)|
+10,97,Indicated reform delay y,1362,562,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,98,97,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1372,598)|
+10,99,Time to change reform delay y,1227,642,49,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,100,99,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1304,645)|
+10,101,"Wellbeing effect of participation (1)",998,79,60,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,102,"Labour participation rate (1)",918,-20,45,28,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,103,"Threshold participation (1)",1026,-30,51,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"sLPeoAWP>0",1105,30,48,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,105,104,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1066,47)|
+1,106,103,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1013,17)|
+1,107,102,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(956,28)|
+1,108,101,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(995,134)|
+10,109,Reform delay y,1387,649,40,20,3,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,110,109,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1375,690)|
+10,111,Exogenous introduction period y,1136,715,66,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,112,111,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1243,728)|
+10,113,"Exogenous introduction period?",1132,769,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,114,113,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1240,757)|
+10,115,Introduction period for policy y,1360,745,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Energy
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Fossil electricity capacity GW,1130,225,47,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Renewable electricity capacity GW,1794,236,52,45,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,3,48,1132,101,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,4,6,1,4,0,0,22,0,0,0,-1--1--1,,1|(1131,171)|
+1,5,6,3,100,0,0,22,0,0,0,-1--1--1,,1|(1131,124)|
+11,6,48,1131,146,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,7,"Addition of fossil el capacity GW/y",1197,146,61,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,8,48,975,227,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,9,11,8,4,0,0,22,0,0,0,-1--1--1,,1|(1002,232)|
+1,10,11,1,100,0,0,22,0,0,0,-1--1--1,,1|(1057,232)|
+11,11,48,1026,232,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,12,"Discard of fossil el capacity GW/y",1026,275,51,35,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,13,48,1794,95,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,14,16,2,4,0,0,22,0,0,0,-1--1--1,,1|(1798,161)|
+1,15,16,13,100,0,0,22,0,0,0,-1--1--1,,1|(1798,111)|
+11,16,48,1798,125,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,17,"Addition of renewable el capacity GW/y",1877,125,71,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,18,48,1977,240,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,19,21,18,4,0,0,22,0,0,0,-1--1--1,,1|(1944,238)|
+1,20,21,2,100,0,0,22,0,0,0,-1--1--1,,1|(1878,238)|
+11,21,48,1916,238,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,22,"Discard of renewable el capacity GW/y",1916,275,68,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,1,11,1,0,0,0,0,128,0,-1--1--1,,1|(1069,209)|
+10,24,Life of fossil el capacity y,1086,351,46,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,24,12,1,0,0,0,0,128,0,-1--1--1,,1|(1089,295)|
+1,26,2,21,1,0,0,0,0,128,0,-1--1--1,,1|(1882,213)|
+10,27,Life of renewable el capacity y,1936,353,63,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,22,0,0,0,0,0,128,0,-1--1--1,,1|(1928,320)|
+10,29,Population Mp,857,-389,51,19,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,30,"GDP per person k$/p/y",651,-516,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,31,"Traditional per person use of electricity before EE MWh/p/y",881,-514,91,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,32,"Traditional per person use of fossil fuels for non-el-use before EE toe/p/y",653,-431,91,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,33,"Demand for electricity before NE TWh/y",1030,-337,70,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,34,"Demand for fossil fuel for non-el use before NE Mtoe/y",775,-296,80,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,35,30,31,1,0,0,0,0,128,0,-1--1--1,,1|(740,-529)|
+1,36,30,32,1,0,0,0,0,128,0,-1--1--1,,1|(636,-486)|
+1,37,29,33,0,0,0,0,0,128,0,-1--1--1,,1|(930,-367)|
+1,38,29,34,0,0,0,0,0,128,0,-1--1--1,,1|(824,-352)|
+1,39,32,34,0,0,0,0,0,128,0,-1--1--1,,1|(708,-368)|
+1,40,31,33,1,0,0,0,0,128,0,-1--1--1,,1|(982,-436)|
+10,41,"Extra ROC in energy productivity after 2022 1/y",1223,-506,54,54,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,42,"Extra energy productivity index 2022=1",1055,-436,57,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,43,48,1229,-428,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,44,46,42,4,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1136,-430)|
+1,45,46,43,100,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1195,-430)|
+11,46,48,1166,-430,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,47,"Increase in extra energy productivity index 1/y",1166,-389,75,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,48,42,46,1,0,0,0,0,128,0,-1--1--1,,1|(1098,-490)|
+1,49,41,46,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(1184,-454)|
+1,50,42,33,0,0,0,0,0,128,0,-1--1--1,,1|(1042,-385)|
+1,51,42,34,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(920,-369)|
+10,52,"4 TWh-el per Mtoe",897,636,44,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,53,"Electricity balance (1)",1365,74,36,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,54,11,135,1,0,0,0,0,128,0,-1--1--1,,1|(1051,109)|
+10,55,"Renewable capacity up-time kh/y",1622,171,55,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,56,"Electricity production TWh/y",1366,307,63,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,57,"Renewable electricity production TWh/y",1677,380,56,36,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,2,57,1,0,0,0,0,128,0,-1--1--1,,1|(1713,300)|
+10,59,"Fossil electricity production TWh/y",1245,378,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,60,"Nuclear electricity production TWh/y",1501,266,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,61,"Biomass energy Mtoe/y",1673,683,44,44,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,62,59,56,1,0,0,0,0,128,0,-1--1--1,,1|(1326,350)|
+10,63,"Nuclear capacity up-time kh/y",1558,368,54,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,64,Nuclear capacity GW,1466,404,41,41,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,65,63,60,0,0,0,0,0,128,0,-1--1--1,,1|(1533,323)|
+1,66,64,60,1,0,0,0,0,128,0,-1--1--1,,1|(1501,317)|
+1,67,1,59,1,0,0,0,0,128,0,-1--1--1,,1|(1143,288)|
+1,68,60,56,1,0,0,0,0,128,0,-1--1--1,,1|(1421,345)|
+1,69,57,56,1,0,0,0,0,128,0,-1--1--1,,1|(1456,461)|
+1,70,56,53,1,0,0,0,0,128,0,-1--1--1,,1|(1404,209)|
+10,71,"Desired supply of renewable electricity TWh/y",1502,-157,65,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,72,"Fossil capacity up-time kh/y",877,171,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,73,72,59,1,0,0,0,0,128,0,-1--1--1,,1|(939,402)|
+10,74,"CAPEX renewable el G$/y",2177,35,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"OPEX renewable el G$/y",2139,231,66,20,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,76,"OPEX renewable el $/kWh",2109,367,68,18,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,77,17,74,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2020,81)|
+1,78,7,205,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1771,88)|
+10,79,"Fraction new electrification in 2022 (1)",241,-228,68,28,8,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,80,"Demand for fossil fuel for non-el use Mtoe/y",833,-56,69,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,81,"Demand for electricity TWh/y",1049,-269,55,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,82,34,80,1,0,0,0,0,128,0,-1--1--1,,1|(813,-241)|
+1,83,33,81,0,0,0,0,0,128,0,-1--1--1,,1|(1037,-309)|
+10,84,"Extra energy productivity index in 2022 (1)",1057,-530,64,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,42,0,0,0,0,0,128,1,-1--1--1,,1|(1056,-492)|
+1,86,81,99,1,0,0,0,0,128,0,-1--1--1,,1|(1060,-243)|
+1,87,52,90,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(851,556)|
+10,88,Fossil el capacity in 1980 GW,1248,279,54,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,88,1,0,0,0,0,0,128,1,-1--1--1,,1|(1191,253)|
+10,90,"Fossil fuels for electricity Mtoe/y",799,464,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,91,90,131,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(726,363)|
+10,92,tCO2 per toe,601,241,43,11,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,93,"CAPEX fossil el $/W",2347,-53,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,94,"CAPEX renewable el $/W",2179,-57,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,95,93,205,0,0,0,0,0,128,0,-1--1--1,,1|(2348,-18)|
+1,96,94,74,0,0,0,0,0,128,0,-1--1--1,,1|(2178,-17)|
+1,97,57,75,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1897,308)|
+1,98,76,75,1,0,0,0,0,128,0,-1--1--1,,1|(2090,300)|
+10,99,"Demand for fossil electricity TWh/y",1065,-134,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,100,0,1409,-544,121,27,8,7,0,10,-1,0,0,0,-1--1--1,0-0-0,|18||0-0-255,0,0,0,0,0,0
+EE=Energy efficiency NE=New electrification
+1,101,57,114,1,0,0,0,0,128,0,-1--1--1,,1|(1564,180)|
+1,102,81,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1171,-168)|
+1,103,99,72,1,0,0,0,0,128,0,-1--1--1,,1|(900,7)|
+1,104,59,90,1,0,0,0,0,128,0,-1--1--1,,1|(1026,506)|
+10,105,"CAPEX renewable el in 1980 $/W",2098,-138,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,106,105,94,0,0,0,0,0,128,0,-1--1--1,,1|(2133,-102)|
+1,107,1,72,1,0,0,0,0,128,0,-1--1--1,,1|(990,134)|
+10,108,Renewable el capacity in 1980 GW,1788,329,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,109,108,2,0,0,0,0,0,128,1,-1--1--1,,1|(1789,302)|
+10,110,Time,1543,441,26,11,8,2,0,3,-1,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,111,"Renewable el fraction in 1980 (1)",1856,-261,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,112,81,71,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1247,-285)|
+1,113,1,135,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1100,131)|
+10,114,"Low-carbon el production TWh/y",1500,119,62,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,114,99,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1409,-55)|
+1,116,60,114,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1512,199)|
+10,117,"Fraction new electrification in 1980 (1)",250,-133,68,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,118,"Renewable el fraction in 2022 (1)",1857,-325,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,119,"OPEX fossil el $/kWh",2254,366,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,59,123,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1737,331)|
+10,121,"Cost of fossil electricity G$/y",2341,116,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,122,"Cost of electricity G$/y",2425,438,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,123,"OPEX fossil el G$/y",2231,284,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,"Normal increase in energy efficiency 1/y",824,-443,59,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,125,124,33,0,0,0,0,0,128,0,-1--1--1,,1|(931,-387)|
+1,126,124,34,0,0,0,0,0,128,0,-1--1--1,,1|(800,-373)|
+10,127,Time,907,-329,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,128,127,34,0,0,0,0,0,64,0,-1--1--1,,1|(874,-321)|
+10,129,"CO2 from energy and industry GtCO2/y",445,416,70,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,130,80,131,1,0,0,0,0,128,0,-1--1--1,,1|(812,116)|
+10,131,"Use of fossil fuels Mtoe/y",706,282,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,132,92,319,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(585,284)|
+10,133,"Fraction fossil plus nuclear electricity (1)",1321,-183,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,134,56,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1344,68)|
+10,135,"Desired fossil el capacity change GW/y",1236,50,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,136,135,7,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1240,115)|
+10,137,Fossil el cap construction time y,1282,-30,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,138,137,135,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1262,4)|
+10,139,"8 khours per year",996,48,47,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,140,Normal life of fossil el capacity y,1085,412,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,141,"FCUTeoLOFC (1)",935,342,51,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,142,"sFCUTeoLOFC>0",847,267,63,9,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,143,141,24,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(986,376)|
+1,144,140,24,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1085,388)|
+1,145,72,141,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(893,260)|
+1,146,139,153,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1066,1)|
+1,147,139,141,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(966,189)|
+1,148,142,141,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(879,294)|
+1,149,55,57,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1646,264)|
+10,150,Renewable el construction time y,1973,184,51,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,151,150,17,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1920,152)|
+1,152,21,17,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1901,195)|
+10,153,Desired fossil el capacity GW,1145,-49,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,99,153,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1099,-96)|
+1,155,153,135,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1185,-4)|
+10,156,Desired renewable el capacity change GW,1717,35,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,71,160,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1547,-111)|
+1,158,2,156,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1728,120)|
+1,159,156,17,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1831,61)|
+10,160,Desired renewable el capacity GW,1595,-66,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,161,160,156,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1650,-19)|
+1,162,55,160,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1608,55)|
+1,163,131,319,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(646,314)|
+1,164,59,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1281,104)|
+10,165,"Extra use of electricity per reduced use of non-el FF MWh/toe",562,-301,83,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,166,127,33,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(939,-330)|
+10,167,"Extra increase in demand for electricity from NE TWh/y",921,-200,80,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,168,"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y",710,-131,92,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,168,80,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(756,-80)|
+1,170,168,167,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(811,-163)|
+1,171,167,81,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(986,-235)|
+1,172,165,167,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(736,-251)|
+1,173,34,168,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(717,-212)|
+10,174,"Cost index for sun and wind capacity (1)",2321,-146,72,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,175,"Cost reduction per doubling of sun and wind capacity (1)",2112,-208,68,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,176,"Number of doublings in sun and wind capacity (1)",2395,-222,71,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,177,Accumulated sun and wind capacity from 1980 GW,2253,-375,67,43,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,178,Sun and wind capacity in 1980 GW,2257,-290,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,179,176,174,1,0,0,0,0,128,0,-1--1--1,,1|(2374,-173)|
+1,180,178,176,0,0,0,0,0,128,0,-1--1--1,,1|(2308,-264)|
+1,181,178,177,0,0,0,0,0,128,1,-1--1--1,,1|(2256,-313)|
+1,182,177,176,1,0,0,0,0,128,0,-1--1--1,,1|(2424,-314)|
+12,183,48,2052,-369,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,184,186,177,4,0,0,22,0,0,0,-1--1--1,,1|(2156,-365)|
+1,185,186,183,100,0,0,22,0,0,0,-1--1--1,,1|(2088,-365)|
+11,186,48,2120,-365,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,187,"Addition of sun and wind capacity GW/y",2120,-324,58,33,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,188,175,174,0,0,0,0,0,128,0,-1--1--1,,1|(2211,-178)|
+1,189,17,187,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1852,-86)|
+10,190,Cropland Mha,2503,429,56,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,191,Cropland Mha,2180,476,56,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,192,174,94,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(2287,-96)|
+10,193,"Cost of fossil fuel for non-el use G$/y",2181,514,57,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,194,"GDP G$/y",2721,649,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,195,"Cost of energy G$/y",2409,542,47,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,196,"Cost of energy as share of GDP (1)",2599,548,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,197,194,196,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2669,606)|
+1,198,60,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1413,47)|
+10,199,"Extra cost per reduced use of non-el FF $/toe",585,-49,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,200,"Cost of new electrification G$/y",636,27,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,201,199,200,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(606,-16)|
+1,202,168,200,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(673,-53)|
+10,203,"Cost of new electrification G$/y",2304,442,62,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,204,203,195,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2355,491)|
+10,205,"CAPEX fossil el G$/y",2351,30,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,206,"Cost of renewable electricity G$/y",2171,118,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,207,"Cost of CCS $/tCO2",475,98,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,208,"Cost of CCS G$/y",469,160,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,209,"Goal for fraction of CO2-sources with CCS (1)",290,176,61,61,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,210,"Fraction of CO2-sources with CCS in 2022 (1)",196,292,67,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,211,207,208,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(472,126)|
+10,212,"Cost of CCS G$/y",2187,456,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,213,212,195,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2291,495)|
+10,214,"MEMO Fraction of non-el fossil fuels use in hard to abate sectors HTAS (1)",320,-28,103,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+10,215,"Renewable heat production Mtoe/y",1394,653,60,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,216,61,215,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1544,703)|
+10,217,"Green hydrogen Mtoe/y",1531,649,52,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,218,217,215,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1473,659)|
+10,219,"Fraction of renewable electricity to hydrogen (1)",1731,535,55,55,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,220,"kWh-el per kgH2",1565,551,56,11,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,221,toe per tH2,1464,598,37,11,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,222,"Green hydrogen MtH2/y",1609,604,52,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,223,57,222,1,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1675,467)|
+1,224,222,217,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1595,635)|
+1,225,221,217,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1486,615)|
+1,226,220,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1579,568)|
+1,227,219,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1669,570)|
+1,228,119,123,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2244,331)|
+1,229,75,206,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2138,171)|
+1,230,74,206,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2174,69)|
+1,231,123,121,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2256,195)|
+1,232,205,121,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2346,66)|
+1,233,206,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2320,245)|
+1,234,121,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2402,255)|
+1,235,122,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2418,483)|
+1,236,193,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2293,527)|
+1,237,195,196,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2492,544)|
+10,238,"Cost of nuclear electricity G$/y",2474,256,47,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,239,238,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2476,346)|
+1,240,60,238,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1986,261)|
+10,241,"Cost of nuclear el $/kWh",2444,174,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,242,241,238,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2453,201)|
+10,243,"Traditional cost of energy G$/y",2398,760,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,244,"Demand for electricity before NE TWh/y",1869,707,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,245,"Demand for fossil fuel for non-el use before NE Mtoe/y",1852,643,85,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,246,"Traditional cost of electricity $/kWh",1876,777,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,247,"Traditional cost of fossil fuel for non-el use $/toe",1872,554,75,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,248,246,255,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1948,766)|
+1,249,247,256,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1943,587)|
+1,250,244,255,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1947,730)|
+1,251,245,256,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1955,638)|
+1,252,247,193,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2028,533)|
+10,253,"Demand for fossil fuel for non-el use Mtoe/y",1966,485,74,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,254,253,193,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2075,499)|
+10,255,"Traditional cost of electricity G$/y",2029,755,52,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,256,"Traditional cost of fossil fuel for non-el use G$/y",2045,634,58,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,257,256,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2216,695)|
+1,258,255,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2203,756)|
+10,259,"Cost of grid G$/y",2273,577,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,260,"Transmission cost $/kWh",2177,614,45,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,261,260,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2217,601)|
+1,262,259,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2335,561)|
+10,263,"Electricity production TWh/y",2116,561,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,264,263,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2194,568)|
+1,265,260,269,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(2219,643)|
+10,266,"Traditional cost of energy as share of GDP (1)",2598,754,81,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,267,243,266,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2479,757)|
+1,268,194,266,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2673,689)|
+10,269,"Traditional grid cost G$/y",2264,673,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,270,244,269,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2073,689)|
+1,271,269,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2324,712)|
+10,272,"Adjustment factor to make costs match 1980-2022 (1)",2235,795,88,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,273,272,256,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(2151,724)|
+1,274,272,255,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(2120,772)|
+10,275,"Ratio of Energy cost to Trad energy cost (1)",2408,633,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,276,243,275,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2401,703)|
+1,277,195,275,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2408,580)|
+10,278,"Extra cost of Energy Turnaround as share of GDP (1)",2586,643,73,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,279,243,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2478,709)|
+1,280,194,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2674,647)|
+1,281,195,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2482,584)|
+10,282,Time,2588,704,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,283,282,278,0,0,0,0,0,64,0,-1--1--1,,1|(2587,688)|
+10,284,"ENERGY USE Mtoe/y",1247,489,53,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,285,80,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1035,210)|
+1,286,56,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1310,392)|
+1,287,52,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1064,565)|
+12,288,0,2918,-103,366,330,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Energy
+10,289,"IIASA Renewable energy production EJ/yr",1231,577,71,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,290,"Mtoe per EJ - calorific equivalent",770,710,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,291,"TWh-heat per EJ - calorific equivalent",1031,720,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,292,"IIASA Fossil energy production EJ/yr",666,592,62,35,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,293,290,292,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(729,664)|
+10,294,"TWh-el per EJ - engineering equivalent",1139,645,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,295,291,294,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1078,686)|
+10,296,"Efficiency of fossil power plant TWh-el/TWh-heat",1217,718,80,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,297,296,294,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1183,686)|
+1,298,294,289,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1171,620)|
+1,299,131,292,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(650,471)|
+1,300,57,289,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1484,554)|
+1,301,290,52,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(826,676)|
+1,302,294,52,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1012,640)|
+1,303,215,284,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1325,576)|
+1,304,215,289,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1329,622)|
+1,305,290,289,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(987,646)|
+10,306,Time,570,190,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,307,306,92,0,0,0,0,1,64,0,192-192-192,|12||0-0-0,1|(581,209)|
+10,308,"ROC in tCO2 per toe 1/y",648,170,58,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,309,308,92,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(625,203)|
+10,310,"CO2 from non-fossil industrial processes GtCO2/y",367,539,66,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,311,"GDP per person k$/p/y",320,711,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,312,"Non-fossil CO2 per person tCO2/p/y",343,623,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,313,Population Mp,202,555,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,314,313,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(272,548)|
+1,315,312,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(351,592)|
+1,316,311,312,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(329,673)|
+10,317,"Max non-fossil CO2 per person tCO2/p/y",519,632,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,318,317,312,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(436,627)|
+10,319,"CO2 from energy production GtCO2/y",563,349,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,320,"CO2 emissions per person tCO2/y",550,491,67,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,321,Population Mp,814,566,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,322,321,320,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(702,534)|
+1,323,129,320,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(491,449)|
+1,324,319,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(510,379)|
+1,325,310,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(404,478)|
+10,326,"Desired renewable electricity share (1)",1663,-247,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,327,"Goal for renewable el fraction (1)",1689,-358,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,328,327,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1673,-290)|
+1,329,118,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1766,-288)|
+1,330,111,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1762,-254)|
+1,331,326,71,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1597,-209)|
+12,332,0,346,-478,154,90,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|16||255-0-255,0,0,0,0,0,0
+TO SIMULATE ENERGY TURNAROUND: Adjust goals for renewable el fraction, new electrification, other point sources with CCS. You may want to also change other pink policy handles
+10,333,"Fraction new electrification (1)",469,-170,54,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,334,"Goal for fraction new electrification (1)",371,-288,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,335,334,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(426,-221)|
+1,336,117,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(359,-150)|
+1,337,79,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(355,-198)|
+1,338,333,168,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(563,-154)|
+10,339,"Energy use per person toe/p/y",977,540,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,340,321,339,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(892,553)|
+1,341,284,339,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1116,513)|
+1,342,110,64,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1517,428)|
+10,343,"Fraction of CO2-sources with CCS (1)",326,355,59,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,344,210,343,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(255,321)|
+1,345,209,343,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(309,274)|
+1,346,343,319,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(433,352)|
+1,347,343,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(344,440)|
+10,348,Introduction period for policy y,216,415,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,349,348,343,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(255,392)|
+10,350,Introduction period for policy y,424,-81,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,351,350,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(442,-119)|
+10,352,Introduction period for policy y,1696,-135,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,353,352,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1681,-184)|
+10,354,"Installed CCS capacity GtCO2/y",446,228,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,355,310,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(405,385)|
+1,356,343,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(385,292)|
+1,357,319,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(509,293)|
+1,358,354,208,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(456,196)|
+10,359,"Cost of air capture G$/y",2572,456,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,360,359,195,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2496,495)|
+///---\\\
+:GRAPH 1._Main_trends
+:TITLE 1. Main trends - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 2.4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequality (1)"
+:Y-MIN 0
+:Y-MAX 1.6
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Social tension (1)"
+:Y-MIN 0
+
+:GRAPH 2._Human_footprint
+:TITLE 2. Human footprint - World 1980 to 2020
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Population below 15 k$/p/y Mp"
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "ENERGY USE Mtoe/y"
+:Y-MIN 0
+:Y-MAX 20000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR "GHG EMISSIONS GtCO2e/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR "Govmnt gross income (as share of NI)"
+:Y-MIN 0
+:Y-MAX 0.4
+:LINE-WIDTH 2
+
+:GRAPH 3._Consumption
+:TITLE 3. Consumption  - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions per person tCO2/y"
+:Y-MIN 0
+:Y-MAX 6
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Energy use per person toe/p/y"
+:Y-MIN 0
+:Y-MAX 4
+:SCALE
+:VAR Forestry land Mha
+:Y-MIN 0
+:Y-MAX 2000
+:LINE-WIDTH 2
+
+:GRAPH 4._Wellbeing
+:TITLE 4. Wellbeing - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Average wellbeing from disposable income (1)"
+:Y-MIN 0
+:Y-MAX 8
+:LINE-WIDTH 2
+:VAR "Average wellbeing from public spending (1)"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 2.4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Average wellbeing from inequality (1)"
+:Y-MIN 0
+:Y-MAX 1.2
+:VAR "Average wellbeing from global warming (1)"
+:Y-MIN 0
+:VAR "Average wellbeing from progress (1)"
+:Y-MIN 0
+
+:GRAPH 5._Turnarounds
+:TITLE 5. Turnaround indicators - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Fraction below 15 k$/p/y (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequality (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "Birth rate 1/y"
+:Y-MIN 0
+:Y-MAX 0.04
+:LINE-WIDTH 2
+:SCALE
+:VAR "FOOD FOOTPRINT INDEX (1980=1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+
+:GRAPH 4-year_cycle
+:TITLE 4-year cycle in inventories
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR Inventory coverage y
+:Y-MIN 0
+:Y-MAX 0.5
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.05
+:Y-MAX 0.05
+:LINE-WIDTH 2
+:SCALE
+:VAR "Hours worked - index (1)"
+:Y-MIN 0.9
+:Y-MAX 1.1
+:LINE-WIDTH 2
+:VAR "Delivery delay - index (1)"
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 100000
+:SCALE
+:VAR "Price Index $/1980$"
+:Y-MIN 0
+:Y-MAX 4
+
+:GRAPH 10-year_wave
+:TITLE 10-year wave in labour market
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 0.8
+:LINE-WIDTH 2
+:SCALE
+:VAR "Investment share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Savings share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+:LINE-WIDTH 1
+:SCALE
+:VAR "Labor particiption rate (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Capital labour ratio k$/j"
+:Y-MIN 0
+:Y-MAX 200
+
+:GRAPH Economic_development__1980_to_2020
+:TITLE Economic development
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 120000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 24
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 1
+:SCALE
+:VAR "Corporate borrowing cost 1/y"
+:Y-MIN 0
+:Y-MAX 0.1
+:SCALE
+:VAR "Govmnt share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH Growth_1980-2020
+:TITLE Economic growth
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 120000
+:LINE-WIDTH 2
+:VAR "Govmnt spending G$/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Workforce M-ftp"
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 30
+:VAR "Consumption per person G$/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+
+:GRAPH Population_and_workforce
+:TITLE Population and workforce - World
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Aged 20-pension age Mp"
+:Y-MIN 0
+:Y-MAX 2000
+:LINE-WIDTH 2
+:VAR Population Mp
+:LINE-WIDTH 2
+:VAR "Workforce M-ftp"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Dependency ratio p/p"
+:Y-MIN 0
+:Y-MAX 6
+:SCALE
+:VAR Life expectancy y
+:Y-MIN 0
+:Y-MAX 100
+:SCALE
+:VAR Observed fertility 1
+:Y-MIN 0
+:Y-MAX 6
+
+:GRAPH New_Labor_market:_10-year_wave
+:TITLE New Labor market: 10-year wave - World
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR Workforce Mp
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Capacity addition PIS G$/y"
+:Y-MIN 0
+:Y-MAX 16000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Labour participation rate (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 1
+:SCALE
+:VAR "Optimal capital labour ratio kcu/ftj"
+:Y-MIN 0
+:Y-MAX 400
+:LINE-WIDTH 1
+
+:GRAPH Distribution_of_national_income
+:TITLE Distribution of national income
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Consumption share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:VAR "Savings share of GDP (1)"
+:LINE-WIDTH 2
+:VAR "Govmnt share of GDP (1)"
+:LINE-WIDTH 2
+:SCALE
+:VAR "National income G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:SCALE
+:VAR Govmnt debt burden y
+:Y-MIN 0
+:Y-MAX 2
+:VAR Worker debt burden y
+
+:GRAPH Cashflows_as_share_of_NI
+:TITLE Cashflows as share of NI
+:SCALE
+:VAR "WCF/NI (1)"
+:Y-MIN 0
+:Y-MAX 1
+:VAR "GCF/NI (1)"
+:VAR "OCF/NI (1)"
+:VAR "Sales tax/NI"
+
+:GRAPH Output:_Long_term_growth
+:TITLE Output: Long term growth
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Investment share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.6
+:VAR "Savings share of GDP (1)"
+:SCALE
+:VAR "Output growth rate 1/y"
+:Y-MIN -0.1
+:Y-MAX 0.1
+
+:GRAPH Inventory:_4-year_cycle
+:TITLE Inventory: 4-year cycle
+:X-DIV 15
+:X-MIN 1980
+:X-MAX 2040
+:SCALE
+:VAR "Pink noise in sales (1)"
+:Y-MIN 0
+:Y-MAX 2
+:SCALE
+:VAR "Perceived relative inventory (1)"
+:Y-MIN 0
+:Y-MAX 1.5
+:SCALE
+:VAR "Hours worked - index (1)"
+:Y-MIN 0
+:Y-MAX 1.25
+:SCALE
+:VAR "Delivery delay - index (1)"
+:Y-MIN 0.9
+:Y-MAX 1.1
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.1
+:Y-MAX 0.1
+:SCALE
+:VAR "Price Index (1980=1)"
+:Y-MIN 0
+:Y-MAX 4
+
+:GRAPH Food_demand_and_supply
+:TITLE Food demand and supply
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:VAR "Crop demand Mt-crop/y"
+:SCALE
+:VAR "Demand for red meat Mt-red-meat/y"
+:Y-MIN 0
+:Y-MAX 400
+:LINE-WIDTH 2
+:VAR "Red meat from grazing land Mt-red-meat/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Red meat supply per person kg-red-meat/p/y"
+:Y-MIN 0
+:Y-MAX 80
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1.2
+
+:GRAPH Food_and_land_use
+:TITLE Food and land use
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:SCALE
+:VAR Total forest area Mha
+:Y-MIN 0
+:Y-MAX 4000
+:LINE-WIDTH 2
+:VAR Cropland Mha
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1.2
+:SCALE
+:VAR "Fraction regenerative agriculture (1)"
+:Y-MIN 0
+:Y-MAX 1
+
+:GRAPH Financial_cycle
+:TITLE Financial cycle
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "Central bank signal rate 1/y"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:VAR "10-yr govmnt interest rate 1/y"
+:LINE-WIDTH 2
+:VAR "Corporate borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Worker borrowing cost 1/y"
+:SCALE
+:VAR Govmnt debt burden y
+:Y-MIN 0
+:Y-MAX 1
+:VAR Worker debt burden y
+:LINE-WIDTH 2
+
+:GRAPH Finance:_Interest_rates
+:TITLE Finance: Interest rates
+:X-DIV 4
+:X-MIN 2010
+:X-MAX 2030
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:VAR "Corporate borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Central bank signal rate 1/y"
+:LINE-WIDTH 2
+:VAR "Govmnt borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Worker borrowing cost 1/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.05
+:Y-MAX 0.05
+
+:GRAPH Climate
+:TITLE Climate
+:X-DIV 6
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:Y-MAX 44
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR CO2 concentration in atm ppm
+:Y-MIN 0
+:Y-MAX 600
+:LINE-WIDTH 2
+:SCALE
+:VAR "Man-made forcing W/m2"
+:Y-MIN 0
+:Y-MAX 8
+:VAR "Water vapour feedback W/m2"
+:SCALE
+:VAR "Ice and snow cover excl G&A Mkm2"
+:Y-MIN 0
+:Y-MAX 20
+
+:GRAPH C_G_S
+:TITLE C G S
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Consumption rate (1)"
+:Y-MIN 0
+:Y-MAX 1
+:VAR "Savings rate (1)"
+:VAR "Government tax rate (1)"
+:SCALE
+:VAR "Total demand G$/y"
+:Y-MIN 0
+:Y-MAX 320000
+:VAR "National income G$/y"
+
+:GRAPH Public_sector:_Services_and_tech_advance
+:TITLE Public sector: Services and tech advance
+:SCALE
+:VAR Public infrastructure G$
+:Y-MIN 0
+:SCALE
+:VAR "Public services per person G$/p/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Rate of technological advance 1/y"
+:Y-MIN -0.04
+:Y-MAX 0.04
+:SCALE
+:VAR "CO2 per GDP tCO2/k$"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fraction of workforce in public sector (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH Other_performance_indicators
+:TITLE Other performance indicators
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "RATE OF GROWTH IN GDP PER PERSON 1/y"
+:Y-MIN 0
+:Y-MAX 0.04
+:LINE-WIDTH 2
+:SCALE
+:VAR "Participation (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN -0.1
+:Y-MAX 0.1
+:SCALE
+:VAR "Population below 15 k$/p/y Mp"
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+
+:GRAPH Energy
+:TITLE Energy
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "ENERGY USE Mtoe/y"
+:Y-MIN 0
+:Y-MAX 24000
+:LINE-WIDTH 2
+:VAR "Total use of fossil fuels Mtoe/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Electricity production TWh/y"
+:Y-MIN 0
+:Y-MAX 80000
+:LINE-WIDTH 2
+:VAR "Renewable electricity production TWh/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions from fossil fuels GtCO2/y"
+:Y-MIN 0
+:Y-MAX 44
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MIN 0
+:Y-MAX 6000
+
+:GRAPH Fertility_vs_GDPpp
+:TITLE Fertility vs GDPpp
+:X-AXIS "Effective GDP per person k$/p/y"
+:SCALE
+:VAR Observed fertility 1
+
+:GRAPH 1._State_of_affairs
+:TITLE 1. State of affairs - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 80
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequity Index (1)"
+:Y-MIN -1
+:Y-MAX 3
+:SCALE
+:VAR Govmnt spending as share of GDP
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH 2._Ecological_damage
+:TITLE 2. Ecological damage - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Loss of forest land Mha/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Loss of cropland Mha/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR Ice and snow cover Mha
+:Y-MIN 0
+:Y-MAX 3000
+:VAR Old growth forest area Mha 1
+
+:GRAPH 3._Human_footprint
+:TITLE 3. Human footprint - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "CO2 emissions from fossil fuels GtCO2/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR Cropland Mha
+:Y-MIN 0
+:Y-MAX 3000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Total use of fossil fuels Mtoe/y"
+:Y-MIN 0
+:Y-MAX 12000
+
+:GRAPH 4._Average_wellbeing
+:TITLE 4. Average wellbeing - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Social tension (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Labour participation rate (1)"
+:Y-MIN 0
+:Y-MAX 2
+:SCALE
+:VAR "Cost of food G$/y"
+:Y-MAX 24000
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MAX 6000
+
+:GRAPH CLR_vs_GDPpp
+:TITLE CLR vs GDPpp
+:X-AXIS "GDP per person k$/p/y"
+:X-DIV 10
+:X-MIN 0
+:X-MAX 100
+:SCALE
+:VAR "Embedded CLR k$/j"
+:Y-MIN 0
+:L<%^E!@
+1:E4A-220501 GL.vdfx
+9:E4A-220501 GL
+15:0,0,0,0,0,0
+19:75,0
+27:0,
+34:0,
+4:Time
+5:10-yr govmnt interest rate 1/y
+35:Date
+36:YYYY-MM-DD
+37:2000
+38:1
+39:1
+40:0
+41:0
+42:0
+72:0
+73:0
+76:0
+77:0
+78:0
+79:0
+80:0
+81:0
+24:1980
+25:2100
+26:2100
+75:
+43:

--- a/vensim_source/mov220501-18 E4A-global jr TLTL.mdl
+++ b/vensim_source/mov220501-18 E4A-global jr TLTL.mdl
@@ -1,0 +1,8664 @@
+{UTF-8}
+"Food sector productivity index (1980=1)"=
+	EXP("ROC in food sector productivity 1/y" * ( Time - 1980))
+	*
+	IF THEN ELSE(Time>2022, EXP( "Extra ROC in food sector productivity from 2022 1/y"* \
+		( Time - 2022)), 1)
+	~	
+	~		|
+
+"ROC in food sector productivity 1/y"=
+	0.002
+	~	1/y [0,0.02,0.001]
+	~	0.002 chosen to fit SSP2 4-5
+	|
+
+"Extra ROC in food sector productivity from 2022 1/y"=
+	0
+	~	
+	~	0 in TLTL and 0.01 in GL
+	|
+
+"Extra rate of decline in CH4 pr kg crop after 2022 1/y"=
+	0
+	~	1/y [0,0.02,0.01]
+	~	0 in TLTL, 0.01 in GL
+	|
+
+"Extra rate of decline in N2O per kg fertilizer from 2022 1/y"=
+	0
+	~	1/y [0,0.02,0.01]
+	~	0 in TLTL, 0.01 in GL
+	|
+
+kg N2O emission per kg fertiliser=
+	kg N2O per kg fertilizer in 1980
+	*  
+	EXP(-("Rate of decline in N2O per kg fertiliser 1/y")
+	 * ( Time - 1980))
+	*IF THEN ELSE(Time>2022, EXP(-("Extra rate of decline in N2O per kg fertilizer from 2022 1/y"\
+		)
+	 * ( Time - 2022)), 1)
+	~	1
+	~		|
+
+kg CH4 emission per kg crop=
+	kg CH4 per kg crop in 1980 
+	*  
+	EXP(-("Rate of decline in CH4 per kg crop 1/y")
+	 * ( Time - 1980))
+	*IF THEN ELSE(Time>2022, EXP(-("Extra rate of decline in CH4 pr kg crop after 2022 1/y"\
+		)
+	 * ( Time - 2022)), 1)
+	~	1
+	~		|
+
+"Rate of decline in N2O per kg fertiliser 1/y"=
+	0.01
+	~	1/y [0,0.02,0.01]
+	~	211102 Should be 0.008 to fit observed time series in N2O emissions and \
+		fertilizer use
+	|
+
+"Margin in 1980 (1)"=
+	0.25
+	~	1
+	~		|
+
+"Recent sales Gu/y"=
+	SMOOTHI("Deliveries Gu/y", Sales averaging time y, "Demand in 1980 G$/y" )
+	~	Gu/y
+	~		|
+
+"National income G$/y"=
+	"Sales G$/y"
+	~	G$/y
+	~		|
+
+"Sales G$/y"=
+	"Deliveries Gu/y" * "Price per unit $/u"
+	~	
+	~		|
+
+"CO2 per GDP (kgCO2/$)"=
+	( "CO2 emissions GtCO2/y" / "GDP G$/y" ) * 1000
+	~	tCO2/$
+	~		|
+
+"Price per unit $/u"=
+	"Cost per unit in 1980 $/u" * ( 1 + "Margin in 1980 (1)" )
+	~	$/u
+	~		|
+
+"Deliveries Gu/y"=
+	( ( "Effective purchasing power G$/y" / "Price per unit $/u" ) / ( "Delivery delay - index (1)"\
+		 / DDI in 1980 y ) )
+	*
+	IF THEN ELSE ( Time > 1984, "Pink noise in sales (1)", 1)
+	~	Gu/y
+	~		|
+
+Time to implement new taxes y=
+	5
+	~	y [0,10,1]
+	~		|
+
+"Owner taxes G$/y"=
+	"Income tax owners (1)"
+	+
+	"Extra taxes from 2022 G$/y" * "Fraction of extra taxes paid by owners (1)"
+	~	G$/y
+	~		|
+
+"Extra taxes from 2022 G$/y"=
+	SMOOTH("Goal for extra taxes from 2022 G$/y", Time to implement new taxes y)
+	~	G$/y
+	~		|
+
+"Owner operating income after tax G$/y"=
+	"Owner income G$/y" - "Owner taxes G$/y"
+	~	G$/y
+	~		|
+
+"Fraction of govmnt budget to workers (1)"=
+	SMOOTH("Goal for fraction of govmnt budget to workers (1)", Time to implement new taxes y\
+		)
+	~	(1)
+	~		|
+
+"Govmnt gross income G$/y"=
+	"Worker taxes G$/y" + "Owner taxes G$/y" + "Sales tax workers G$/y" + "Sales tax owners G$/y"
+	+ "Income from commons from 2022 G$/y"
+	~	G$/y
+	~		|
+
+"Transfer payments G$/y"=
+	"Govmnt gross income G$/y" * "Fraction of govmnt budget to workers (1)"
+	~	G$/y
+	~		|
+
+"Owner tax rate (1)"=
+	"Owner taxes G$/y" / "Owner income G$/y"
+	~	1
+	~		|
+
+"Worker taxes G$/y"=
+	"Income tax workers (1)"
+	+
+	"Extra taxes from 2022 G$/y" * ( 1 - "Fraction of extra taxes paid by owners (1)" )
+	~	G$/y
+	~		|
+
+"Govmnt gross income (as share of NI)"=
+	"Govmnt gross income G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Fraction transferred in 1980 (1)"=
+	0.3
+	~	
+	~	Logic: 0.3 is value for US 1980 to 2020 (8% of GDP transferred of budget \
+		28% of GDP = 0.29. Ca 0.5 in Norway
+	|
+
+"CO2 emissions GtCO2/y"=
+	"CO2 from energy and industry GtCO2/y" + "CO2 emissions from LULUC GtCO2/y" - "Direct air capture of CO2 GtCO2/y"
+	~	GtCO2/y
+	~		|
+
+"Goal for fraction of govmnt budget to workers (1)"=
+	"Fraction transferred in 1980 (1)"
+	+
+	IF THEN ELSE(Time>2022, "Extra transfer of govmnt budget to workers (1)", 0)
+	~	1
+	~		|
+
+"Direct air capture of CO2 GtCO2/y"=
+	IF THEN ELSE(Time>2022,
+	 RAMP(("Direct air capture of CO2 in 2100 GtCO2/y" ) / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	, 0 )
+	~	Gt/y
+	~		|
+
+"Cost of energy G$/y"=
+	"Cost of fossil fuel for non-el use G$/y" + "Cost of electricity G$/y" + "Cost of grid G$/y"\
+		 + "Cost of new electrification G$/y"
+	 + "Cost of CCS G$/y"
+	+ "Cost of air capture G$/y"
+	~	G$/y
+	~		|
+
+"Income from commons from 2022 G$/y"=
+	"National income G$/y"
+	*
+	IF THEN ELSE(Time>2022, 
+	RAMP( "Goal for extra income from commons (share of NI)" / Introduction period for policy y
+	, 2022, 2020 + Introduction period for policy y)
+	, 0)
+	~	G$/y
+	~		|
+
+"Cost of air capture G$/y"=
+	"Direct air capture of CO2 GtCO2/y" * "Cost of CCS $/tCO2"
+	~	G$/y
+	~		|
+
+"Direct air capture of CO2 in 2100 GtCO2/y"=
+	0
+	~	GtCO2/y [0,15,1]
+	~	0 in TLTL and 12 in GL (increased from 8 on 220427)
+		8 GtCO2/y is about the same amount as is annually absorbed in the world's \
+		forestry land in 2100, and thus a conceivable potential in BECCS - but \
+		wildly unrealistic, unless one discovers other ways of binding CO2. But 12 \
+		is necessary to hold warming below 2 deg C
+	|
+
+"Installed CCS capacity GtCO2/y"=
+	"Fraction of CO2-sources with CCS (1)" *
+	( "CO2 from non-fossil industrial processes GtCO2/y" +"CO2 from energy production GtCO2/y"\
+		 ) /
+	(1 - "Fraction of CO2-sources with CCS (1)" )
+	~	GtCO2/y
+	~		|
+
+"Cost of CCS G$/y"=
+	"Installed CCS capacity GtCO2/y"
+	*
+	"Cost of CCS $/tCO2"
+	~	G$/y
+	~		|
+
+"Rate of technological advance 1/y"=
+	( "Domestic rate of technological advance 1/y" + 0 )
+	*
+	"Reduction in ROTA from inequality 1/y"
+	+
+	"Imported ROTA 1/y"
+	~	1/y
+	~		|
+
+"Imported ROTA 1/y"=
+	IF THEN ELSE(Time>2022,
+	MAX(0, 
+	"Max imported ROTA from 2022 1/y" * 
+	( 1 - 1 * ( "GDP per person k$/p/y" / "GDPpp of technology leader k$/p/y" - 1 ))
+	), 
+	0)
+	~	1
+	~		|
+
+"Domestic rate of technological advance 1/y"=
+	( "Domestic ROTA in 1980 1/y" + (IF THEN ELSE(Time>2022, "Extra domestic ROTA from 2022 1/y"\
+		, 0))
+	* 
+	( 1 +  "sSCeoROTA>0" * ( "State capacity (fraction of GDP)" / "State capacity in 1980 (fraction of GDP)"
+	 - 1 )))
+	~	1/y
+	~		|
+
+"Extra pension tax from 2022 (share of NI)"=
+	0
+	~	1 [0,0.02,0.01]
+	~	0 in TLTL and 0.02 in GL
+	|
+
+"Average wellbeing from progress (1)"=
+	( 1 + "sROPeoAW>0" * ( "Observed rate of progress 1/y" - "Threshold progress rate 1/y"\
+		 ))
+	*
+	"Wellbeing effect of participation (1)"
+	~	1
+	~		|
+
+"AVERAGE WELLBEING INDEX (1)"=
+	( 0.5 * "Average wellbeing from disposable income (1)"
+	+
+	0.5 * "Average wellbeing from public spending (1)")
+	* "Average wellbeing from inequality (1)"
+	* "Average wellbeing from global warming (1)"
+	* "Average wellbeing from progress (1)"
+	~	1
+	~		|
+
+"Extra general tax from 2022 G$/y"=
+	IF THEN ELSE(Time>2022, "Extra general tax rate from 2022 (1)" + "Extra empowerment tax from 2022 (share of NI)"\
+		 + "Extra pension tax from 2022 (share of NI)", 0)
+	*
+	"National income G$/y"
+	~	1
+	~		|
+
+"Extra empowerment tax from 2022 (share of NI)"=
+	0
+	~	1 [0,0.02,0.01]
+	~	0 in TLTL and 0.02 in GL
+	|
+
+"Worker tax rate (1)"=
+	"Worker taxes G$/y" / "Worker income G$/y"
+	~	1
+	~		|
+
+"Fraction new electrification (1)"=
+	"Fraction new electrification in 1980 (1)"
+	+
+	RAMP(("Fraction new electrification in 2022 (1)" - "Fraction new electrification in 1980 (1)"\
+		 ) / 42, 1980, 2022)
+	+
+	RAMP(( "Goal for fraction new electrification (1)" - "Fraction new electrification in 2022 (1)"\
+		 ) / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction regenerative agriculture (1)"=
+	RAMP( "Goal for fraction regenerative agriculture (1)" / Introduction period for policy y
+	, 2022, 2020 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Extra fertility reduction (1)"=
+	RAMP( "Goal for extra fertility reduction (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction new red meat (1)"=
+	RAMP( "Goal for fraction new red meat (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y)
+	~	1
+	~		|
+
+"Fraction of CO2-sources with CCS (1)"=
+	"Fraction of CO2-sources with CCS in 2022 (1)"
+	+
+	RAMP(( "Goal for fraction of CO2-sources with CCS (1)" - "Fraction of CO2-sources with CCS in 2022 (1)"\
+		 ) / Introduction period for policy y
+	, 2022 , 2022 + Introduction period for policy y)
+	~	
+	~		|
+
+"Desired renewable electricity share (1)"=
+	"Renewable el fraction in 1980 (1)"
+	+
+	RAMP(( "Renewable el fraction in 2022 (1)" - "Renewable el fraction in 1980 (1)" ) /\
+		 42, 1980, 2022)
+	+
+	RAMP(( "Goal for renewable el fraction (1)" - "Renewable el fraction in 2022 (1)" ) \
+		/ Introduction period for policy y, 2022, 2022 + Introduction period for policy y )
+	~	1
+	~		|
+
+"Crop waste reduction (1)"=
+	RAMP( "Goal for crop waste reduction (1)" / Introduction period for policy y
+	, 2022, 2022 + Introduction period for policy y )
+	~	1
+	~		|
+
+Introduction period for policy y=
+	IF THEN ELSE("Exogenous introduction period?">0, Exogenous introduction period y, Reform delay y\
+		)
+	~	y
+	~		|
+
+"Extra normal LPR from 2022 (1)"=
+	RAMP("Goal for extra normal LPR (1)" / Introduction period for policy y, 2022, 2022 \
+		+ Introduction period for policy y)
+	~	1
+	~		|
+
+Extra pension age y=
+	RAMP(( Goal for extra pension age y - Extra pension age in 2022 y ) / Introduction period for policy y\
+		, 2022, 22022 + Introduction period for policy y)
+	~	1/y
+	~		|
+
+Reform delay y=
+	SMOOTH(Indicated reform delay y, Time to change reform delay y)
+	~	y
+	~		|
+
+Exogenous introduction period y=
+	30
+	~	y [0,70,10]
+	~		|
+
+"Exogenous introduction period?"=
+	0
+	~	 [0,1,1]
+	~		|
+
+"10-yr loop delay y"=
+	2.3
+	~	y [2,3,0.1]
+	~	was 3*0.85=2.55, so 2.6
+	|
+
+Unemployment perception time y=
+	"10-yr loop delay y" / 3
+	~	y [0,2,0.05]
+	~	was 2, so 1, so 0.8, so 0.7, so 0.9,so 0.8
+	|
+
+"Hiring/firing delay y"=
+	"10-yr loop delay y" / 3
+	~	 [0,2,0.1]
+	~	was 1, so 0.8, so 0.7, so 0.9, so 0.8,
+	|
+
+Time to change tooling y=
+	"10-yr loop delay y"/3
+	~	y [0,1,0.01]
+	~	was 0.8, so 0.7, so 0.9, so 0.8,
+	|
+
+"Cancellation of debt G$/y"=
+	PULSE( 2022, 1)* Govmnt debt G$ * "Fraction of govmnt debt cancelled in 2022 1/y"
+	~	G$/y
+	~		|
+
+"OWeoLOC (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoLOC<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"CO2 from non-fossil industrial processes GtCO2/y"=
+	( "Non-fossil CO2 per person tCO2/p/y" / 1000 )
+	* Population Mp
+	* ( 1 - "Fraction of CO2-sources with CCS (1)")
+	~	GtCO2/y
+	~		|
+
+Life of capacity PIS y=
+	( Life of capacity PIS in 1980 y * "OWeoLOC (1)" ) / "Excess demand effect on life of capacity (1)"
+	~	y
+	~		|
+
+Life of capacity PUS in 1980 y=
+	15 * "OWeoLOC (1)"
+	~	y
+	~		|
+
+"sOWeoLOC<0"=
+	-0.1
+	~	1 [-1,0,0.01]
+	~	220323 Set to -0.1 to get life of capacity reduced from 15 y in 2022 (+1.3 \
+		deg C) to 13 y in 2100 at +2.5 deg C.
+	|
+
+"CO2 from energy production GtCO2/y"=
+	"Use of fossil fuels Mtoe/y" * ( tCO2 per toe / 1000 )
+	* 
+	( 1 - "Fraction of CO2-sources with CCS (1)" )
+	~	GtCO2/y
+	~		|
+
+"Cost of TAs in 2022 G$/y"=
+	9145
+	~	G$/y
+	~		|
+
+"Extra taxes for TAs from 2022 G$/y"=
+	IF THEN ELSE(Time>2022, "Extra cost of TAs from 2022 G$/y" * "Fraction of extra TA cost paid by extra taxes (1)"\
+		 , 0 )
+	~	1
+	~		|
+
+"Goal for extra taxes from 2022 G$/y"=
+	"Extra general tax from 2022 G$/y" + "Extra taxes for TAs from 2022 G$/y"
+	~	
+	~		|
+
+"Extra cost of TAs from 2022 G$/y"=
+	MAX(0, "Cost of TAs G$/y" - "Cost of TAs in 2022 G$/y")
+	~	G$/y
+	~		|
+
+"Extra cost of TAs as share of GDP (1)"=
+	"Extra cost of TAs from 2022 G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Productivity loss from unprofitable activity (1)"=
+	"Extra cost of TAs as share of GDP (1)" * "Fraction unprofitable activity in TAs (1)"
+	~	1
+	~		|
+
+"Investment share of GDP (1)"=
+	( "Investment in new capacity PIS G$/y" + "Govmnt investment in public capacity G$/y"\
+		 ) / "GDP G$/y"
+	~	1
+	~		|
+
+"Indicated TFP (1)"=
+	"TFP including effect of 5TAs (1)" * OWeoTFP
+	~	1
+	~		|
+
+OWeoTFP=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoTFP<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"xExtra TA cost in 2100 (share of GDP)"=
+	0
+	~	1 [0,1,0.05]
+	~		|
+
+"xExtra cost of TAs as share of GDP (1)"=
+	"xExtra TA cost in 2022 (share of GDP)" + RAMP(("xExtra TA cost in 2100 (share of GDP)"\
+		-"xExtra TA cost in 2022 (share of GDP)")/78, 2022, 2022 + 78)
+	~	1
+	~		|
+
+"sOWeoTFP<0"=
+	-0.1
+	~	1 [-0.5,0,0.01]
+	~	220323 Set to - 0.1 to get TFP reduced by 10 % at +2.5 deg C. (dvs -4% per \
+		deg C)
+	|
+
+"xExtra TA cost in 2022 (share of GDP)"=
+	0
+	~	
+	~		|
+
+"Fertilizer use per person kg/p/y"=
+	( "Fertilizer use Mt/y" / Population Mp ) * 1000
+	~	kg/p/y
+	~		|
+
+"Energy use per person toe/p/y"=
+	"ENERGY USE Mtoe/y" / Population Mp
+	~	toe/p/y
+	~		|
+
+"Goal for income tax rate owners (1)"=
+	0.3
+	~	1 [0,1,0.05]
+	~		|
+
+"Basic income tax rate owners (1)"=
+	MIN(1, "Income tax rate owners in 1980 (1)"
+	+
+	RAMP(( "Income tax rate owners in 2022 (1)" - "Income tax rate owners in 1980 (1)" )\
+		 / 42, 1980, 2022)
+	+
+	RAMP(( "Goal for income tax rate owners (1)" - "Income tax rate owners in 2022 (1)" \
+		) / 78, 2022, 2100) )
+	~	1
+	~		|
+
+"Owner income G$/y"=
+	"National income G$/y" * ( 1 - "Worker share of output (1)")
+	~	G$/y
+	~		|
+
+"Income tax workers (1)"=
+	"Basic income tax rate workers (1)" 
+	* "National income G$/y" * "Worker share of output (1)"
+	~	1 [0,0.3,0.01]
+	~		|
+
+"Fraction of extra TA cost paid by extra taxes (1)"=
+	0.5
+	~	1 [0,1,0.1]
+	~	0.5 in TLTL 1.0 in GL
+	|
+
+"Worker income G$/y"=
+	"National income G$/y" * "Worker share of output (1)"
+	~	G$/y
+	~		|
+
+"Income tax owners (1)"=
+	"Basic income tax rate owners (1)"
+	*
+	"National income G$/y" * ( 1 - "Worker share of output (1)")
+	~	1 [0,0.3,0.01]
+	~		|
+
+"sLPeoAWP>0"=
+	0.5
+	~	 [0,1,0.1]
+	~		|
+
+"Wellbeing effect of participation (1)"=
+	1 + "sLPeoAWP>0" * ( "Labour participation rate (1)" / "Threshold participation (1)"\
+		 - 1 )
+	~	
+	~		|
+
+"GDP per person k$/p/y"=
+	"GDP G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+Govmnt debt G$= INTEG (
+	"Govmnt new debt G$/y"-"Cancellation of debt G$/y"-"Govmnt payback G$/y",
+		Govmnt debt in 1980 G$)
+	~	G$
+	~		|
+
+"Owner cash inflow G$/y"=
+	"Owner operating income after tax G$/y"
+	~	G$/y
+	~		|
+
+"Threshold participation (1)"=
+	0.8
+	~	 [0,1,0.1]
+	~		|
+
+"Govmnt new debt G$/y"=
+	MAX(0, ( Max govmnt debt G$ - Govmnt debt G$ ) / Govmnt drawdown period y) + 
+	STEP( "Govmnt stimulus from 2022 (share of NI)", 2022 ) * "National income G$/y"
+	~	G$/y
+	~		|
+
+"Bank cash inflow as share of NI (1)"=
+	"Bank cash inflow from lending G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Demand for red meat Mt-red-meat/y"=
+	( ( Population Mp * "Demand for red meat per person kg-red-meat/p/y" ) / 1000 )
+	*
+	( 1 - "Fraction new red meat (1)" )
+	~	Mt/y
+	~		|
+
+"Crop use Mt/y"=
+	"Crop supply (after 20 % waste) Mt-crop/y" * ( 1 + "Crop waste reduction (1)" )
+	~	Mt/y
+	~		|
+
+"Non-fossil CO2 per person tCO2/p/y"=
+	"Max non-fossil CO2 per person tCO2/p/y" *
+	( 1 - EXP(-("GDP per person k$/p/y" / 10)))
+	~	tCO2/p/y
+	~		|
+
+"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"=
+	"Fraction new electrification (1)" * "Demand for fossil fuel for non-el use before NE Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+Time to change reform delay y=
+	10
+	~	y
+	~	The time it takes for society to shorten decision and implementation delay.
+	|
+
+"Cost index for Regenerative agriculture (1)"=
+	( 1 - "Cost reduction per doubling in Regenerative agriculture (1)" ) ^ "Number of doublings in reg ag (1)"
+	~	
+	~		|
+
+Experience gained before 2022 Mha=
+	5
+	~	Mha [0,30,1]
+	~		|
+
+"Goal for fraction new red meat (1)"=
+	0.1
+	~	1 [0,1,0.05]
+	~	0.1 in TLTL, 0.5 i GL (lowered from 1 on 220427)
+	|
+
+"Goal for renewable el fraction (1)"=
+	0.5
+	~	1 [0,1,0.1]
+	~	0.5 i TLTL and 1 in GL
+	|
+
+Desired no of children 1=
+	(
+	( DNCmin + ( DNC in 1980 - DNCmin ) * EXP(-DNCgamma * ( "Effective GDP per person k$/p/y"\
+		 - "GDP per person in 1980 k$/p/y"
+	))) *
+	(1 + "DNCalfa<0" * ("Effective GDP per person k$/p/y" - "GDP per person in 1980 k$/p/y"\
+		 ))
+	)
+	* ( 1 - "Extra fertility reduction (1)" )
+	* "Fertility multiplier (1)"
+	~	1
+	~		|
+
+Indicated reform delay y=
+	Normal reform delay y 
+	*
+	"Social trust effect on reform delay (1)"
+	*
+	"Social tension effect on reform delay (1)"
+	~	
+	~		|
+
+"Desired supply of renewable electricity TWh/y"=
+	"Demand for electricity TWh/y" * "Desired renewable electricity share (1)"
+	~	TWh/y
+	~		|
+
+"Cost of extra fertility reduction (share of GDP)"=
+	"Cost of Max fertility reduction (share of GDP)" * "Extra fertility reduction (1)"
+	~	1
+	~		|
+
+"Goal for crop waste reduction (1)"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~	0.05 in TLTL and 0,2 in GL
+	|
+
+"Goal for fraction regenerative agriculture (1)"=
+	0.1
+	~	1 [0,0.9,0.1]
+	~	0.1 in TLTL and 0.5 in GL (lowered from 0.9 220427)
+	|
+
+"Number of doublings in reg ag (1)"=
+	LN( ( Regenerative agriculture area Mha + Experience gained before 2022 Mha ) / Experience gained before 2022 Mha\
+		) / 0.693
+	~	1
+	~	ln2 = 0.693
+	|
+
+"Goal for fraction new electrification (1)"=
+	0.5
+	~	1 [0,1,0.01]
+	~	0.5 i TLTL and 1 in GL
+	|
+
+"Inequity effect on logistic k (1)"=
+	1 + "sINEeoLOK<0" * ( "Inequality (1)" / 0.5 - 1 )
+	~	1
+	~		|
+
+"Normal k (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	was 1, so 0.3, so 0.15, so 0.2
+		goal is to have 600 Mp > 15k$/y in 2000, ie 10 % of population at the \
+		time. And 50 % > 15 k$/p/y in 2020
+	|
+
+"Population below 15 k$/p/y Mp"=
+	Population Mp * "Fraction below 15 k$/p/y (1)"
+	~	Mp
+	~		|
+
+"sINEeoLOK<0"=
+	-0.5
+	~	1 [-1,0,0.1]
+	~	was - 1
+	|
+
+"Logistic k (1)"=
+	"Normal k (1)" * "Inequity effect on logistic k (1)"
+	~	1
+	~		|
+
+"Goal for extra fertility reduction (1)"=
+	0
+	~	1 [0,0.2,0.01]
+	~	0 in TLTL and 0.2 in GL
+	|
+
+"Fraction below 15 k$/p/y (1)"=
+	1 - ( 1 / ( 1 + EXP( - "Logistic k (1)" * ( "GDP per person k$/p/y" - 14))))
+	~	
+	~		|
+
+"Satisfactory public spending (1)"=
+	0.3
+	~	1 [0,1,0.01]
+	~		|
+
+"Social tension (1)"=
+	1 + "sPPReoSTE<0" * ( "Observed rate of progress 1/y" - "Acceptable progress 1/y" )
+	~	1
+	~		|
+
+"Social tension effect on reform delay (1)"=
+	1 + "sSTEeoRD>0" * ( "Social tension (1)" / "Social tension in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Social tension in 1980 (1)"=
+	1.3
+	~	1
+	~		|
+
+"Acceptable inequality (1)"=
+	0.6
+	~	1 [0,1,0.01]
+	~	was 0.5
+	|
+
+"Social trust effect on reform delay (1)"=
+	1 + "sSTReoRD<0" * ( "Social trust (1)" / "Social trust in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Social trust in 1980 (1)"=
+	0.6
+	~	1
+	~		|
+
+"Public spending effect on social trust (1)"= WITH LOOKUP (
+	Public spending as share of GDP / "Satisfactory public spending (1)",
+		([(0,0)-(1,2)],(0,0),(1,1) ))
+	~	1
+	~		|
+
+"GDP G$/y"=
+	"Output Gu/y" * "Price per unit $/u"
+	~	G$/y
+	~		|
+
+"sSTReoRD<0"=
+	-1
+	~	1 [-1,0,0.1]
+	~	was -0.1
+	|
+
+Time to establish social trust y=
+	10
+	~	y
+	~		|
+
+"Average wellbeing from global warming (1)"=
+	MAX("Min wellbeing from global warming (1)", MIN(1, 1 + "sGWeoAW<0" * ( Perceived warming deg C\
+		 / Threshold warming deg C - 1)))
+	~	1
+	~		|
+
+"Income tax rate owners in 2022 (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	was 0.4 - reduced to match liberalization 1980-2020
+	|
+
+"Inequity effect on social trust (1)"= WITH LOOKUP (
+	"Inequality (1)"/ "Acceptable inequality (1)",
+		([(0,0)-(4,2)],(0,1),(1,1),(2,0) ))
+	~	1
+	~		|
+
+"Min wellbeing from global warming (1)"=
+	0.2
+	~	 [0,0.3,0.01]
+	~	was 0.15
+	|
+
+"Social trust (1)"=
+	SMOOTHI("Indicated social trust (1)", Time to establish social trust y, "Social trust in 1980 (1)"\
+		)
+	~	1
+	~		|
+
+"sSTEeoRD>0"=
+	1
+	~	1 [0,1,0.01]
+	~		|
+
+Public spending as share of GDP=
+	"Public spending per person k$/p/y" / "GDP per person k$/p/y"
+	~	1
+	~		|
+
+Normal reform delay y=
+	30
+	~	 [0,70,10]
+	~		|
+
+"Indicated social trust (1)"=
+	"Public spending effect on social trust (1)" * "Inequity effect on social trust (1)"
+	~	1
+	~		|
+
+"sPPReoSTE<0"=
+	-15
+	~	1 [-20,0,1]
+	~	Assume social tension = 1 at 0.02 1/y
+		And social tension = 0.7 at 0.04
+	|
+
+"Average wellbeing from public spending (1)"=
+	EXP("Diminishing return public spending (1)" + LN( "Public spending per person k$/p/y"\
+		 / "Threshold public spending k$/p/y" ))
+	~	1
+	~		|
+
+"Public spending per person k$/p/y"=
+	"Govmnt spending G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+"Observed rate of progress 1/y"=
+	SMOOTHI( (( "AVERAGE WELLBEING INDEX (1)" - "Past AWI (1)") / "AVERAGE WELLBEING INDEX (1)"\
+		)
+	/ Average wellbeing perception delay y, Average wellbeing perception delay y , 0 )
+	~	
+	~		|
+
+"Threshold disposable income k$/p/y"=
+	15
+	~	k$/p/y
+	~	What is needed to satisfy the UN SDGs according to David Collste et al
+	|
+
+"Threshold public spending k$/p/y"=
+	3
+	~	k$/p/y
+	~	Normal public spending at GDPpp=15.000 k$/p/y, namely 20 % of GDP
+	|
+
+"Acceptable progress 1/y"=
+	0.02
+	~	1/y [0,0.04,0.001]
+	~		|
+
+"sROPeoAW>0"=
+	6
+	~	1 [0,10,0.1]
+	~	was 1, so 10, so 3, so 8, so 6, so 9
+	|
+
+"Threshold inequality (1)"=
+	0.5
+	~	
+	~	Inequity index is defined as oso/wso = (1 - wso) / wso = 1/wso - 1 which \
+		equals 1 at wso=0.5, and
+	|
+
+"Average wellbeing from inequality (1)"=
+	1 + "sIIeoAW<0" * ( "Inequality (1)" / "Threshold inequality (1)" - 1 )
+	~	1
+	~		|
+
+"Diminishing return disposable income (1)"=
+	0.5
+	~	1 [0,1,0.1]
+	~		|
+
+"sIIeoAW<0"=
+	-0.6
+	~	 [-5,0,0.1]
+	~	was -0.6, -1.2, so -1
+	|
+
+"sGWeoAW<0"=
+	-0.58
+	~	1 [-1,0,0.01]
+	~	was -1, so -0.6, so -0.5
+	|
+
+Average wellbeing perception delay y=
+	9
+	~	y [0,15,1]
+	~	was 4, 6, so 8, 10
+	|
+
+"AWI in 1980 (1)"=
+	0.65
+	~	 [0,2,0.01]
+	~	was 1, 1,02, so 0.98
+	|
+
+"Past AWI (1)"=
+	SMOOTHI("AVERAGE WELLBEING INDEX (1)", Average wellbeing perception delay y, "AWI in 1980 (1)"\
+		)
+	~	1
+	~		|
+
+"Diminishing return public spending (1)"=
+	0.7
+	~	1 [0,1,0.1]
+	~	was 0.8, so 0.7
+		More utility from public spending (0.8) than from dispoable income (0.5)
+	|
+
+"Average wellbeing from disposable income (1)"=
+	EXP("Diminishing return disposable income (1)" + LN( "Worker disposable income k$/p/y"\
+		 / "Threshold disposable income k$/p/y" ))
+	~	1
+	~		|
+
+Threshold warming deg C=
+	1
+	~	deg C
+	~	IPCC expects climate damage to be visible when warming passes 1 deg C and \
+		be significant at +2 deg C
+	|
+
+"Threshold progress rate 1/y"=
+	0.02
+	~	 [0,0.04,0.001]
+	~	If there is progress above 2 % per year, there is social clm
+	|
+
+GDPppeoROCCLR=
+	MAX( 0 , 1 + "sGDPppeoROCCLR<0" * ( "GDP per person k$/p/y" / GDP per person in 1980\
+		 - 1 ))
+	~	1
+	~		|
+
+"ROC in ECLR 1/y"=
+	"ROC in ECLR in 1980 1/y" * GDPppeoROCCLR
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"sGDPppeoROCCLR<0"=
+	-0.1
+	~	1 [-1,0,0.01]
+	~		|
+
+"Goal for extra normal LPR (1)"=
+	0
+	~	1 [0,0.1,0.01]
+	~	was 0.05
+		remeber it takes a lot of time to increase LPR
+	|
+
+"Goal for extra income from commons (share of NI)"=
+	0
+	~	1 [0,0.05,0.01]
+	~	0 i TLTL and 0.02 in GL
+	|
+
+"Normal LPR (1)"=
+	("Normal LPR in 1980 (1)" 
+	*
+	(1 + "sWSOeoLPR>0" * ( "Worker share of output (1)" / "WSO in 1980 (1)" - 1 )))
+	+
+	"Extra normal LPR from 2022 (1)"
+	~	1
+	~		|
+
+"Fraction of govmnt debt cancelled in 2022 1/y"=
+	0
+	~	1/y [0,1,0.1]
+	~	0 in TLTL and 0.1 in GL
+	|
+
+"Off-balance sheet govmnt inv in PIS (share of GDP)"=
+	IF THEN ELSE(Time>2022, "Unconventional stimulus in PIS from 2022 (share of GDP)", 0\
+		)
+	~	1 [0,0.1,0.01]
+	~		|
+
+"Off-balance-sheet govmnt inv in PUS (share of GDP)"=
+	IF THEN ELSE(Time>2022, 0.01 + "Unconventional stimulus in PUS from 2022 (share of GDP)"\
+		, 0.01)
+	~	1 [0,0.05,0.01]
+	~		|
+
+"Unconventional stimulus in PIS from 2022 (share of GDP)"=
+	0
+	~	1 [0,0.05,0.01]
+	~	0 in TLTL and 0.01 in GL
+		This is the place to input a government stimulus programme of x % of GDP \
+		for private sector
+	|
+
+"Unconventional stimulus in PUS from 2022 (share of GDP)"=
+	0
+	~	1 [0,0.05,0.01]
+	~	0 in TLTL and 0.01 in GL
+		This is the place to input an unconventional government stimulus programme \
+		of x % of GDP for public sector
+	|
+
+"Govmnt payback G$/y"=
+	Govmnt debt G$ /Govmnt payback period y
+	~	G$/y
+	~		|
+
+Max govmnt debt burden y=
+	1
+	~	y [0,2,0.1]
+	~		|
+
+"Govmnt interest cost G$/y"=
+	Govmnt debt G$ * "Govmnt borrowing cost 1/y"
+	~	G$/y
+	~		|
+
+"Fertilizer use in 1980 Mt/y"=
+	61
+	~	Mt/y
+	~		|
+
+Life expectancy y=
+	(
+	( LEmax - (LEmax - LE in 1980) * EXP(- LEgamma * ("Effective GDP per person k$/p/y" \
+		- "GDP per person in 1980 k$/p/y"))
+	) *
+	( 1 + LEalfa * ( "Effective GDP per person k$/p/y" - "GDP per person in 1980 k$/p/y"\
+		 ))
+	)
+	* "Warming effect on life expectancy (1)"
+	* "Life expectancy multipler (1)"
+	~	y
+	~		|
+
+"Inequality (1)"=
+	"Owner operating income after tax G$/y" / "Worker income after tax G$/y"
+	~	1
+	~		|
+
+Food footprint in 1980=
+	Cropland in 1980 Mha * "Fertilizer use in 1980 Mt/y"
+	~	Mha*Mt/y
+	~		|
+
+"FOOD FOOTPRINT INDEX (1980=1)"=
+	Food footprint / Food footprint in 1980
+	~	1
+	~		|
+
+"SSP2 family action from 2022? (1)"=
+	1
+	~	1 [0,1,1]
+	~	1 means action as per SSP2. 0 means no action
+	|
+
+"Fertility multiplier (1)"=
+	IF THEN ELSE("SSP2 family action from 2022? (1)" > 0, 
+	IF THEN ELSE(Time>2022, 1 + RAMP(("Max fertility multiplier (1)" - 1 )/78, 2022, 2100\
+		), 1), 
+	1)
+	~	
+	~		|
+
+"Reduction in ROTA from inequality 1/y"=
+	MIN(1, 1 + "sIIEeoROTA<0" * ( "INEQUALITY INDEX (1980=1)" / 1 - 1) )
+	~	1
+	~		|
+
+"Life expectancy multipler (1)"=
+	IF THEN ELSE("SSP2 family action from 2022? (1)" > 0, 
+	IF THEN ELSE(Time>2022, 1 + RAMP(("Max life expectancy multiplier (1)" - 1 )/78, 2022\
+		, 2100), 1), 
+	1)
+	~	
+	~		|
+
+"Inequality in 1980 (1)"=
+	0.61
+	~	1
+	~	=8426/13874
+	|
+
+"INEQUALITY INDEX (1980=1)"=
+	"Inequality (1)" / "Inequality in 1980 (1)"
+	~	1
+	~	Inequity is defined as "owners income after tax" divided by "workers \
+		imcome after tax".
+	|
+
+"Max life expectancy multiplier (1)"=
+	1.1
+	~	1 [0,1.3,0.01]
+	~	to match SSP2 assumption of LE up 2 years per decade
+	|
+
+Food footprint=
+	Cropland Mha * "Fertilizer use Mt/y"
+	~	Mha*Mt/y
+	~		|
+
+"Max fertility multiplier (1)"=
+	1.6
+	~	1 [1,1.5,0.01]
+	~	220224: changed from 1 to 1.6 to match SSP 2
+	|
+
+"CO2 emissions per person tCO2/y"=
+	( "CO2 from energy and industry GtCO2/y" / Population Mp ) * 1000
+	~	tCO2/p/y
+	~		|
+
+"Melting Mha/y"=
+	"Ice and snow cover excl G&A Mkm2" * "Melting rate surface 1/y"
+	~	Mkm3/y
+	~		|
+
+"Crop use per person t-crop/p/y"=
+	"Crop use Mt/y" / Population Mp
+	~	t/p/y
+	~		|
+
+"Forest absorption multipler (1)"=
+	IF THEN ELSE(Time>2022, 1 + "SSP2 land management action from 2022? (1)"* RAMP(("Max forest absorption multiplier (1)"\
+		 - 1)/78, 2022, 2100), 1)
+	~	
+	~		|
+
+"CO2 absorption in forestry land tCO2/ha/y"=
+	1.6 * "Forest absorption multipler (1)"
+	~	t/ha/y
+	~	Numbers for Northern forest from ESMICON 2016: 0.24 GtC/y * 3.7 tCO2/tC / 1100 Mha = \
+		0.8 tCO2/ha/y
+		Increased by 100% to include absorption in non-Northern forests
+	|
+
+"Old growth removal Mha/y"=
+	Old growth forest area Mha 1 * "Old growth removal rate 1/y" * "Old growth removal rate multiplier (1)"
+	~	Mha/y
+	~		|
+
+"Cropland expansion multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" *
+	RAMP((1 - 0 )/78, 2022, 2100),
+	1)
+	~	
+	~		|
+
+"Land erosion multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" * 
+	RAMP((1 - 0 )/ 78, 2022, 2100),
+	1)
+	~	1
+	~		|
+
+"Land erosion rate 1/y"=
+	"Land erosion rate in 1980 1/y" * "Fertilizer effect on erosion rate (1)" * "Land erosion multiplier (1)"
+	~	1/y
+	~		|
+
+"Cropland loss Mha/y"=
+	Cropland Mha * "Land erosion rate 1/y"
+	~	Mha/y
+	~		|
+
+"Grazing land yied in 1980 kg-red-meat/ha/y"=
+	14
+	*"CO2 effect on land yield (1)"
+	*"Warming effect on land yield (1)"
+	~	kg/kg [5,20,1]
+	~	Estimate derived from complex considerations. Should be between 10 and 30 \
+		kg red meat/ha/y in US grazing lands
+	|
+
+"Crop supply (after 20 % waste) Mt-crop/y"=
+	"Average crop yield t-crop/ha/y" * Cropland Mha
+	~	Mt/y
+	~		|
+
+"SSP2 land management action from 2022? (1)"=
+	1
+	~	1 [0,78,1]
+	~	1 means action as per SSP2. 0 means no action
+	|
+
+"Albedo in 1980 (1)"=
+	( Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2 * "Albedo ice and snow (1)"
+	+
+	( Global surface Mkm2 - Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2\
+		 ) * "Albedo global average (1)" )
+	/
+	Global surface Mkm2
+	~	1
+	~	Global average is 0.3, much higher than indicated by 75% ocean. Due to \
+		clouds! (Wikipedia)Fresh snow 0.8, desert 0.4, green grass, bare soil 0.2, \
+		0.25, forest ca 0.15, urban area ca 0.15 open ocean 0.06
+	|
+
+"Max forest absorption multiplier (1)"=
+	2
+	~	1
+	~		|
+
+"CO2 absorption in forestry land GtCO2/y"=
+	Forestry land Mha 
+	* ("CO2 absorption in forestry land tCO2/ha/y" / 1000 )
+	* "CO2 effect on land yield (1)"
+	* "Warming effect on land yield (1)"
+	~	GtCO2/y
+	~		|
+
+"Albedo (1)"=
+	( "Ice and snow cover excl G&A Mkm2" * "Albedo ice and snow (1)"
+	+
+	( Global surface Mkm2 - "Ice and snow cover excl G&A Mkm2" ) * "Albedo global average (1)"\
+		 )
+	/
+	Global surface Mkm2
+	~	1
+	~		|
+
+"Average crop yield t-crop/ha/y"=
+	( "Desired crop yield in conv ag t-crop/ha/y" * ( 1 - "Fraction regenerative agriculture (1)"\
+		 ) *
+	"Soil quality index in conv ag (1980=1)"
+	+
+	"Crop yield in reg ag t-crop/ha/y" * "Fraction regenerative agriculture (1)" )
+	* "CO2 effect on land yield (1)"
+	* "Warming effect on land yield (1)"
+	~	t/ha/y
+	~		|
+
+"Desired crop supply Mt-crop/y"=
+	"Crop demand Mt-crop/y"
+	~	Mt/y
+	~		|
+
+"Crop balance (1)"=
+	"Crop use Mt/y" / "Desired crop supply Mt-crop/y"
+	~	1
+	~		|
+
+Ice and snow cover Mha=
+	"Ice and snow cover excl G&A Mkm2" * 100
+	~	Mha
+	~		|
+
+"Old growth removal rate multiplier (1)"=
+	IF THEN ELSE(Time>2022, 
+	1 - "SSP2 land management action from 2022? (1)" *
+	RAMP((1 - 0 )/78, 2022, 2100), 1)
+	~	
+	~		|
+
+"Cropland expansion Mha/y"=
+	IF THEN ELSE(Forestry land Mha>0, Cropland Mha * "Cropland expansion rate 1/y", 0) 
+	*
+	"Acceptable loss of forestry land (1)"
+	*
+	"Cropland expansion multiplier (1)"
+	~	Mha/y
+	~		|
+
+"Land erosion rate in 1980 1/y"=
+	0.004
+	~	 [0,0.02,0.001]
+	~	equal to 1 / 250 years
+	|
+
+"4 TWh-el per Mtoe"=
+	"TWh-el per EJ - engineering equivalent" / "Mtoe per EJ - calorific equivalent"
+	~	MWh/toe
+	~		|
+
+"Renewable heat production Mtoe/y"=
+	"Biomass energy Mtoe/y" + "Green hydrogen Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"IIASA Renewable energy production EJ/yr"=
+	"Renewable electricity production TWh/y" / "TWh-el per EJ - engineering equivalent"
+	+
+	"Renewable heat production Mtoe/y" / "Mtoe per EJ - calorific equivalent"
+	~	EJ/y
+	~		|
+
+tCO2 per toe=
+	2.8*EXP("ROC in tCO2 per toe 1/y" * (Time -1980))
+	~	tCO2/toe
+	~	CO2 emissions per toe fell from 2.8 in 1980 to 2.4 in 2019 - minus 0.3 %/y \
+		- probably because of fuel shift
+	|
+
+"Efficiency of fossil power plant TWh-el/TWh-heat"=
+	0.345
+	~	1 [0,1,0.01]
+	~	1 toe contains 12 MWh-heat and produces ca 4 MWh-el in a modern fossil \
+		power plant. 4/12=ca0.345 (chosen to get 4 TWH-el per Mtoe)
+	|
+
+"Demand for fossil fuel for non-el use before NE Mtoe/y"=
+	( Population Mp
+	* "Traditional per person use of fossil fuels for non-el-use before EE toe/p/y" 
+	* EXP(-"Normal increase in energy efficiency 1/y" * ( Time - 1980 )))
+	/ "Extra energy productivity index 2022=1"
+	~	Mtoe/y
+	~		|
+
+"CO2 from energy and industry GtCO2/y"=
+	"CO2 from energy production GtCO2/y"
+	+
+	"CO2 from non-fossil industrial processes GtCO2/y"
+	~	GtCO2/y
+	~		|
+
+"ROC in tCO2 per toe 1/y"=
+	-0.003
+	~	
+	~	CO2 emissions per toe fell from 2.8 in 1980 to 2.4 in 2019 - minus 0.3 %/y \
+		- probably because of fuel shift
+	|
+
+"ENERGY USE Mtoe/y"=
+	"Demand for fossil fuel for non-el use Mtoe/y" + "Electricity production TWh/y" / "4 TWh-el per Mtoe"\
+		 + "Renewable heat production Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"IIASA Fossil energy production EJ/yr"=
+	"Use of fossil fuels Mtoe/y" / "Mtoe per EJ - calorific equivalent"
+	~	EJ/y
+	~		|
+
+"TWh-heat per EJ - calorific equivalent"=
+	278
+	~	TWh/EJ
+	~	From 1 J = 1 Ws and 1h = 3600 s
+	|
+
+"Demand for electricity before NE TWh/y"=
+	( Population Mp 
+	* "Traditional per person use of electricity before EE MWh/p/y" 
+	* EXP(-"Normal increase in energy efficiency 1/y" * ( Time - 1980)))
+	/ "Extra energy productivity index 2022=1"
+	~	TWh/y
+	~		|
+
+"Max non-fossil CO2 per person tCO2/p/y"=
+	0.5
+	~	tCO2/p/y [0,2,0.1]
+	~	CO2 from industrial processes was 3.4 GtCO2/y in 2019 i.e. 3.4/7.9=0.43 tCO2/p/y.
+		GDPpp=15.000 k$/p/y so max must be higher. In Norway much higher.
+	|
+
+"Mtoe per EJ - calorific equivalent"=
+	24
+	~	Mtoe/EJ
+	~	1 toe = 43 GJ. Means that 1Mtoe = 43 MGJ = 43e15 and 24 Mtoe = 1032 e15J = \
+		1.03 e18J = 1 EJ
+	|
+
+"TWh-el per EJ - engineering equivalent"=
+	"TWh-heat per EJ - calorific equivalent" * "Efficiency of fossil power plant TWh-el/TWh-heat"
+	~	TWh/EJ
+	~		|
+
+Total forest area Mha=
+	Old growth forest area Mha 1 + Forestry land Mha
+	~	Mha
+	~		|
+
+"Extra domestic ROTA from 2022 1/y"=
+	0.003
+	~	1/y [0,0.02,0.001]
+	~	220221 Changed from 0 to 0.003 to match SSP2 4-5 6-doubling of GDP from \
+		2000 to 2100
+	|
+
+"CO2 forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,0.01)],(1980,0.0032),(1990,0.0041),(2000,0.0046),(2020,0.0051),(2100\
+		,0.006) ))
+	~	W/m2/ppm
+	~		|
+
+N2O concentration in atm ppm=
+	N2O in atmosphere GtN2O / GtN2O per ppm
+	~	ppm
+	~		|
+
+"Forcing from CO2 W/m2"=
+	CO2 concentration in atm ppm * "CO2 forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from CO2 in 1980 W/m2" 
+		* ( 1 + LN( CO2 concentration in atm ppm / CO2 concentration in 1980 ppm))
+	|
+
+"Forcing from N2O W/m2"=
+	N2O concentration in atm ppm * "N2O forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from N2O in 1980 W/m2" * ( 1 + "N2O forcing per ppm W/m2/ppm" * ( N2O \
+		concentration in atm ppm / N2O concentration in atm in 1980 ppm
+		 - 1 ))
+	|
+
+"Acceptable loss of forestry land (1)"=
+	1 - EXP(-"Fraction forestry land remaining (1)"/"Threshold FFLR (1)")
+	~	1
+	~		|
+
+"Warming from extra heat deg/ZJ"=
+	0.0006
+	~	 [0,0.01,0.001]
+	~	was 0.8/1400=0.0006
+		since ca 1400 ZJ (40 years at net 35) added from 1980 to 2020 gave 1.2 - \
+		0.4 = 0.8 deg C warming
+	|
+
+Observed warming deg C=
+	Warming in 1980 deg C + ( Extra heat in surface ZJ - Extra heat in 1980 ZJ )*"Warming from extra heat deg/ZJ"
+	~	deg C
+	~		|
+
+"Fraction forestry land remaining (1)"=
+	MAX(0, Forestry land Mha / Forestry land in 1980 Mha )
+	~	1
+	~		|
+
+"Man-made forcing W/m2"=
+	"Forcing from CO2 W/m2" + "Forcing from CH4 W/m2" + "Forcing from N2O W/m2" + "Forcing from other gases W/m2"
+	~	
+	~		|
+
+"Total man-made forcing W/m2"=
+	"Man-made forcing W/m2" + "Water vapour feedback W/m2"
+	~	W/m2
+	~	"Forcing from CO2 W/m2" + "Forcing from CH4 W/m2" + "Forcing from N2O W/m2" \
+		+"Forcing from other gases 
+		+"Water vapour feedback W/m2"
+	|
+
+CH4 concentration in atm ppm=
+	CH4 in atmosphere GtCH4 / GtCH4 per ppm
+	~	ppm
+	~		|
+
+"Transfer rate for heat going to abyss 1/y"=
+	"Transfer rate surface-abyss in 1980 1/y" * (( Observed warming deg C + 287 ) /  287\
+		 )
+	~	1/y
+	~	I assume 273 + 14 = 287 deg K was the normal temperature in 1850
+	|
+
+CO2 concentration in atm ppm=
+	CO2 in atmosphere GtCO2 / GtCO2 per ppm
+	~	ppm
+	~		|
+
+N2O conc in 1980 ppm=
+	N2O in atm in 1980 GtN2O / Mass of atmosphere Zt
+	~	ppm
+	~		|
+
+GtCH4 per ppm=
+	5
+	~	GtCH4/ppm
+	~	In 1980 4 GtCH4 gave 1446 ppb = 1.5 ppm
+	|
+
+CH4 conc in 1980 ppm=
+	CH4 in atm in 1980 GtCH4 / Mass of atmosphere Zt
+	~	
+	~		|
+
+Mass of atmosphere Zt=
+	5
+	~	Zt
+	~	Weight of atmosphere is 5 * 10^15 ton. 29 g/mol
+	|
+
+"OWeoCOC (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoCOC>0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"Warming effect on life expectancy (1)"=
+	IF THEN ELSE(Time>2022, MAX(0, 1 + "sOWeoLE<0" * 
+	( Observed warming deg C / Observed warming in 2022 deg C - 1 )), 1 )
+	~	1
+	~		|
+
+OWeoLoCO2=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoLoCO2>0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"New forestry land Mha/y"=
+	"Old growth removal Mha/y" * ( 1 - "Fraction cleared for grazing (1)")
+	~	Mha/y
+	~		|
+
+"Forcing from CH4 W/m2"=
+	CH4 concentration in atm ppm * "CH4 forcing per ppm W/m2/ppm"
+	~	W/m2
+	~	"Forcing from CH4 in 1980 W/m2" * ( 1 + "CH4 forcing per ppm W/m2/ppm" * (( CH4 \
+		concentration in atm ppm / CH4 concentration in atm in 1980 ppm
+		 ) - 1 ))
+	|
+
+Observed warming in 2022 deg C=
+	1.35
+	~	deg C
+	~	was 1.29, so 1.54, so 1.31, so 1.3
+	|
+
+"New grazing land Mha/y"=
+	"Old growth removal Mha/y" * "Fraction cleared for grazing (1)"
+	~	Mha/y
+	~		|
+
+"Warming effect on land yield (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sOWeoACY<0" * ( Observed warming deg C / Observed warming in 2022 deg C\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+CO2 concentration in 2022 ppm=
+	420
+	~	ppm
+	~	410 i 2018 plus ca 2 ppm/y
+	|
+
+"Traditional per person use of electricity before EE MWh/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(65,20)],(0,0),(10,4),(20,7),(30,9),(50,12),(65,13) ))
+	~	MWh/p/y
+	~	211023: Set equal to
+		([(0,0)-(60,10)],(0,0),(6.1,2.02),(9.3,2.35),(12.8,3.05),(60,10) )
+		corrected for 1%/y normal energy efficiency rise
+	|
+
+"CO2 effect on land yield (1)"=
+	IF THEN ELSE(Time>2022, 1 + "sCO2CeoACY>0" * ( CO2 concentration in atm ppm / CO2 concentration in 2022 ppm\
+		 - 1 ), 1)
+	~	1
+	~		|
+
+"Traditional per person use of fossil fuels for non-el-use before EE toe/p/y"= WITH LOOKUP\
+		 (
+	"GDP per person k$/p/y",
+		([(0,0)-(60,5)],(0,0.3),(15,2),(25,3.1),(35,4),(50,5) ))
+	~	t/p/y
+	~	was([(0,0)-(60,5)],(0,0),(6.37,1),(9.63,1.1),(14,1.31),(50,5) )
+		211023: equal to
+		([(0,0)-(60,2)],(0,0),(6.1,0.85),(9.3,0.88),(12.8,0.88),(60,0.88) )
+		corrected for 1 %/y energy efficiency increase
+	|
+
+Warming in 1980 deg C=
+	0.4
+	~	deg C
+	~		|
+
+"Melting rate deep ice 1/y"=
+	"Melting rate surface 1/y" / "Surface vs deep rate (1)"
+	~	1/y
+	~		|
+
+"Risk of extreme heat event (1)"= WITH LOOKUP (
+	Observed warming deg C,
+		([(0,0)-(6,40)],(0,1),(1.2,4.8),(2,8.6),(2.9,14),(5.2,40) ))
+	~	1
+	~		|
+
+"Water vapour concentration 1980 g/kg"=
+	2
+	~	g/kg [0,3,0.1]
+	~	Value from ESMICON-pp
+	|
+
+"Water vapor concentration g/kg"=
+	"Water vapour concentration 1980 g/kg" *
+	( 1 + "sOWeoWV>0" * ( Observed warming deg C/ Warming in 1980 deg C - 1 ))
+	~	g/kg
+	~		|
+
+"Water vapor feedback in 1980 W/m2"=
+	0.9
+	~	W/m2 [0,1,0.1]
+	~	Equals fraction H20 / CO2 in Nature articlw (=0.8) times CO2 forcing in \
+		1980 (= 1.07 W/m2)
+	|
+
+"Forcing from other gases W/m2"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,1)],(1980,0.18),(2000,0.36),(2020,0.39),(2050,0.37),(2100,0) ))
+	~	W/m2
+	~	unclear what is happening in SSP 2.0
+	|
+
+"Transfer rate surface-abyss in 1980 1/y"=
+	0.01
+	~	y [0,0.03,0.001]
+	~	211103: changed from 0.001 to 0.01, ie equilibration time 100 years
+	|
+
+"N2O forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,2)],(1980,0.43),(2000,0.64),(2010,0.73),(2020,0.8),(2100,1) ))
+	~	1 [0,20,1]
+	~	Adjusted to get N2O forcing right, from 0.1 to 0.2 W/m2 1980 to 2020
+	|
+
+"Extra warming from forcing ZJ/y"=
+	( "Total man-made forcing W/m2"
+	* Global surface Mkm2)   
+	* 31.5 / 1000
+	~	ZJ/y
+	~	1 TW gir 31.5 ZJ/y (1 Z = 1E21)
+		since there are 365*24*60*60 = 31.5 million seconds in a year, and 1 J = 1Ws
+		1 W/m2 = 16 ZJ/y
+	|
+
+Amount of ice in 1980 Mkm3=
+	55
+	~	Mkm3 [0,55,1]
+	~	16 Mkm2 is Greenland 2.2 and Antarctica 14.2, say 3km thick => 52 Mkm3.
+		30 Mkm2 is land and ocean ice, say 100 m thick => 3 Mkm3
+	|
+
+"sWVeoWVF>0"=
+	3
+	~	1 [0,5,0.1]
+	~	Taken from scatter diagram ESMICON-pp Humidity effect on H2O Blocking
+	|
+
+"Melting rate surface in 1980 1/y"=
+	0.0015
+	~	1/y [0,0.003,0.0001]
+	~	was 0.001
+	|
+
+"CH4 forcing per ppm W/m2/ppm"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,2)],(1980,0.82),(2000,0.94),(2020,1.01),(2100,1.1) ))
+	~	W/m2/ppm
+	~	To get CH4 forcing = 0.5 W/m2 in 2015
+	|
+
+"sOWeoWV>0"=
+	0.18
+	~	1 [0,0.3,0.01]
+	~	220221 Chosen to be smaller than CO2 forcing in 1980 and larger in 2020
+	|
+
+"Water vapour feedback W/m2"=
+	"Water vapor feedback in 1980 W/m2" 
+	* ( 1 + "sWVeoWVF>0" * ( "Water vapor concentration g/kg" / "Water vapour concentration 1980 g/kg"\
+		 - 1 ))
+	~	1
+	~	This is really "Forcing from H2O W/m2". Renamed "Water vapor feedback \
+		W/m2" to fit climate community language
+	|
+
+"Perceived unemployment CB (1)"=
+	SMOOTH("Unemployment rate (1)", Unemployment perception time CB y)
+	~	1
+	~		|
+
+"Fraction unprofitable activity in TAs (1)"=
+	0.3
+	~	 [0,1,0.1]
+	~		|
+
+"Cost of food and energy TAs G$/y"=
+	"Cost of food G$/y" + "Cost of energy G$/y"
+	~	
+	~		|
+
+"Demand in 1980 G$/y"=
+	"Optimal output in 1980 Gu/y" * "Price per unit $/u" * "SWI in 1980 (1)"
+	~	G$/y
+	~	28160*0.8=22528
+	|
+
+"Loss of cropland Mha/y"=
+	"Cropland loss Mha/y" + "Urban expansion Mha/y"
+	~	Mha/y
+	~		|
+
+"Loss of forest land Mha/y"=
+	"Old growth removal Mha/y" + "Cropland expansion Mha/y"
+	~	Mha/y
+	~		|
+
+"Average gross income per worker k$/p/y"=
+	"Wage rate $/ph" * "Average hours worked kh/y"
+	~	k$/p/y
+	~		|
+
+"Labour use Gph/y"=
+	Workforce Mp * "Average hours worked kh/y"
+	~	Gph/y
+	~		|
+
+"Labour use in 1980 Gph/y"=
+	Workforce in 1980 Mp * "Average hours worked in 1980 kh/y"
+	~	Gph/y
+	~		|
+
+"Cost of TAs G$/y"=
+	"Cost of food and energy TAs G$/y"
+	~	G$/y
+	~		|
+
+"Wage effect on optimal CLR (1)"=
+	SMOOTH("Indicated wage effect on optimal CLR (1)", Time to change tooling y)
+	~	1
+	~		|
+
+"Reduction in TFP from unprofitable activity (1)"=
+	SMOOTH("Productivity loss from unprofitable activity (1)", Investment planning time y\
+		 + Construction time PIS y)
+	~	1
+	~		|
+
+"Participation (1)"=
+	"Labour participation rate (1)" * ( 1 - "Perceived unemployment rate (1)" )
+	~	1
+	~		|
+
+"Indicated wage effect on optimal CLR (1)"=
+	1 + "sWSOeoCLR>0" * ( "Worker share of output (1)" / "WSO in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Average hours worked in 1980 kh/y"=
+	"Normal hours worked in 1980 kh/ftj/y" / "Persons per full-time job in 1980 p/ftj"
+	~	kh/y
+	~		|
+
+"Persons per full-time job in 1980 p/ftj"=
+	1
+	~	p/ftj
+	~		|
+
+"Average hours worked kh/y"=
+	"Normal hours worked kh/ftj/y" / "Persons per full-time job p/ftj"
+	~	kh/y
+	~		|
+
+Govmnt spending as share of GDP=
+	"Govmnt spending G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Worker disposable income k$/p/y"=
+	"Permanent worker cash inflow G$/y" / Workforce Mp
+	~	k$/p/y
+	~		|
+
+"Fraction of available capital to new capacity (1)"=
+	SMOOTH("FRA in 1980 (1)" * "FRACA mult from GDPpp - Line (1)"
+	*
+	( "WSO effect on flow to capacity addition (1)" 
+	+ 
+	"CBC effect on flow to capacity addion (1)" 
+	+ 
+	"ED effect on flow to capacity addition (1)"
+	 ) / 3, 
+	Investment planning time y )
+	~	1
+	~		|
+
+"FRACA mult from GDPpp - Line (1)"=
+	MAX(FRACA min, 1 + "sGDPppeoFRACA<0" * ( "GDP per person k$/p/y" / GDP per person in 1980\
+		 - 1 ))
+	~	1
+	~		|
+
+"sGDPppeoFRACA<0"=
+	-0.2
+	~	1 [-0.3,0,0.01]
+	~	was -0.1, so -0.15
+	|
+
+FRACA min=
+	0.65
+	~	1 [0,1,0.01]
+	~	was 0.8, so 0.7
+	|
+
+"Wage rate erosion rate 1/y"=
+	"Inflation rate 1/y" * ( 1 - "Fraction of inflation compensated (1)" )
+	~	1/y [0,0.02,0.001]
+	~		|
+
+"Labour productivity $/ph"=
+	( "Output Gu/y" * "Price per unit $/u" ) / "Labour use Gph/y"
+	~	$/ph
+	~		|
+
+"Labour productivity in 1980 $/ph"=
+	( "Optimal output in 1980 Gu/y" * "Cost per unit in 1980 $/u" ) / "Labour use in 1980 Gph/y"
+	~	$/ph
+	~		|
+
+"Optimal capital labour ratio kcu/ftj"=
+	"Embedded CLR kcu/ftj" * "Wage effect on optimal CLR (1)"
+	~	kcu/ftj
+	~		|
+
+"Change in wage rate $/ph/y"=
+	"Wage rate $/ph" * "ROC in WSO - Table 1/y"
+	~	$/ph/y
+	~		|
+
+"WSO effect on flow to capacity addition (1)"=
+	1 + "sWSOeoFRA<0" * ("Wage share (1)" / "WSO in 1980 (1)" - 1 )
+	~	1
+	~		|
+
+"Optimal real output Gu/y"=
+	"Optimal output in 1980 Gu/y" * 
+	( ( Capacity PIS Gcu + Capacity PUS Gcu ) / ( CAP PIS in 1980 Gcu + CAP PUS in 1980 Gcu\
+		) )^Kappa * 
+	( "Labour use Gph/y" / "Labour use in 1980 Gph/y" )^Lambda  * 
+	( "Embedded TFP (1)" )
+	~	G$/y
+	~	was "Embedded TFP in 1980 (1)" * EXP("ROC in embedded TFP 1/y" * ( Time - \
+		1980 )
+	|
+
+"Fraction of inflation compensated (1)"=
+	1
+	~	1 [0,2,0.1]
+	~		|
+
+"Wage rate in 1980 $/ph"=
+	"Labour productivity in 1980 $/ph" * "WSO in 1980 (1)"
+	~	$/ph
+	~		|
+
+"CLR in 1980 kcu/ftj"=
+	41
+	~	kcu/ftj [8,12,0.1]
+	~	was 10
+		220113 changed from 9.8 to 10 for China
+		211222 Equal to capacity (3750 cu) divided by Available work seekers (383 Mp) = 9.8 \
+		for China in 1980
+		was 41
+		211127 changed from 44.7 to get suitable amplitude for new lower savings \
+		slope. Equilibrium 40.3
+	|
+
+"Embedded CLR kcu/ftj"= INTEG (
+	"Change in embedded CLR kcu/ftj/y",
+		"CLR in 1980 kcu/ftj")
+	~	kcu/ftj
+	~		|
+
+"Change in embedded CLR kcu/ftj/y"=
+	"ROC in ECLR 1/y" * "Embedded CLR kcu/ftj"
+	~	kcu/ftj/y
+	~		|
+
+"ROC in ECLR in 1980 1/y"=
+	0.02
+	~	1/y [0,0.1,0.001]
+	~	was 0.06
+		220114 changfd from 0.03 to 0.06 to get correct workforce growth to 810 Mp at peak \
+		in 2020
+		211216 increased from 0.01 to 0.03 to get decline in wso over time
+		210827 was 0.015, so 0.02, so 0.015, so 0.017
+	|
+
+"Central bank signal rate 1/y"= INTEG (
+	"Change in signal rate 1/yy",
+		"Normal signal rate 1/y")
+	~	1/y
+	~		|
+
+"Labour participation rate (1)"=
+	SMOOTH("Indicated labour participation rate (1)", "Time to enter/leave labor market y"\
+		)
+	~	1
+	~		|
+
+"Acceptable unemployment rate (1)"=
+	0.05
+	~	1 [0,0.1,0.001]
+	~		|
+
+"sTIeoNHW<0"=
+	-0.03
+	~	1 [-0.1,0,0.01]
+	~	NWH falls linerly from 2000 h/y at 6 k$/p/y to 1500 h/y at 48 k$/p/y.
+		Means sTeoNHW<0=-0.03
+	|
+
+Optimal workforce Mp=
+	( Capacity Gcu / "Optimal capital labour ratio kcu/ftj" ) * "Persons per full-time job p/ftj"
+	~	Mp
+	~		|
+
+"Persons per full-time job p/ftj"=
+	1
+	~	p/ftj [0,2,0.01]
+	~		|
+
+"Wage rate $/ph"= INTEG (
+	"Change in wage rate $/ph/y"-"Wage rate erosion $/ph/y",
+		"Wage rate in 1980 $/ph")
+	~	$/ph
+	~		|
+
+"Hours worked mult from GDPpp (1)"=
+	1 + "sTIeoNHW<0" * ( "GDP per person k$/p/y" / GDP per person in 1980 - 1 )
+	~	1
+	~	Falls linerly from 2000 h/y at 6 k$/p/y to 1500 h/y at 48 k$/p/y.
+		Means sTeoNHW<0=-0.03
+	|
+
+"sWSOeoCLR>0"=
+	1.05
+	~	1 [0.9,1.1,0.01]
+	~	was 0.6, so 1.2, so 1, so 1.1, so 1
+	|
+
+"Wage share (1)"=
+	"Wage rate $/ph" / "Labour productivity $/ph"
+	~	1
+	~		|
+
+"Normal hours worked in 1980 kh/ftj/y"=
+	2
+	~	kh/ftj/y
+	~		|
+
+"Normal hours worked kh/ftj/y"=
+	SMOOTHI( "Normal hours worked in 1980 kh/ftj/y" * "Hours worked mult from GDPpp (1)"\
+		, Time to adjust hours worked y, "Normal hours worked in 1980 kh/ftj/y")
+	~	kh/ftj/y
+	~		|
+
+"FRACA mult from GDPpp - Table (1)"= WITH LOOKUP (
+	"GDP per person k$/p/y" / GDP per person in 1980,
+		([(0,0)-(16,1)],(0,1),(1,1),(2,0.85),(2.1,0.84),(4,0.65),(8,0.55),(16,0.5) ))
+	~	
+	~		|
+
+"WSO in 1980 (1)"=
+	0.5
+	~	1 [0.4,0.8,0.01]
+	~		|
+
+"Real wage erosion rate 1/y"=
+	0.015
+	~	y [0,0.02,0.001]
+	~	was 0.015, so 0.01,
+	|
+
+Working age population Mp=
+	"Aged 20-pension age Mp"
+	~	Mp
+	~		|
+
+"Change in workforce Mp/y"=
+	( Optimal workforce Mp - Workforce Mp ) / "Hiring/firing delay y"
+	~	Mj/y
+	~		|
+
+Available workforce Mp=
+	Working age population Mp * "Labour participation rate (1)"
+	~	Mp
+	~		|
+
+Time to adjust hours worked y=
+	5
+	~	y
+	~		|
+
+"Wage rate erosion $/ph/y"=
+	"Wage rate $/ph" * "Wage rate erosion rate 1/y"
+	~	$/ph/y
+	~		|
+
+"Long-term erosion of wso 1/y"=
+	"Worker share of output (1)" * "Real wage erosion rate 1/y"
+	~	1/y
+	~		|
+
+"Perceived unemployment rate (1)"=
+	SMOOTHI("Unemployment rate (1)", Unemployment perception time y , "Unemployment rate in 1980 (1)"\
+		)
+	~	
+	~		|
+
+"sWSOeoLPR>0"=
+	0.2
+	~	1 [0,1,0.01]
+	~	was 1, so 0, so 0.5
+	|
+
+"Unemployment rate (1)"=
+	Unemployed Mp / Available workforce Mp
+	~	1
+	~		|
+
+"Unemployment rate in 1980 (1)"=
+	0.05
+	~	1 [0,0.1,0.01]
+	~		|
+
+"sPUNeoLPR>0"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~	was 0.5, so 0
+	|
+
+"Worker share of output (1)"= INTEG (
+	"Change in wso 1/y"-"Long-term erosion of wso 1/y",
+		"WSO in 1980 (1)")
+	~	1
+	~		|
+
+"ROC in WSO - Table 1/y"= WITH LOOKUP (
+	"Perceived unemployment rate (1)" / "Acceptable unemployment rate (1)",
+		([(0,-0.06)-(2,0.06)],(0,0.06),(0.5,0.02),(1,0),(1.5,-0.007),(2,-0.01) ))
+	~	1/y
+	~		|
+
+Workforce in 1980 Mp=
+	1530
+	~	Mp [1000,1800,10]
+	~	was 1330, so 1600, so 1530 to avoid tarnsient in unemployment.
+		Still need to ge the phase right (that is bottom in unemployment around \
+		2000, 2008, 2020). Should probably be done by adjusting the labor \
+		participation rate in 1980
+	|
+
+Workforce Mp= INTEG (
+	"Change in workforce Mp/y",
+		Workforce in 1980 Mp)
+	~	Mp
+	~		|
+
+"Indicated labour participation rate (1)"=
+	"Normal LPR (1)" - "Perceived surplus workforce (1)"
+	~	1
+	~		|
+
+Unemployed Mp=
+	MAX(0, Available workforce Mp - Workforce Mp)
+	~	Mp
+	~		|
+
+"Perceived surplus workforce (1)"=
+	"Acceptable unemployment rate (1)" * ( 1 + "sPUNeoLPR>0" * ( "Perceived unemployment rate (1)"\
+		 / "Acceptable unemployment rate (1)"
+	 - 1 ))
+	~	1
+	~		|
+
+"Normal LPR in 1980 (1)"=
+	0.85
+	~	1 [0.7,0.9,0.01]
+	~	was 0.7
+	|
+
+"Time to enter/leave labor market y"=
+	5
+	~	y [0,20,1]
+	~		|
+
+"Change in wso 1/y"=
+	"Worker share of output (1)" * "ROC in WSO - Table 1/y"
+	~	1/y
+	~		|
+
+GDP per person in 1980=
+	6.4
+	~	k$/p/y [6.2,6.5,0.02]
+	~	was 6.1
+	|
+
+Observed fertility 1=
+	Desired no of children 1 * "Fraction achieving desired family size (1)"
+	~	1
+	~	220207 changed from "As math: Observed fertility 1"
+		220114 changed from Desired no of children 1 * "Fraction achieving desired family \
+		size (1)"
+		210821 changed from: IF THEN ELSE(Time>"Fertility = 2.5 introduction time \
+		y", 2.5 , Desired no of children 1)
+	|
+
+Capacity Gcu=
+	Capacity PIS Gcu + Capacity PUS Gcu
+	~	Gcu
+	~		|
+
+"Passing 40 in 1980 Mp/y"=
+	64
+	~	Mp/y [0,20,1]
+	~	was 13
+	|
+
+"TFP including effect of 5TAs (1)"=
+	"TFP excluding effect of 5TAs (1)" * ( 1 - "Reduction in TFP from unprofitable activity (1)"\
+		 )
+	~	1
+	~	was
+		"TFP excluding effect of 5TAs (1)" * ( 1 - "Reduction in TFP from \
+		less-cost-effective activities (1)" )
+	|
+
+"Passing 60 in 1980 Mp/y"=
+	38
+	~	Mp/y [0,20,1]
+	~	was 8
+	|
+
+"Passing 60 Mp/y"= 
+	DELAY N("Passing 40 Mp/y", 20, "Passing 60 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+"Deaths Mp/y"= 
+	DELAY N("Passing 60 Mp/y", LE at 60 y, "Dying in 1980 Mp/y", Order)
+	~	Mp/y
+	~	211111: Changed from IF THEN ELSE(LE at 60 y > 0, SMOOTH3("Aged 60 + Mp" / \
+		LE at 60 y, 20), 0)
+	|
+
+"Aged 40-60 in 1980 Mp"=
+	768
+	~	Mp
+	~	was 174
+	|
+
+"Dying in 1980 Mp/y"=
+	30
+	~	Mp/y [0,12,1]
+	~	was 6.3
+	|
+
+"Aged 60 + Mp"= INTEG (
+	"Passing 60 Mp/y"-"Deaths Mp/y",
+		"Aged 60+ in 1980 Mp")
+	~	Mp
+	~	was 382
+	|
+
+"Max imported ROTA from 2022 1/y"=
+	0
+	~	1/y [0,0.005,0.001]
+	~	0 in TLTL and 0.005 in GL
+		was at least 0.02 for China from 1980 to 2010: The technological lead of \
+		the West added at least 2 % points to China's growth.
+	|
+
+"Cost per unit in 1980 $/u"=
+	0.8
+	~	$/u [0.9,1.2,0.01]
+	~		|
+
+"Jobs in 1980 M-ftj"=
+	1600
+	~	Mp [350,400,1]
+	~	500
+		220109 changed from 382 to 500 to match David's data
+		211222 Equal to (Aged 20-pension age)*0.9*0.95=447*0.9*0.95=382, and reduced to 371 \
+		to avoid transient
+		was 1600
+		was 1330 (*1.2 = 1.600) to get phase correct
+	|
+
+"Passing 40 Mp/y"= 
+	DELAY N("Passing 20 Mp/y", 20, "Passing 40 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+"Aged 60+ in 1980 Mp"=
+	382
+	~	Mp
+	~	was 86
+	|
+
+"GDPpp of technology leader k$/p/y"=
+	15
+	~	k$/p/y
+	~	I assume countries stop copying at GDPpp=15.000 $/p/y
+	|
+
+"Capacity initiation PUS Gcu/y"=
+	MAX( ( "Govmnt investment in public capacity G$/y" + "Off-balance-sheet govmnt inv in PUS (share of GDP)"\
+		 * "GDP G$/y") / "Cost of capacity $/cu", 0)
+	~	Gcu/y
+	~		|
+
+"Aged 40-60 Mp"= INTEG (
+	"Passing 40 Mp/y"-"Passing 60 Mp/y",
+		"Aged 40-60 in 1980 Mp")
+	~	
+	~	was 768
+	|
+
+"Passing 20 in 1980 Mp/y"=
+	100
+	~	Mp/y [0,30,1]
+	~	was 21
+	|
+
+"Passing 20 Mp/y"= 
+	DELAY N("Births Mp/y", 20, "Passing 20 in 1980 Mp/y", Order)
+	~	Mp/y
+	~		|
+
+Multiplier to avoid transient in unemployment=
+	1
+	~	1 [0.8,1.2,0.01]
+	~	220114 changed from 0.97 to 1 to get initial jobs = 500 Mp
+	|
+
+"Optimal ouput - value G$/y"=
+	"Optimal real output Gu/y" * "Price per unit $/u"
+	~	G$/y
+	~		|
+
+"Capacity initiation PIS Gcu/y"=
+	MAX( ( "Investment in new capacity PIS G$/y" + "Off-balance sheet govmnt inv in PIS (share of GDP)"\
+		 * "GDP G$/y" )  / "Cost of capacity $/cu" , 0)
+	~	Gcu/y
+	~		|
+
+"Govmnt stimulus from 2022 (share of NI)"=
+	0
+	~	1 [0,0.1,0.01]
+	~		|
+
+Regenerative agriculture area Mha=
+	Cropland Mha * "Fraction regenerative agriculture (1)"
+	~	Mha
+	~		|
+
+"Cost of fertilizer G$/y"=
+	"Fertilizer use Mt/y" * "Cost per ton fertilizer $/t" / 1000
+	~	G$/y
+	~		|
+
+Goal for extra pension age y=
+	0
+	~	1 [0,10,1]
+	~	Can be set to 5, if one want to lift the pension age from 82 to 89 in 2100.
+	|
+
+Pension age y=
+	IF THEN ELSE(Life expectancy y < LE in 1980, Pension age in 1980 y, Pension age in 1980 y\
+		 + "sLEeoPa>0" * ( Life expectancy y + Extra pension age y
+	 - LE in 1980 ))
+	~	y [62,80,1]
+	~		|
+
+"Cost of food G$/y"=
+	"Agriculture as fraction of GDP (1)" * "GDP G$/y" + "Cost of regenerative agriculture G$/y"\
+		 + "Cost of fertilizer G$/y"
+	~	G$/y
+	~		|
+
+"Effective GDP per person k$/p/y"=
+	SMOOTHI("GDP per person k$/p/y", Time to adapt to higher income y, "GDP per person in 1980 k$/p/y"\
+		)
+	~	k$/p/y
+	~		|
+
+Forestry land Mha= INTEG (
+	"New forestry land Mha/y"-"Cropland expansion Mha/y",
+		Forestry land in 1980 Mha)
+	~	Mha
+	~		|
+
+Cropland Mha= INTEG (
+	"Cropland expansion Mha/y"-"Cropland loss Mha/y"-"Urban expansion Mha/y",
+		Cropland in 1980 Mha)
+	~	Mha
+	~	From HYDE: Cropland 1.600
+	|
+
+"Agriculture as fraction of GDP (1)"=
+	0.05
+	~	
+	~		|
+
+"Cost of food and energy as share of GDP (1)"=
+	"Cost of food and energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Extra CO2 absorption in reg ag GtCO2/y"=
+	Regenerative agriculture area Mha * "CO2 absorbed in reg ag tCO2/ha/y" / 1000
+	~	GtCO2/y
+	~		|
+
+"CO2 absorbed in reg ag tCO2/ha/y"=
+	1
+	~	
+	~	pure guess, but this is approx what is photosyntesized per ha per year
+	|
+
+"Cost of food and energy G$/y"=
+	"Cost of food G$/y" + "Cost of energy G$/y"
+	~	G$/y
+	~		|
+
+"CO2 emissions from LULUC GtCO2/y"=
+	"CO2 release from forest cut GtCO2/y" - "CO2 absorption in forestry land GtCO2/y" - \
+		"Extra CO2 absorption in reg ag GtCO2/y"
+	~	
+	~		|
+
+"CO2 release from forest cut GtCO2/y"=
+	(( "Old growth removal Mha/y" + "Cropland expansion Mha/y" )
+	* 
+	"CO2 release per ha of forest cut tCO2/ha") / 1000
+	~	GtCO2/y
+	~		|
+
+"sIIEeoROTA<0"=
+	-0.1
+	~	1 [-0.2,0,0.01]
+	~		|
+
+Extra pension age in 2022 y=
+	0
+	~	1 [0,0.4,0.02]
+	~		|
+
+"Embedded labour productivity in 1980 k$/p/y"=
+	"Optimal output in 1980 Gu/y" / "Jobs in 1980 M-ftj"
+	~	k$/p/y
+	~		|
+
+"sCO2CeoACY>0"=
+	0.3
+	~	1 [0,1,0.1]
+	~	I assume that yields increase in proportion with CO2 ppm (ie s=1) after \
+		2022, but should have been at a a declining pace
+	|
+
+"sOWeoACY<0"=
+	-0.3
+	~	1 [-1,0,0.1]
+	~	I assume that yields decrease slowly with rising temperatures after 2022, \
+		but should accelerate.
+	|
+
+"CO2 release per ha of forest cut tCO2/ha"=
+	65
+	~	t/ha
+	~	Numbers for Northern forests from ESMICON 2016: (215 GtC * 3.7 tCO2/tC ) / 1100 Mha \
+		= 72 tCO2/ha
+		Numbers for Southern forests from ESMICON 2016: (260 GtC * 3.7 tCO2/tC ) / \
+		1600 Mha = 60 tCO2/ha
+	|
+
+"sFFLReoOGRR<0"=
+	-5
+	~	1 [-5,0,0.1]
+	~	Parametrized to ensure there is still some forestry land in 2100 in Base \
+		Case
+	|
+
+"Cost of capacity $/cu"=
+	"Cost of capacity in 1980 $/cu" * "OWeoCOC (1)"
+	~	$/cu
+	~		|
+
+"Cost of capacity in 1980 $/cu"=
+	1
+	~	$/cu [0.8,1.3,0.01]
+	~		|
+
+"Forests cleared Mha/y"=
+	0
+	~	
+	~		|
+
+"OGRR in 1980 1/y"=
+	0.004
+	~	1/y [0,0.01,0.001]
+	~	0.4 % per year is a rough estimate based on tropical rainforest removal of \
+		1%/y and Northern forest regrowth of 0.3%/y
+	|
+
+"Threshold FFLR (1)"=
+	0.2
+	~	1 [0,2,0.1]
+	~	Parametrized to ensure there is still some forestry land in 2100 in Base \
+		Case
+	|
+
+"Old growth removal rate 1/y"=
+	"OGRR in 1980 1/y"
+	*
+	FFLReoOGRR
+	~	1/y
+	~		|
+
+FFLReoOGRR=
+	MAX(1, 1 + "sFFLReoOGRR<0" * ( "Fraction forestry land remaining (1)" - "Threshold FFLR (1)"\
+		 ))
+	~	1
+	~		|
+
+"sPUNeoPEW>0"=
+	0.5
+	~	1
+	~		|
+
+"Time to join/leave job market y"=
+	3
+	~	1 [0,10,1]
+	~	was 8, so 4, so 5
+	|
+
+"Fraction NASJ in 1980 (1)"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~		|
+
+"ROC in CLR 1/y"=
+	"ROC in CLR in 1980 1/y"
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"Fraction Aged 20-pension age wanting paid work in 1980 (1)"=
+	0.9
+	~	1 [0.9,1.2,0.01]
+	~	was 1.13
+		220113 changed from 0.7 to 1.13 to fit Chinese WF statistics (WF=500, Aged \
+		20-pension age = 466). Means 34 out of 500 Mp below 20 working, 7%. \
+		Probably much too low.
+		was 0.9 for world
+	|
+
+"Normal unemployment rate (1)"=
+	0.05
+	~	1 [0,0.1,0.01]
+	~		|
+
+Time for people to prepare for paid work y=
+	5
+	~	y [0,20,1]
+	~		|
+
+"sWSOeoWPR>0"=
+	1
+	~	1 [0,2,0.01]
+	~		|
+
+"Change in ECLR k$/y/y"=
+	"ROC in CLR 1/y" * "Embedded CLR k$/j"
+	~	k$/y/y
+	~		|
+
+"ROC in CLR in 1980 1/y"=
+	0.02
+	~	1/y [0,0.1,0.005]
+	~	was 0.06
+		220114 changfd from 0.03 to 0.06 to get correct workforce growth to 810 Mp at peak \
+		in 2020
+		211216 increased from 0.01 to 0.03 to get decline in wso over time
+		210827 was 0.015, so 0.02, so 0.015, so 0.017
+	|
+
+Infrastructure purchases ratio y=
+	Capacity PUS Gcu / "Govmnt purchases G$/y"
+	~	y
+	~	Is te equivalent of the capital output ratio in the productive economy.
+		Happens to be 6 years rather than 2.5
+	|
+
+"PCOR PUS cu/u/y"=
+	2.3
+	~	y [0,3.5,0.1]
+	~	was 2.5
+		211216 changed back from 2.3 to 2.5 to get slower growth
+	|
+
+"Embedded CLR k$/j"= INTEG (
+	"Change in ECLR k$/y/y",
+		"CLR in 1980 k$/j")
+	~	k$/j
+	~		|
+
+"Optimal output in 1980 Gu/y"=
+	CAP PIS in 1980 Gcu / "PCOR PIS cu/u/y" + CAP PUS in 1980 Gcu / "PCOR PUS cu/u/y"
+	~	G$/y
+	~		|
+
+"Owner savings fraction (1)"=
+	Owner savings fraction in 1980 
+	* 
+	( 1 + "sGDPeoOSR<0" * 
+	( "Effective GDP per person k$/p/y" / "GDP per person in 1980 k$/p/y" - 1 ))
+	~	1
+	~		|
+
+Capacity PUS Gcu= INTEG (
+	"Capacity addition PUS Gcu/y"-"Capacity discard PUS Gcu/y",
+		CAP PUS in 1980 Gcu)
+	~	Gcu
+	~		|
+
+Capacity under construction PUS Gcu= INTEG (
+	"Capacity initiation PUS Gcu/y"-"Capacity addition PUS Gcu/y",
+		CUC PUS in 1980 Gcu)
+	~	Gcu
+	~	was 160
+	|
+
+CUC PUS in 1980 Gcu=
+	( CAP PUS in 1980 Gcu / Life of capacity PUS in 1980 y ) * Construction time PUS y *\
+		 "Extra mult on CUC, to avoid initial transient in Investment share of GDP"
+	~	Gcu
+	~		|
+
+"Capacity addition PUS Gcu/y"=
+	Capacity under construction PUS Gcu / Construction time PUS y
+	~	Gcu/y
+	~		|
+
+Construction time PUS y=
+	1.5
+	~	y
+	~	was 2
+	|
+
+CAP PUS in 1980 Gcu=
+	5350
+	~	Gcu [750,1070,10]
+	~	was 1000
+		220113 Changed from 750 to 1000 to match China
+		was 5879, so 5350, so 14000
+	|
+
+Life of capacity PUS y=
+	Life of capacity PUS in 1980 y
+	~	y
+	~		|
+
+"Capacity discard PUS Gcu/y"=
+	Capacity PUS Gcu / Life of capacity PUS y
+	~	Gcu/y
+	~		|
+
+Life of extra CO2 in atm y=
+	Life of extra CO2 in atm in 1980 y * OWeoLoCO2
+	~	y [0,200,5]
+	~		|
+
+Life of extra CO2 in atm in 1980 y=
+	60
+	~	y
+	~	211102: changed from 9 to 60 to match observed history (after I found a mistake)
+		And before UG calculated that in ESMICON it rises from 40 to 60
+	|
+
+"sOWeoLoCO2>0"=
+	1
+	~	1 [0,2,0.1]
+	~	was 0
+	|
+
+"tCO2e/tCH4"=
+	23
+	~	1
+	~		|
+
+"GHG EMISSIONS GtCO2e/y"=
+	"CO2 emissions GtCO2/y" * "tCO2e/tCO2"
+	+
+	"CH4 emissions GtCH4/y" * "tCO2e/tCH4"
+	+
+	"N2O emissions GtN2O/y" * "tCO2e/tN2O"
+	~	GtCO2e/y
+	~		|
+
+"tCO2e/tN2O"=
+	7
+	~	1
+	~	guestimate
+	|
+
+"tCO2e/tCO2"=
+	1
+	~	1
+	~		|
+
+"Govmnt net income as share of NI (1)"=
+	"Govmnt net income G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Income tax rate owners in 1980 (1)"=
+	0.4
+	~	1 [0,1,0.1]
+	~	211125 changed from 0.2 to mimic more typical countries than US
+	|
+
+"Basic income tax rate workers (1)"=
+	0.2
+	~	1 [0,1,0.1]
+	~	211125 changed from 0.1 to mimic more typical countries than US
+	|
+
+"Extra general tax rate from 2022 (1)"=
+	0
+	~	1 [0,0.1,0.01]
+	~	0 in TLTL and 0.01 in GL
+	|
+
+"Extra cost of Energy Turnaround as share of GDP (1)"=
+	IF THEN ELSE(Time>2022, ( "Cost of energy G$/y" - "Traditional cost of energy G$/y" \
+		) / "GDP G$/y", 0)
+	~	1
+	~		|
+
+"Ratio of Energy cost to Trad energy cost (1)"=
+	"Cost of energy G$/y" / "Traditional cost of energy G$/y"
+	~	1
+	~		|
+
+"Extra cost of reg ag $/ha/y"=
+	"Extra cost of reg ag in 2022 $/ha/y" * "Cost index for Regenerative agriculture (1)"
+	~	$/ha/y [0,600,20]
+	~		|
+
+"Traditional cost of electricity $/kWh"=
+	0.03
+	~	$/kWh
+	~	80% fossil at 0.03, 15 % nuclear at 0.033, 5 % hydro at 0.025
+	|
+
+"Traditional cost of electricity G$/y"=
+	( "Demand for electricity before NE TWh/y" * "Traditional cost of electricity $/kWh"\
+		 / 1000 ) 
+	* "Adjustment factor to make costs match 1980-2022 (1)"
+	~	G$/y
+	~		|
+
+"Traditional cost of energy as share of GDP (1)"=
+	"Traditional cost of energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Traditional cost of fossil fuel for non-el use $/toe"=
+	240
+	~	$/toe
+	~	Cost per ton is cost per barrel times 6.
+		33% coal at 30*6=180, 33 % oil at 50*6=300, 33 % gas at 40*6=240
+	|
+
+"Addition of sun and wind capacity GW/y"=
+	"Addition of renewable el capacity GW/y"
+	~	GW/y
+	~		|
+
+"Adjustment factor to make costs match 1980-2022 (1)"=
+	1.35
+	~	1 [1,3,0.1]
+	~		|
+
+"Cost of regenerative agriculture G$/y"=
+	( "Extra cost of reg ag $/ha/y" * Regenerative agriculture area Mha ) / 1000
+	~	G$/y
+	~		|
+
+"Cost of grid G$/y"=
+	"Electricity production TWh/y" * "Transmission cost $/kWh"
+	~	G$/y
+	~		|
+
+"Extra cost of Food Turnaround as share of GDP (1)"=
+	"Extra cost of Food Turnaround G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"Amount of fertilizer saved in reg ag kgN/ha/y"=
+	268 - "Sustainable fertiliser use kgN/ha/y"
+	~	kg/ha/y
+	~	Comment: From the table function I know that 268 kgN/ha/y fertilizer is \
+		needed to achieve the yield in regenerative agriculture (namely 7 \
+		tcrop/ha/y). I assume that reg ag reduces this need to the sustainable use \
+		20 kgN/ha/y
+	|
+
+"Traditional grid cost G$/y"=
+	"Demand for electricity before NE TWh/y" * "Transmission cost $/kWh"
+	~	G$/y
+	~		|
+
+"Extra cost of reg ag in 2022 $/ha/y"=
+	400
+	~	$/ha/y [0,600,50]
+	~	I assume that reg ag requires 30 % higher manpower input, and that this increases \
+		total farming cost by 30%.
+		Current manpower input in Norway is 20.000 fulltime farmers cultivating 1 \
+		Mha => 0.02 p/ha/y. At 600.000 kr/p/y this means an extra cost of \
+		30%*600.000 kr/p/y*0.02 p/ha/y = 3600 kr/p/y or 400$/ha/y
+	|
+
+"Cost per ton fertilizer $/t"=
+	500
+	~	$/t
+	~	Taken from Norway 2020 3000 - 5000 kr pr ton fertilizer
+	|
+
+"Cost reduction per doubling in Regenerative agriculture (1)"=
+	0.05
+	~	1 [0,0.2,0.01]
+	~	was 0.1
+	|
+
+"Traditional cost of energy G$/y"=
+	"Traditional cost of electricity G$/y" + "Traditional cost of fossil fuel for non-el use G$/y"\
+		 + "Traditional grid cost G$/y"
+	~	G$/y
+	~		|
+
+Investment planning time y=
+	1
+	~	y [0,10,1]
+	~		|
+
+"Cost of nuclear electricity G$/y"=
+	"Nuclear electricity production TWh/y"
+	*
+	"Cost of nuclear el $/kWh"
+	~	G$/y
+	~		|
+
+"Cost of fossil fuel for non-el use G$/y"=
+	("Demand for fossil fuel for non-el use Mtoe/y"
+	* 
+	"Traditional cost of fossil fuel for non-el use $/toe" )
+	/1000
+	~	G$/y
+	~		|
+
+"Fertilizer cost reduction G$/y"=
+	( "Amount of fertilizer saved in reg ag kgN/ha/y" / 1000) * Regenerative agriculture area Mha\
+		 * ("Cost per ton fertilizer $/t" )
+	~	G$/y
+	~		|
+
+"Cost of energy as share of GDP (1)"=
+	"Cost of energy G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+"OPEX fossil el G$/y"=
+	"OPEX fossil el $/kWh" * "Fossil electricity production TWh/y"
+	~	G$/y
+	~		|
+
+"Cost of renewable electricity G$/y"=
+	"CAPEX renewable el G$/y" + "OPEX renewable el G$/y"
+	~	G$/y
+	~		|
+
+"FRA in 1980 (1)"=
+	0.9
+	~	1 [0.8,1.2,0.01]
+	~	was 1, so 0.84
+		was 0.8, so 0.76, so 0.84 so back to 1, since this was case in GROWTH model
+		211126 changed from 1 to reduce GDP growth rate from 4 %/y to 3.5%
+	|
+
+"Cost of fossil electricity G$/y"=
+	"CAPEX fossil el G$/y" + "OPEX fossil el G$/y"
+	~	G$/y
+	~		|
+
+"Cost of nuclear el $/kWh"=
+	0.033
+	~	$/kWh
+	~	I assume nuclear el is 10 % more expensive than fossil el
+	|
+
+"Extra cost of Food Turnaround G$/y"=
+	"Cost of regenerative agriculture G$/y" - "Fertilizer cost reduction G$/y"
+	~	G$/y
+	~		|
+
+"Cost of electricity G$/y"=
+	"Cost of fossil electricity G$/y" + "Cost of renewable electricity G$/y" + "Cost of nuclear electricity G$/y"
+	~	G$/y
+	~		|
+
+"Traditional cost of fossil fuel for non-el use G$/y"=
+	( "Demand for fossil fuel for non-el use before NE Mtoe/y" * "Traditional cost of fossil fuel for non-el use $/toe"\
+		 / 1000 )
+	*
+	"Adjustment factor to make costs match 1980-2022 (1)"
+	~	G$/y
+	~		|
+
+"Transmission cost $/kWh"=
+	0.02
+	~	$/kWh
+	~	DNV-GL ETO 2018 p 176 says 0.02
+	|
+
+"Govmnt net income G$/y"=
+	"Govmnt gross income G$/y" - "Transfer payments G$/y" + "Sales tax G$/y"
+	~	G$/y
+	~		|
+
+"Cost of Max fertility reduction (share of GDP)"=
+	0.01
+	~	1
+	~		|
+
+"Births Mp/y"=
+	"Aged 20-40 years Mp" * "Fraction women (1)" * ( Observed fertility 1 / Fertile period y\
+		 )
+	~	Mp/y
+	~		|
+
+"State capacity in 1980 (fraction of GDP)"=
+	0.3
+	~	1 [0,1,0.01]
+	~	was 0.15
+	|
+
+"Change in TFP 1/y"=
+	"Rate of technological advance 1/y" * "TFP excluding effect of 5TAs (1)"
+	~	1/y
+	~		|
+
+"Domestic ROTA in 1980 1/y"=
+	0.01
+	~	1/y [0,0.04,0.001]
+	~	was 0.01, so 0.04
+	|
+
+"sSCeoROTA>0"=
+	0.5
+	~	1 [0,1,0.1]
+	~		|
+
+"sOWeoCOC>0"=
+	0.2
+	~	1 [0,1,0.01]
+	~	220323 Set 0.2 to get investment cost 20 % at +2.5 deg C (ie +8% per deg C)
+		Way way above the estimate of NN in SDR 2021 used "Loss of GDPPC growth per \
+		additional degree = 0.005", which I represent as sOWeoCI = 0.0065 from \
+		2022 (since observed warming in 2022 is 1.3 deg C)
+		(CI is capacity addition)
+	|
+
+"sOWeoLE<0"=
+	-0.02
+	~	1 [-0.4,0,0.01]
+	~	Set to -0.02 means a reduction in LE by 2.5 years in 2100 at +2.5 deg C, ie 1 years \
+		per deg C
+		NN in SDR 2021 used "Fractional increase in death rates per additional degree = \
+		0.02".
+		means a reduction in LE of 2 years when temp increases 1 deg C.
+	|
+
+"sIPReoVPSS>0"=
+	1
+	~	1 [1,2,0.1]
+	~	Guess
+	|
+
+"TFP excluding effect of 5TAs (1)"= INTEG (
+	"Change in TFP 1/y",
+		"TFP in 1980 (1)")
+	~	1
+	~		|
+
+"Public services per person k$/p/y"=
+	"Value of public services supplied G$/y" / Population Mp
+	~	k$/p/y
+	~		|
+
+"Effect of capacity renewal 1/y"=
+	( "Indicated TFP (1)" - "Embedded TFP (1)" ) * "Capacity renewal rate 1/y"
+	~	1/y
+	~		|
+
+"Embedded TFP (1)"= INTEG (
+	"Effect of capacity renewal 1/y",
+		"Embedded TFP in 1980 (1)")
+	~	1
+	~		|
+
+"Capacity renewal rate 1/y"=
+	"Capacity addition PIS Gcu/y" / Capacity PIS Gcu
+	~	1/y
+	~		|
+
+"Productivity of public purchases (1)"=
+	MAX(0, 1 + "sIPReoVPSS>0"* LN(Infrastructure purchases ratio y/Infrastructure purchases ratio in 1980 y\
+		))
+	~	1
+	~		|
+
+Infrastructure purchases ratio in 1980 y=
+	1.2
+	~	y
+	~		|
+
+"TFP in 1980 (1)"=
+	1
+	~	1
+	~		|
+
+"Value of public services supplied G$/y"=
+	"Govmnt purchases G$/y" * "Productivity of public purchases (1)"
+	~	G$/y
+	~		|
+
+"State capacity (fraction of GDP)"=
+	"Value of public services supplied G$/y" / "GDP G$/y"
+	~	1
+	~		|
+
+xTFP observation time y=
+	4
+	~	y
+	~		|
+
+toe per tH2=
+	10
+	~	
+	~	Guess
+	|
+
+"kWh-el per kgH2"=
+	40
+	~	kWh/kgH2
+	~	Guess
+	|
+
+"Green hydrogen Mtoe/y"=
+	"Green hydrogen MtH2/y"
+	*
+	toe per tH2
+	~	Mtoe/y
+	~		|
+
+"Green hydrogen MtH2/y"=
+	"Renewable electricity production TWh/y"
+	*
+	"Fraction of renewable electricity to hydrogen (1)"
+	/
+	"kWh-el per kgH2"
+	~	MtH2/y
+	~		|
+
+"Fraction of renewable electricity to hydrogen (1)"=
+	0
+	~	1
+	~	Placeholder
+	|
+
+"MEMO Fraction of non-el fossil fuels use in hard to abate sectors HTAS (1)"=
+	0.4
+	~	1
+	~	Rough estimate of use as rawmaterial is 5%.
+		plastics prod / non-el FF gives 1980 (60 Mtp/y, 1.5 %) 2000 (200 Mtp/y, 3.7 %) 2020 \
+		(400 Mtp/y, 5.5%)
+		Must add room for fertilizer, reduction of steel, decarbonized gas, blue \
+		hydrogen
+	|
+
+"Demand for red meat per person kg-red-meat/p/y"=
+	"Traditional use of red meat per person kg-red-meat/p/y"
+	~	kg/p/y
+	~		|
+
+"Extra cooling from ice melt ZJ/y"=
+	"Melting rate deep ice 1/y" * Amount of ice in 1980 Mkm3 * Ton per m3 ice * "Heat required to melt ice kJ/kg"
+	~	ZJ/y
+	~		|
+
+GtN2O per ppm=
+	5
+	~	Gt/ppm
+	~	From UG ESMICON 3.29/0.65=
+	|
+
+"Albedo global average (1)"=
+	0.3
+	~	1 [0,1,0.1]
+	~	Wikipedia says:land average = 0.3 ocean average = 0.06 ocean ice = 0.6 fresh snow = \
+		0.8
+		Gives 0.1 as world average with 75% ocean and 25 % land. But real albedo \
+		is higher because of clouds, perhaps around 0.3
+	|
+
+"N2O breakdown GtN2O/y"=
+	N2O in atmosphere GtN2O / Life of N2O in atm y
+	~	GtN2O/y
+	~		|
+
+"Heat to space ZJ/y"=
+	Extra heat in surface ZJ * "Transfer rate for heat going to space 1/y"
+	~	ZJ/y
+	~		|
+
+N2O in atmosphere GtN2O= INTEG (
+	"N2O emissions GtN2O/y" - "N2O breakdown GtN2O/y",
+		N2O in atm in 1980 GtN2O)
+	~	GtN2O
+	~		|
+
+"Surface vs deep rate (1)"=
+	4
+	~	1 [0,10,1]
+	~	211103: changed from 10 to 4
+	|
+
+"Albedo ice and snow (1)"=
+	0.7
+	~	1 [0,1,0.1]
+	~	Wikipedia says:land average = 0.3 ocean average = 0.06 ocean ice = 0.6 fresh snow = \
+		0.8
+		But real number is higher because of clouds, perhaps around 0.1
+	|
+
+Extra heat in surface ZJ= INTEG (
+	"Extra warming from forcing ZJ/y"-"Extra cooling from ice melt ZJ/y"-"Heat to deep ocean ZJ/y"\
+		-"Heat to space ZJ/y",
+		Extra heat in 1980 ZJ)
+	~	ZJ
+	~		|
+
+"Melting rate surface 1/y"=
+	"Melting rate surface in 1980 1/y" * ( Observed warming deg C / Warming in 1980 deg C\
+		 )
+	~	1/y
+	~		|
+
+"Transfer rate for heat going to space 1/y"=
+	( "Transfer rate surface-space in 1980 1/y" * (( Observed warming deg C + 297 ) /  297\
+		 ) )
+	*
+	( "Albedo (1)" / "Albedo in 1980 (1)" )
+	~	1/y
+	~		|
+
+tCO2 per tCH4=
+	2.75
+	~	t/t
+	~	CO2 = 12+16+16=44  CH4 = 12+1+1+1+1 = 16.   44/16=2.75
+	|
+
+"CO2 from CH4 GtCO2/y"=
+	"CH4 breakdown GtCH4/y" * tCO2 per tCH4
+	~	Gt/y
+	~		|
+
+"Transfer rate surface-space in 1980 1/y"=
+	0.01
+	~	1/y [0,0.02,0.001]
+	~	was 0.01, so 0.02 to obtain observed warming
+		211103: changed from 0.001 to 0.01, ie equilibration time 100 years
+	|
+
+"Heat to deep ocean ZJ/y"=
+	Extra heat in surface ZJ * "Transfer rate for heat going to abyss 1/y"
+	~	ZJ/y
+	~		|
+
+"Natural N2O emissions GtN2O/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,0.01)],(1980,0.009),(2020,0.009),(2099.27,0) ))
+	~	
+	~	211030 From UG FAO
+	|
+
+"CH4 emissions GtCH4/y"=
+	"Man-made CH4 emissions GtCH4/y" + "Natural CH4 emissions GtCH4/y"
+	~	Gt/y
+	~		|
+
+kg CH4 per kg crop in 1980=
+	0.05
+	~	1
+	~	220220 Adjusted to give correct natural emissions EM according to ESMICONpp
+	|
+
+kg N2O per kg fertilizer in 1980=
+	0.11
+	~	1
+	~	UG and ESMICON
+	|
+
+"Man-made N2O emissions GtN2O/y"=
+	"Fertilizer use Mt/y" * kg N2O emission per kg fertiliser / 1000
+	~	Gt/y
+	~		|
+
+"Traditional use of crops ex red meat Mt/y"=
+	( "Traditional use of crops Mt/y"
+	-
+	"Traditional use of feed for red meat Mt-crop/y" )
+	/
+	"Food sector productivity index (1980=1)"
+	~	Mt/y
+	~		|
+
+"N2O emissions GtN2O/y"=
+	"Natural N2O emissions GtN2O/y" + "Man-made N2O emissions GtN2O/y"
+	~	Gt/y
+	~		|
+
+CH4 in atm in 1980 GtCH4=
+	2.5
+	~	Gt/y
+	~	3 GtC from UG ESMICON multiplied with 12+1+1+1+1 = 16 / 12 = 1.33
+	|
+
+N2O in atm in 1980 GtN2O=
+	1.052
+	~	GtN2O [0,2,0.1]
+	~	1.052 Gt N2O according to ESMICON,
+		But this equals 1.052 Gt / 5E15 = 1E9/5E15=0.2 E-6 = 200 ppb, and should \
+		have been 320 ppb!
+	|
+
+"Natural CH4 emissions GtCH4/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,1)],(1980,0.19),(2020,0.19),(2100,0.19) ))
+	~	
+	~	220220 from ESMICONpp
+		was 0.29 and rising
+	|
+
+"Man-made CH4 emissions GtCH4/y"=
+	("Crop supply (after 20 % waste) Mt-crop/y" * kg CH4 emission per kg crop ) / 1000
+	~	Gt/y
+	~		|
+
+"Forcing from CO2 in 1980 W/m2"=
+	1.07
+	~	W/m2 [0,2,0.1]
+	~	From Esmicon Supplimentary information
+	|
+
+Life of N2O in atm y=
+	95
+	~	y [0,500,10]
+	~	from ESMICON, was 100
+	|
+
+"Red meat from feedlots Mt-red-meat/y"=
+	"Demand for red meat Mt-red-meat/y"- "Red meat from grazing land Mt-red-meat/y"
+	~	Mt/y
+	~		|
+
+"Rate of decline in CH4 per kg crop 1/y"=
+	0.01
+	~	1/y [0,0.03,0.01]
+	~	Guestimate to get concentration to follow forcing
+	|
+
+"Fertilizer effect on erosion rate (1)"=
+	1 + "sFUeoLER>0" * ( "Fertilizer use in conv ag kgN/ha/y"/ "Sustainable fertiliser use kgN/ha/y"\
+		 - 1 )
+	~	1
+	~		|
+
+"Red meat from grazing land Mt-red-meat/y"=
+	MIN("Demand for red meat Mt-red-meat/y", "Potential red meat from grazing land Mt-red-meat/y"\
+		)
+	~	Mt/y
+	~		|
+
+"Fertilizer use Mt/y"=
+	Cropland Mha * ( 1 - "Fraction regenerative agriculture (1)" ) * "Fertilizer use in conv ag kgN/ha/y"\
+		/ 1000
+	~	Mt/y
+	~		|
+
+"Crop demand Mt-crop/y"=
+	("Traditional use of crops ex red meat Mt/y"
+	+
+	"Feed for red meat Mt-crop/y"
+	+
+	"Crops for biofuel Mt-crop/y")
+	~	Mt/y
+	~		|
+
+"CAPEX fossil el G$/y"=
+	"CAPEX fossil el $/W" * "Addition of fossil el capacity GW/y"
+	~	G$/y
+	~		|
+
+"CAPEX renewable el G$/y"=
+	"CAPEX renewable el $/W" * "Addition of renewable el capacity GW/y"
+	~	G$/y
+	~		|
+
+"OPEX fossil el $/kWh"=
+	0.02
+	~	G$/y
+	~		|
+
+"Fraction of CO2-sources with CCS in 2022 (1)"=
+	0
+	~	1
+	~		|
+
+CH4 in atmosphere GtCH4= INTEG (
+	"CH4 emissions GtCH4/y"-"CH4 breakdown GtCH4/y",
+		CH4 in atm in 1980 GtCH4)
+	~	Gt
+	~		|
+
+"OPEX renewable el G$/y"=
+	"OPEX renewable el $/kWh" * "Renewable electricity production TWh/y"
+	~	G$/y
+	~		|
+
+"Goal for fraction of CO2-sources with CCS (1)"=
+	0.2
+	~	1 [0,0.9,0.1]
+	~	0.2 in TLTL and 0.9 in GL
+		set to 0.06 which means 6 % of non-el fossil use (5600 Mtoe/y= 15 GtCO2/y \
+		in 2050) and non-fossil CO2 industrial processes (16 GtCO2/y) are equipped \
+		with CCS. Means capturing ca 2 GtCO2/y or 2000 big CCS plants. Is our \
+		estimate of what is assumed in TLTL. Could be achieved by 2100.
+	|
+
+"Cost of CCS $/tCO2"=
+	95
+	~	$/tCO2
+	~	DNV-GL assumes cost of CCS at 95 USD/tCO2 in 2020, delining to 70 in 2050 (with \
+		limited uptake). 
+		This means 85 EUR/tCO2 declining to 63 when 1 USD = 0.9 EUR. Supports \
+		Lavutslippsutvalget:
+		To make gas power with CCS competitive with conventional gas power requires a carbon \
+		price of 50 EUR/tCO2.
+		Since each toe emits 2.8 tCO2, the cost of CCS is around 2.8*50 = 150 \
+		EUR/toe.
+	|
+
+"Fraction fossil plus nuclear electricity (1)"=
+	( "Fossil electricity production TWh/y" + "Nuclear electricity production TWh/y" ) /\
+		 "Electricity production TWh/y"
+	~	1
+	~		|
+
+"Extra increase in demand for electricity from NE TWh/y"=
+	"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	*
+	"Extra use of electricity per reduced use of non-el FF MWh/toe"
+	~	TWh/y
+	~		|
+
+"CAPEX renewable el $/W"=
+	"CAPEX renewable el in 1980 $/W" * "Cost index for sun and wind capacity (1)"
+	~	$/W
+	~		|
+
+"ROC in fertilizer productivity 1/y"=
+	0.01
+	~	1/y [0,0.03,0.001]
+	~		|
+
+"ROC in soil quality in conv ag 1/y"=
+	0 + "sFUeoSQ<0" * ( "Fertilizer use in conv ag kgN/ha/y" / "Sustainable fertiliser use kgN/ha/y"\
+		 - 1 )
+	~	1/y
+	~		|
+
+Accumulated sun and wind capacity from 1980 GW= INTEG (
+	"Addition of sun and wind capacity GW/y",
+		Sun and wind capacity in 1980 GW)
+	~	Gha
+	~		|
+
+"Extra use of electricity per reduced use of non-el FF MWh/toe"=
+	3
+	~	
+	~	1.500 l of gasoline can be replaced with 3500 kWh when an electric car replaces a \
+		fossil car (ratio 3.5/1.5=2.3)
+		12.000 kWh heat in 1.000 l of heating oil can be replaced with 12.000 kWh heat from \
+		a heat pump drawing 3.000 KWh el (ratio 12/3 = 4)
+		A small petrol driven generator can generate 3kWh/h when drawing 1 liter of fuel pr \
+		hour.Can be replaced with a 2 kW electric engine (ratio 3kWh/1 liter = 3)
+		Old lightingen bulbs drawing 50 W can be replaced with LED drawing 8 W - I \
+		sort this as energy efficiency
+	|
+
+"Cost index for sun and wind capacity (1)"=
+	( 1 - "Cost reduction per doubling of sun and wind capacity (1)" ) ^ "Number of doublings in sun and wind capacity (1)"
+	~	
+	~		|
+
+"Cost of new electrification G$/y"=
+	( "Extra cost per reduced use of non-el FF $/toe" / 1000 )
+	* "Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	~	G$/y
+	~		|
+
+"Number of doublings in sun and wind capacity (1)"=
+	LN(2)+ LN(Accumulated sun and wind capacity from 1980 GW / Sun and wind capacity in 1980 GW\
+		)
+	~	1
+	~		|
+
+"Demand for fossil fuel for non-el use Mtoe/y"=
+	"Demand for fossil fuel for non-el use before NE Mtoe/y"
+	-
+	
+	"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"Fertilizer productivity index (1980=1)"=
+	EXP("ROC in fertilizer productivity 1/y" * ( Time - 1980))
+	~	1
+	~		|
+
+"Demand for electricity TWh/y"=
+	"Demand for electricity before NE TWh/y"
+	+
+	"Extra increase in demand for electricity from NE TWh/y"
+	~	TWh/y
+	~		|
+
+"Extra cost per reduced use of non-el FF $/toe"=
+	10
+	~	$/toe [0,200,10]
+	~	It costs an extra 200.000 kr/y in battery and power to save 1.500 liters \
+		of fuel (Ratio 15k$/1.5 toe=10)
+	|
+
+"Fertilizer use in conv ag kgN/ha/y"=
+	"Traditional fertilizer use in conv ag kgN/ha/y" / "Fertilizer productivity index (1980=1)"
+	~	kgN/ha/y
+	~		|
+
+"Cost reduction per doubling of sun and wind capacity (1)"=
+	0.2
+	~	1 [0,1,0.01]
+	~		|
+
+"Traditional fertilizer use in conv ag kgN/ha/y"= WITH LOOKUP (
+	"Desired crop yield in conv ag t-crop/ha/y",
+		([(1,0)-(10,600)],(1,0),(2,40),(2.5,50),(3,60),(3.5,70),(4.5,100),(6.5,200),(10,600\
+		) ))
+	~	
+	~	211030: Changed to fit UG numbers from FAO
+	|
+
+Sun and wind capacity in 1980 GW=
+	10
+	~	GW
+	~	Renewable capacity 300 minus hydro capacity 290
+	|
+
+"Addition of fossil el capacity GW/y"=
+	MAX(0, "Desired fossil el capacity change GW/y")
+	~	GW/y
+	~		|
+
+Desired renewable el capacity change GW=
+	Desired renewable el capacity GW - Renewable electricity capacity GW
+	~	GW
+	~		|
+
+Desired renewable el capacity GW=
+	"Desired supply of renewable electricity TWh/y" / "Renewable capacity up-time kh/y"
+	~	GW
+	~		|
+
+"Desired fossil el capacity change GW/y"=
+	( Desired fossil el capacity GW - Fossil electricity capacity GW ) / Fossil el cap construction time y
+	+
+	"Discard of fossil el capacity GW/y"
+	~	GW
+	~		|
+
+"Addition of renewable el capacity GW/y"=
+	MAX(0, ( Desired renewable el capacity change GW / Renewable el construction time y \
+		)
+	+
+	( "Discard of renewable el capacity GW/y" ))
+	~	GW/y
+	~		|
+
+"Renewable electricity production TWh/y"=
+	Renewable electricity capacity GW
+	* 
+	"Renewable capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+"Fossil capacity up-time kh/y"=
+	"Demand for fossil electricity TWh/y" / Fossil electricity capacity GW
+	~	kh/y
+	~	 8760 hours per year
+	|
+
+"8 khours per year"=
+	8
+	~	kh/y
+	~	8760 hours in a year
+	|
+
+"sFCUTeoLOFC>0"=
+	0.5
+	~	1 [0,1,0.1]
+	~	was 0.1, should be 1?
+	|
+
+Normal life of fossil el capacity y=
+	40
+	~	y
+	~	was 25
+	|
+
+"Demand for fossil electricity TWh/y"=
+	MAX(0, "Demand for electricity TWh/y" - "Low-carbon el production TWh/y")
+	~	TWh/y
+	~		|
+
+Fossil el cap construction time y=
+	3
+	~	
+	~		|
+
+Life of fossil el capacity y=
+	Normal life of fossil el capacity y * "FCUTeoLOFC (1)"
+	~	y [0,50,1]
+	~		|
+
+Renewable el construction time y=
+	3
+	~	
+	~		|
+
+Desired fossil el capacity GW=
+	"Demand for fossil electricity TWh/y" / "8 khours per year"
+	~	GW
+	~		|
+
+"FCUTeoLOFC (1)"=
+	1 + "sFCUTeoLOFC>0" * ( ("Fossil capacity up-time kh/y" / "8 khours per year" ) - 1 \
+		)
+	~	1
+	~		|
+
+"CH4 from production of fossil fuels GtCH4/y"=
+	0
+	~	
+	~		|
+
+"Use of fossil fuels Mtoe/y"=
+	"Demand for fossil fuel for non-el use Mtoe/y"
+	+
+	"Fossil fuels for electricity Mtoe/y"
+	~	Mtoe/y
+	~		|
+
+"Normal increase in energy efficiency 1/y"=
+	0.01
+	~	1/y
+	~		|
+
+"OPEX renewable el $/kWh"=
+	0.001
+	~	$/kWh
+	~		|
+
+"Renewable el fraction in 1980 (1)"=
+	0.065
+	~	1
+	~		|
+
+"Electricity balance (1)"=
+	"Electricity production TWh/y" / "Demand for electricity TWh/y"
+	~	1
+	~		|
+
+"Electricity production TWh/y"=
+	"Fossil electricity production TWh/y"
+	+ "Nuclear electricity production TWh/y"
+	+ "Renewable electricity production TWh/y"
+	~	TWh/y
+	~		|
+
+"Biomass energy Mtoe/y"=
+	0
+	~	Mtoe/y
+	~		|
+
+"CAPEX fossil el $/W"=
+	0.7
+	~	$/W
+	~	211117 changed from: 5.5
+		2.2 Gkr for 0.4 GW gas utility Kårstø 2006 = 5.5 kr/W = 0.7 $/W
+	|
+
+"Extra energy productivity index 2022=1"= INTEG (
+	"Increase in extra energy productivity index 1/y",
+		"Extra energy productivity index in 2022 (1)")
+	~	1
+	~		|
+
+Life of renewable el capacity y=
+	40
+	~	y
+	~		|
+
+"Fossil electricity production TWh/y"=
+	Fossil electricity capacity GW * "Fossil capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+Nuclear capacity GW= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,400)],(1980,75),(2000,310),(2020,310),(2098.9,310) ))
+	~	GW
+	~		|
+
+"Nuclear capacity up-time kh/y"=
+	8
+	~	h/y
+	~	Full time is 8760 h/y
+	|
+
+"Nuclear electricity production TWh/y"=
+	Nuclear capacity GW
+	* "Nuclear capacity up-time kh/y"
+	~	TWh/y
+	~		|
+
+Renewable el capacity in 1980 GW=
+	300
+	~	GW [0,1000,10]
+	~	was 200
+	|
+
+Fossil electricity capacity GW= INTEG (
+	"Addition of fossil el capacity GW/y"-"Discard of fossil el capacity GW/y",
+		Fossil el capacity in 1980 GW)
+	~	GW
+	~		|
+
+"CAPEX renewable el in 1980 $/W"=
+	7
+	~	$/W [0,10,1]
+	~	211117: changed from 10
+	|
+
+"Renewable el fraction in 2022 (1)"=
+	0.23
+	~	1 [0,1,0.01]
+	~		|
+
+"Discard of renewable el capacity GW/y"=
+	Renewable electricity capacity GW / Life of renewable el capacity y
+	~	GW/y
+	~		|
+
+"Low-carbon el production TWh/y"=
+	"Renewable electricity production TWh/y" + "Nuclear electricity production TWh/y"
+	~	TWh/y
+	~		|
+
+Fossil el capacity in 1980 GW=
+	980
+	~	GW [900,1000,10]
+	~	was 950
+	|
+
+"Fossil fuels for electricity Mtoe/y"=
+	"Fossil electricity production TWh/y" / "4 TWh-el per Mtoe"
+	~	Mtoe/y
+	~		|
+
+"Discard of fossil el capacity GW/y"=
+	Fossil electricity capacity GW/ Life of fossil el capacity y
+	~	GW/y
+	~		|
+
+"Increase in extra energy productivity index 1/y"=
+	"Extra energy productivity index 2022=1" * 0 + STEP("Extra ROC in energy productivity after 2022 1/y"\
+		, 2022)
+	~	1/y
+	~		|
+
+"Fraction new electrification in 2022 (1)"=
+	0.03
+	~	1 [0,0.01,0.001]
+	~	was 0.03
+	|
+
+"Extra energy productivity index in 2022 (1)"=
+	1
+	~	1
+	~		|
+
+Renewable electricity capacity GW= INTEG (
+	"Addition of renewable el capacity GW/y"-"Discard of renewable el capacity GW/y",
+		Renewable el capacity in 1980 GW)
+	~	GW
+	~		|
+
+"Renewable capacity up-time kh/y"=
+	3
+	~	h/y
+	~	Full time is 8760 hours per year. 3000 h/y is 34%.
+	|
+
+"Fraction new electrification in 1980 (1)"=
+	0
+	~	 [0,0.1,0.01]
+	~		|
+
+"Extra ROC in energy productivity after 2022 1/y"=
+	0.002
+	~	1/y [0,0.004,0.001]
+	~	0.002 in TLTL and 0.004 in GL
+		220221 changed from 0 to 0.002 to match SSP
+	|
+
+Perceived warming deg C=
+	SMOOTH(Observed warming deg C, Perception delay y)
+	~	deg C
+	~		|
+
+"Grazing land yield kg-red-meat/ha/y"=
+	"Grazing land yied in 1980 kg-red-meat/ha/y"
+	+ 0 * CO2 concentration in atm ppm
+	- 0 * Observed warming deg C
+	~	kg/ha/y
+	~		|
+
+"Cropland expansion rate 1/y"=
+	1/200 + "sFBeoCLE<0" * ( "Perceived crop balance (1)" - 1 )
+	~	1/y
+	~		|
+
+"Biofuels use Mtoe/y"= WITH LOOKUP (
+	Time,
+		([(1980,0)-(2100,200)],(1980,0),(1990,0),(2000,0),(2020,0),(2100,0) ))
+	~	Mt/y
+	~	was \
+		([(1980,0)-(2100,200)],(1980,0),(1990,0),(2000,2.5),(2020,40),(2100,40) )
+	|
+
+"Perceived crop balance (1)"=
+	"Crop balance (1)"/
+	(1 + "Desired reserve capacity (1)" )
+	~	1
+	~		|
+
+"Red meat supply per person kg-red-meat/p/y"=
+	("Red meat from grazing land Mt-red-meat/y"
+	+
+	"Red meat from feedlots Mt-red-meat/y" * MIN(1, "Crop balance (1)") )
+	* 1000
+	/
+	Population Mp
+	~	kg/p/y
+	~		|
+
+"Desired crop supply conv ag Mt-crop/y"=
+	"Desired crop supply Mt-crop/y" - "Crop supply reg ag Mt-crop/y"
+	~	Mt/y
+	~		|
+
+"Traditional use of crops ex red meat per person kg-crop/p/y"=
+	"Traditional use of crops ex red meat Mt/y" * 1000
+	/
+	Population Mp
+	~	kg/p/y
+	~		|
+
+"Traditional use of crops Mt/y"=
+	"Traditional use of crops per person kg-crop/p/y" * Population Mp / 1000
+	~	
+	~		|
+
+"Traditional use of feed for red meat Mt-crop/y"=
+	((("Traditional use of red meat per person kg-red-meat/p/y" / 1000) * Population Mp \
+		) - "Red meat from grazing land Mt-red-meat/y"
+	)*"kg-crop per kg-red-meat"
+	~	Mt/y
+	~		|
+
+"Crops for biofuel Mt-crop/y"=
+	"Biofuels use Mtoe/y" * Ton crops per toe biofuel
+	~	Mt/y
+	~		|
+
+Ton crops per toe biofuel=
+	0
+	~	t/toe
+	~	I think it should be around 4
+	|
+
+Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2=
+	12
+	~	Mkm2
+	~	220221 UG/ESMICON view: relevant Arctic is 12 - 11 Mkm2 1980 - 2020 (minus 9 %) and \
+		other galciers (except permafrost) is <1 Mkm2
+		Total area covered by ice and snow is 46 Mkm2
+		If we disregard Greenland 2.2 Mkm2 and Antarctica 14.2 Mkm2, the rest (that is \
+		likely to melt duirng this century) is some 30 Mkm2. It has declined by 10 \
+		% from 1980 to 2020.
+		(Onland ice and snow was 5000 Gha in 1980 and declined to 4600 Gha in 2018 \
+		(I believe HYDE))
+	|
+
+"Ice and snow cover excl G&A Mkm2"= INTEG (
+	-"Melting Mha/y",
+		Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2)
+	~	Gkm2
+	~	Total area covered by ice and snow is 46 Mkm2
+		If we disregard Greenland 2.2 Mkm2 and Antarctica 14.2 Mkm2, the rest \
+		(that is likely to melt duirng this century) is some 30 Mkm2. It has \
+		declined by 10 % from 1980 to 2020.
+	|
+
+GtCO2 per ppm=
+	7.9
+	~	GtCO2/ppm [7.8,8,0.01]
+	~	211102 changed from 1.8 to 7.92 as per ESMICON
+	|
+
+CO2 in atm in 1980 GtCO2=
+	2600
+	~	GtCO2
+	~	211103: changed from 600
+	|
+
+kg CH4 per $ of GDP=
+	0
+	~	
+	~		|
+
+CO2 in atmosphere GtCO2= INTEG (
+	"CO2 emissions GtCO2/y"+"CO2 from CH4 GtCO2/y"-"CO2 absorption GtCO2/y"+"CO2 from CH4 GtCO2/y"\
+		,
+		CO2 in atm in 1980 GtCO2)
+	~	GtC
+	~		|
+
+"CH4 breakdown GtCH4/y"=
+	CH4 in atmosphere GtCH4 / Life of CH4 in atm y
+	~	Gt/y
+	~		|
+
+Life of CH4 in atm y=
+	7.5
+	~	y [0,10,1]
+	~	was 11, so 7, so 8
+	|
+
+"Traditional use of red meat per person kg-red-meat/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(100,40)],(0,0),(6.1,6),(8.8,8.5),(14,13),(30,27),(40,32),(50,33),(100,25) \
+		))
+	~	
+	~	Equal to traditional use growing asymptotically towards ca 40 kg/p/y, \
+		minus "automatic" red-meat-use-index falling from 100% at 40 k$/p/y to 70% \
+		at 100 k$/p/y as a consequence of more educated eating habits
+	|
+
+"Traditional use of crops per person kg-crop/p/y"= WITH LOOKUP (
+	"GDP per person k$/p/y",
+		([(0,0)-(100,2000)],(0,400),(6.1,680),(8.7,780),(13.9,950),(20,1050),(30,1150),(40,\
+		1250),(60,1350),(100,1550) ))
+	~	kg/p/y
+	~	211029: Estimated from UG FAO. Disregarding biofuel use growing from 0 in \
+		2000 to 200 in 2020.
+	|
+
+"Urban expansion Mha/y"=
+	MAX(0, ( Indicated urban land Mha - Urban land Mha ) / Urban development time y)
+	~	Mha/y
+	~		|
+
+"Crop yield in reg ag t-crop/ha/y"=
+	5
+	~	t/ha/y [0,10,1]
+	~	5 (reduced from 7 on 220427 to get acceptable fertilizer forecast)
+	|
+
+"Change in soil quality in conv ag t-crop/ha/y/y"=
+	"ROC in soil quality in conv ag 1/y" * "Soil quality index in conv ag (1980=1)"
+	~	t/ha/y/y
+	~		|
+
+"Crop supply reg ag Mt-crop/y"=
+	"Crop yield in reg ag t-crop/ha/y" * Cropland Mha * "Fraction regenerative agriculture (1)"
+	~	Mt/y
+	~		|
+
+Indicated urban land Mha=
+	Population Mp * "Urban land per population ha/p"
+	~	Mha
+	~		|
+
+"Desired crop yield in conv ag t-crop/ha/y"=
+	"Desired crop supply conv ag Mt-crop/y" / ( Cropland Mha * ( 1 - "Fraction regenerative agriculture (1)"\
+		 ))
+	~	t/ha/y
+	~		|
+
+"Feed for red meat Mt-crop/y"=
+	"Red meat from feedlots Mt-red-meat/y" * "kg-crop per kg-red-meat"
+	~	Mt/y
+	~		|
+
+"kg-crop per kg-red-meat"=
+	24
+	~	kg/kg [1,30,1]
+	~	cattle 25, lamb 15, pork 6.4, poultry 3.3 (OWID)
+		One third each of 1) red meat (90% cattle, 10% lamb), 2) pork and 3) \
+		poultry
+	|
+
+"sFUeoSQ<0"=
+	-0.001
+	~	1 [-0.001,-0,0.0001]
+	~	was -0.001, so -0.0005, so 0, so 0.0005, so -0.0002
+	|
+
+"Sustainable fertiliser use kgN/ha/y"=
+	20
+	~	kgN/ha/y [0,40,5]
+	~		|
+
+"sGReoCR<0"=
+	0
+	~	 [-1,1,0.1]
+	~		|
+
+"Normal corporate credit risk 1/y"=
+	0.02 * ( 1 + "sGReoCR<0" * ( "Output growth rate 1/y" / 0.03 - 1 ))
+	~	1/y [0,0.2,0.01]
+	~		|
+
+Barren land Mha= INTEG (
+	"Cropland loss Mha/y",
+		3000)
+	~	Mha
+	~	From HYDE: Barren land 3.000 Mha i 2017
+	|
+
+Old growth forest in 1980 Mha=
+	2600
+	~	Mha
+	~	From Earth3: Sum of Northern forest 1000 (slowly growing at 0.3 %/y) and Southern \
+		forest 1600 (declinig at 1 %/y)
+		Similar to HYDE: Sum of Wild remote woodlands 1550 plus Seminatural remote \
+		woodlands 850
+	|
+
+"Fraction cleared for grazing (1)"=
+	0.1
+	~	1 [0,1,0.1]
+	~	Since grazing land data show a stable area, forest must have been removed \
+		(ca 10 Mha/y) to increase cropland (soya?) (+7 Mha/y?)and to replace \
+		cropland loss (3 Mha/y?).
+	|
+
+Old growth forest area Mha 1= INTEG (
+	-"New forestry land Mha/y"-"New grazing land Mha/y",
+		Old growth forest in 1980 Mha)
+	~	Mha
+	~		|
+
+"Potential red meat from grazing land Mt-red-meat/y"=
+	Grazing land Mha * "Grazing land yield kg-red-meat/ha/y" / 1000
+	~	Mt/y
+	~		|
+
+"sFUeoLER>0"=
+	0.02
+	~	1 [-0.1,0,0.01]
+	~	GUSTIMATE: 100 kgNP/ha/y halves cropland life from 250 to 125 years
+	|
+
+"Desired reserve capacity (1)"=
+	0.05
+	~	1 [0,0.3,0.01]
+	~	0.1 sounds more reasonable
+	|
+
+"sFBeoCLE<0"=
+	-0.03
+	~	1 [-0.1,0,0.01]
+	~	was 0.1, so 0.01,0.015, 0.02, 0.03, 0.005, - 0.004, so -0.04, so -0.05
+		JR guestimate, based on fact that cropland has only expanded by some 10% \
+		since 1980
+	|
+
+"Soil quality index in conv ag (1980=1)"= INTEG (
+	"Change in soil quality in conv ag t-crop/ha/y/y",
+		"Soil quality index in 1980 (1)")
+	~	t/ha/y
+	~		|
+
+Forestry land in 1980 Mha=
+	1100
+	~	Mha
+	~	From HYDE: Woodlands 3500 minus Wild remote 1550 and seminatural woodlands \
+		remote 850
+	|
+
+Cropland in 1980 Mha=
+	1450
+	~	Mha [1350,1450,10]
+	~	Was 1350 Mha - From Earth3, but similar to HYDE - rising to 1500 in 2020
+		211030: changed to 1420 from UG FAO
+	|
+
+"Urban land per population ha/p"=
+	0.05
+	~	1 [0.04,0.06,0.001]
+	~	From HYDE: 215, 285, 320 in 1980, 2000, 2017
+		Means 0.049, 0.048, 0.041 ha/p ie around 500 m2 per person or 200 p/km2
+	|
+
+"Soil quality index in 1980 (1)"=
+	1
+	~	t/ha/y
+	~		|
+
+Grazing land Mha= INTEG (
+	"New grazing land Mha/y",
+		Grazing land in 1980 Mha)
+	~	Mha
+	~		|
+
+Urban land Mha= INTEG (
+	"Urban expansion Mha/y",
+		Urban land in 1980 Mha)
+	~	Mha
+	~		|
+
+Grazing land in 1980 Mha=
+	3300
+	~	Mha
+	~	OWID and HYDE. Disregarding Rangeland 2.200,Pasture 0.8, forest converted \
+		to rangeland 300
+	|
+
+Urban land in 1980 Mha=
+	215
+	~	Mha
+	~	From HYDE: 215, 285, 320 in 1980, 2000, 2017
+		Means 0.049, 0.048, 0.041 ha/p ie around 500 m2 per person or 200 p/km2
+	|
+
+Urban development time y=
+	10
+	~	y
+	~	should be longer if we want to test urbanisation policies
+	|
+
+Global surface Mkm2=
+	510
+	~	Mkm2
+	~	Global surface is 510 Mkm2. Land surface is 150 Mkm2, some 30% of total.
+	|
+
+"Heat required to melt ice kJ/kg"=
+	333
+	~	kJ/kg
+	~	smeltevarnen er 6 kJ/mol og jeg gjetter at 1 mol er 1+1+16 = 18 g
+	|
+
+"sOWeoMR>0"=
+	1
+	~	1 [0,1,0.1]
+	~	was 0.01, 0.001
+	|
+
+"sEHeoOW>0"=
+	0.8
+	~	1 [0,1,0.05]
+	~	was 0.5, 0.7
+	|
+
+Ton per m3 ice=
+	0.95
+	~	t/m3
+	~		|
+
+CO2 concentration in 1980 ppm=
+	330
+	~	ppm
+	~		|
+
+Extra heat in 1980 ZJ=
+	0
+	~	ZJ [0,500,100]
+	~	220221 Changed definition so zero by definition
+	|
+
+"Past GDP per person k$/y"=
+	SMOOTHI("GDP per person k$/p/y" , Time to establish growth rate y, "GDP per person in 1980 k$/p/y"\
+		 * "Factor to avoid transient in growth rate (1)")
+	~	k$/p/y
+	~		|
+
+"RATE OF GROWTH IN GDP PER PERSON 1/y"=
+	(( "GDP per person k$/p/y" - "Past GDP per person k$/y" ) / "Past GDP per person k$/y"\
+		)
+	/
+	Time to establish growth rate y
+	~	1/y
+	~		|
+
+"Factor to avoid transient in growth rate (1)"=
+	0.93
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+Time to establish growth rate y=
+	4
+	~	y
+	~		|
+
+"Fraction of extra taxes paid by owners (1)"=
+	0.5
+	~	 [0,1,0.1]
+	~	0.5 in TLTL and 0.8 in GL
+	|
+
+"CO2 absorption GtCO2/y"=
+	( CO2 in atmosphere GtCO2 - CO2 in atm in 1850 GtCO2 ) / Life of extra CO2 in atm y
+	~	GtCO2/y
+	~		|
+
+Perception delay y=
+	5
+	~	y [0,10,1]
+	~		|
+
+"Govmnt share of GDP (1)"=
+	"Govmnt spending G$/y" / "National income G$/y"
+	~	
+	~		|
+
+CO2 in atm in 1850 GtCO2=
+	2200
+	~	GtCO2 [0,500,50]
+	~		|
+
+"Control: (C+G+S)/NI = 1"=
+	"Consumption share of GDP (1)" + "Govmnt share of GDP (1)" + "Savings share of GDP (1)"
+	~	1
+	~		|
+
+"Consumption per person G$/y"=
+	"Consumption demand G$/y" /  Population Mp
+	~	G$/y
+	~		|
+
+"Output Gu/y"=
+	"Optimal real output Gu/y" * "Shifts worked - index (1)" / "SWI in 1980 (1)"
+	~	Gu/y
+	~		|
+
+"Price Index (1980=1)"= INTEG (
+	"Change in Price Index 1/y",
+		"Price Index in 1980 (=1)")
+	~	dmnl
+	~		|
+
+"Price Index in 1980 (=1)"=
+	1
+	~	 [0,5,0.1]
+	~		|
+
+"10-yr govmnt interest rate 1/y"=
+	"Govmnt borrowing cost 1/y" + "Expected long term inflation 1/y"
+	~	1/y
+	~		|
+
+"Expected long term inflation 1/y"=
+	SMOOTHI("Perceived inflation CB 1/y", Inflation expectation formation time y, "Inflation in 1980 (1/y)"\
+		)
+	~	1/y
+	~		|
+
+Inflation expectation formation time y=
+	10
+	~	y [0,20,1]
+	~		|
+
+"Delivery delay - index (1)"= INTEG (
+	"Change in DDI 1/y",
+		1)
+	~	1
+	~		|
+
+"Corporate borrowing cost in 1980 1/y"=
+	"Normal signal rate 1/y" + "Normal basic bank margin 1/y" + "Normal bank operating margin 1/y"\
+		 + "Normal corporate credit risk 1/y"
+	~	1/y
+	~	220207 corrected an error!"Normal corporte credit risk" appeared twice in \
+		sum.
+	|
+
+"Excess demand (1)"=
+	"Total purchasing power G$/y" / "Optimal ouput - value G$/y"
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+"Public services per person in 1980 k$/p/y"=
+	0.58
+	~	k$/p/y
+	~		|
+
+"Demand pulse 2020-25 (1)"=
+	0 + "Pulse height (1)"* PULSE(2020,5)
+	~	1 [0,0.1,0.01]
+	~	was 0.01
+	|
+
+OCI in 1980=
+	7081
+	~	G$/y
+	~	was 307
+	|
+
+WFI in 1980=
+	13000
+	~	G$/y [10000,30000,1000]
+	~	was 1059
+		211127 changed from 14000
+		211126 changed from 19015
+	|
+
+"Permanent govmnt cash inflow G$/y"=
+	SMOOTHI("Govmnt cash inflow G$/y", Time to adjust budget y, GCI in 1980)
+	~	G$/y
+	~		|
+
+"Permanent owner cash inflow G$/y"=
+	SMOOTHI("Owner cash inflow G$/y", Time to adjust owner consumption y, OCI in 1980)
+	~	G$/y
+	~		|
+
+"Total purchasing power G$/y"=
+	"Worker cash inflow G$/y" + "Govmnt cash inflow G$/y" + "Owner cash inflow G$/y" - "Sales tax G$/y"
+	~	G$/y
+	~		|
+
+"Pulse height (1)"=
+	0
+	~	1 [0,0.1,0.01]
+	~	was 0.04
+	|
+
+Worker debt burden y=
+	Workers debt G$ / "Worker income after tax G$/y"
+	~	y
+	~		|
+
+GCI in 1980=
+	5400
+	~	G$/y [2000,6000,100]
+	~	was 276
+		211126 changed from 2576
+	|
+
+"Permanent worker cash inflow G$/y"=
+	SMOOTHI("Worker cash inflow G$/y", Time to adjust worker consumption y, WFI in 1980)
+	~	G$/y
+	~		|
+
+"Worker finance cost as share of income (1)"=
+	"Cash flow from workers to banks G$/y" / "Worker income after tax G$/y"
+	~	1
+	~		|
+
+"Owner consumption G$/y"=
+	"Permanent owner cash inflow G$/y" * "Owner consumptin fraction (1)"
+	~	G$/y
+	~		|
+
+"CLR in 1980 k$/j"=
+	41
+	~	k$/j [8,12,0.1]
+	~	was 10
+		220113 changed from 9.8 to 10 for China
+		211222 Equal to capacity (3750 cu) divided by Available work seekers (383 Mp) = 9.8 \
+		for China in 1980
+		was 41
+		211127 changed from 44.7 to get suitable amplitude for new lower savings \
+		slope. Equilibrium 40.3
+	|
+
+"sWSOeoFRA<0"=
+	-2.5
+	~	1 [-4,-0.1,0.1]
+	~	was -1, so -3, so -5, so -10, so -2.4, so -1, so -2
+	|
+
+"Investment in new capacity PIS G$/y"=
+	"Available capital G$/y" * "Fraction of available capital to new capacity (1)"
+	~	G$/y
+	~		|
+
+INV in 1980 Gu=
+	"Optimal output in 1980 Gu/y" * "SWI in 1980 (1)" * Desired inventory coverage y
+	~	Gu
+	~		|
+
+"sCBCeoFRA<0"=
+	-0.8
+	~	1 [-1,0,0.1]
+	~	as -0.5
+		211125 changed from -0.8 - after intro of PUS
+	|
+
+"CBC effect on flow to capacity addion (1)"=
+	1 + "sCBCeoFRA<0" * ("Corporate borrowing cost 1/y" / "Corporate borrowing cost in 1980 1/y"\
+		 - 1 )
+	~	1
+	~		|
+
+"sINVeoSWI<0"=
+	-0.6
+	~	1 [-0.8,-0.4,0.01]
+	~	was -0.5
+	|
+
+"sINVeoDDI<0"=
+	-0.6
+	~	1 [-0.6,-0.4,0.01]
+	~	was -0.2, so -0.46, so -0.48, so -0.51
+	|
+
+"Change in DDI 1/y"=
+	"ROC in DDI 1/y"* "Delivery delay - index (1)"
+	~	1/y
+	~		|
+
+"Sufficient relative inventory (1)"=
+	1
+	~	1 [0.9,1.1,0.01]
+	~		|
+
+"Sales tax G$/y"=
+	"Sales tax workers G$/y" + "Sales tax owners G$/y"
+	~	G$/y
+	~		|
+
+"Effective purchasing power G$/y"=
+	SMOOTHI("Total purchasing power G$/y", Demand adjustment time y, "Demand in 1980 G$/y"\
+		) * 
+	( 1 +  "Demand pulse 2020-25 (1)")
+	~	G$/y [990,1010,1]
+	~		|
+
+"Desired shifts worked - index (1)"=
+	1 + "sINVeoSWI<0" * ("Perceived relative inventory (1)" / "Desired relative inventory (1)"\
+		 - 1 )
+	~	1
+	~		|
+
+"Available capital G$/y"=
+	"Total savings G$/y" + "Foreign capital inflow G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust shifts y=
+	0.24
+	~	y [0.2,0.3,0.001]
+	~	was 0.25
+	|
+
+"Shifts worked - index (1)"=
+	SMOOTH("Desired shifts worked - index (1)", Time to adjust shifts y)
+	~	1
+	~		|
+
+"ROC in DDI 1/y"=
+	0 + "sINVeoDDI<0" * ( "Perceived relative inventory (1)" / "Sufficient relative inventory (1)"\
+		 - 1 )
+	~	1/y
+	~		|
+
+"Desired relative inventory (1)"=
+	1
+	~	1
+	~		|
+
+"Foreign capital inflow G$/y"=
+	0
+	~	G$/y [0,500,50]
+	~		|
+
+Max workers debt burden y=
+	1
+	~	y [0,5,1]
+	~		|
+
+Max workers debt G$=
+	"Worker income G$/y" * Max workers debt burden y
+	~	G$
+	~		|
+
+"sEDeoFRA>0"=
+	5
+	~	1 [0,20,0.5]
+	~	210827 changed from: 1
+		was 0.2, so 0.05
+	|
+
+Time to observe excess demand y=
+	1
+	~	
+	~		|
+
+"Extra mult on CUC, to avoid initial transient in Investment share of GDP"=
+	1.7
+	~	1 [0.8,6,0.1]
+	~	Should be 1 in equilibrium
+	|
+
+"Excess demand in 1980 (1)"=
+	1
+	~	1 [0.8,1.1,0.01]
+	~	was 1.02, so .98, so .92, so 0.9, so 0.8, so 1, so 0.85
+	|
+
+"PCOR PIS cu/u/y"=
+	2.3
+	~	y [1,3.5,0.1]
+	~	was 2.5
+		211216 changed back from 2.3 to 2.5 to get slower growth
+		211125 changed from 2.5 (to get higher output - and lower pop growth in \
+		1980)
+	|
+
+"Excess demand effect on life of capacity (1)"=
+	1 + "sEDeoLOC>0" * ("Perceived excess demand (1)" / "Excess demand in 1980 (1)" - 1)
+	~	1
+	~		|
+
+CAP PIS in 1980 Gcu=
+	59250
+	~	Gcu [3000,4300,100]
+	~	was 4000
+		220113 changed from 3000 to 4000 to match China
+		was 70400, so 64520, so 59250, so 56000
+	|
+
+"Capacity addition PIS Gcu/y"=
+	Capacity under construction PIS Gcu / Construction time PIS y
+	~	Gcu/y
+	~		|
+
+"Capacity discard PIS Gcu/y"=
+	Capacity PIS Gcu / Life of capacity PIS y
+	~	Gcu/y
+	~		|
+
+Capacity PIS Gcu= INTEG (
+	"Capacity addition PIS Gcu/y"-"Capacity discard PIS Gcu/y",
+		CAP PIS in 1980 Gcu)
+	~	Gcu
+	~		|
+
+Capacity under construction PIS Gcu= INTEG (
+	"Capacity initiation PIS Gcu/y"-"Capacity addition PIS Gcu/y",
+		CUC PIS in 1980 Gcu)
+	~	Gcu
+	~	was 160
+	|
+
+Construction time PIS y=
+	1.5
+	~	y
+	~	was 2
+	|
+
+CUC PIS in 1980 Gcu=
+	( CAP PIS in 1980 Gcu / Life of capacity PIS in 1980 y ) * Construction time PIS y *\
+		 "Extra mult on CUC, to avoid initial transient in Investment share of GDP"
+	~	Gcu
+	~		|
+
+"ED effect on flow to capacity addition (1)"=
+	1 + "sEDeoFRA>0" * ( "Perceived excess demand (1)"/ "Excess demand in 1980 (1)" - 1 \
+		)
+	~	1
+	~		|
+
+"Output growth in 1980 1/y (to avoid transient)"=
+	0.06
+	~	1/y [0.02,0.08,0.001]
+	~	was 0.06
+	|
+
+"Output growth rate 1/y"=
+	SMOOTHI( ("Optimal real output Gu/y" - "Output last year G$/y" ) / "Output last year G$/y"\
+		 / 1, 1, "Output growth in 1980 1/y (to avoid transient)")
+	~	1/y
+	~		|
+
+"Output last year G$/y"=
+	SMOOTHI("Optimal real output Gu/y", 1, "Optimal output in 1980 Gu/y" / ( 1 + "Output growth in 1980 1/y (to avoid transient)"\
+		 ))
+	~	G$/y
+	~		|
+
+"Perceived excess demand (1)"=
+	SMOOTHI("Excess demand (1)", Time to observe excess demand y, 1)
+	~	1
+	~		|
+
+"ROC in embedded TFP 1/y"=
+	0.01
+	~	1/y [0,0.02,0.001]
+	~	was 0.007, was 0.009, so 0.004, so 0.008
+	|
+
+Kappa=
+	0.3
+	~	1 [0.3,0.7,0.05]
+	~		|
+
+Lambda=
+	1 - Kappa
+	~	1
+	~		|
+
+Life of capacity PIS in 1980 y=
+	15
+	~	y
+	~		|
+
+"Embedded TFP in 1980 (1)"=
+	1
+	~	1
+	~		|
+
+"sEDeoLOC>0"=
+	0.5
+	~	1 [0,2,0.1]
+	~	was 0.2, so 1
+	|
+
+Max govmnt debt G$=
+	"National income G$/y" * Max govmnt debt burden y
+	~	G$
+	~		|
+
+"Minimum relative inventory without inflation (1)"=
+	1.07
+	~	1 [0.9,1.1,0.01]
+	~	was 1.12, so 1.07, so 1
+	|
+
+"Savings share of GDP (1)"=
+	"Total savings G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Consumption share of GDP (1)"=
+	"Consumption demand G$/y" / "National income G$/y"
+	~	1
+	~		|
+
+"Perceived inflation CB 1/y"=
+	SMOOTHI("Inflation rate 1/y", Inflation perception time CB y, "Inflation in 1980 (1/y)"\
+		)
+	~	1/y [-0.04,0.04,0.01]
+	~		|
+
+"Govmnt finance as share of NI (1)"=
+	( "Govmnt interest cost G$/y" + "Govmnt payback G$/y" ) / "National income G$/y"
+	~	
+	~		|
+
+"Inflation rate 1/y"=
+	"sINVeoIN<0" * ( "Perceived relative inventory (1)" / "Minimum relative inventory without inflation (1)"\
+		 - 1 )
+	~	1/y
+	~		|
+
+"Owner savings G$/y"=
+	"Permanent owner cash inflow G$/y" - "Owner consumption G$/y"
+	~	G$/y
+	~		|
+
+Govmnt debt burden y=
+	Govmnt debt G$ / "National income G$/y"
+	~	y
+	~		|
+
+Sales averaging time y=
+	1
+	~	y [0,1,0.1]
+	~	was 0.25, so 0.5
+	|
+
+"Normal (1)"=
+	1
+	~	1
+	~		|
+
+DDI in 1980 y=
+	1
+	~	y [0.9,1.1,0.01]
+	~	DD was 0.2
+	|
+
+"Perceived relative inventory (1)"=
+	SMOOTH(Inventory coverage y / Desired inventory coverage y, Inventory coverage perception time y\
+		)
+	~	1
+	~		|
+
+Sampling time y=
+	0.1
+	~	y
+	~	roughly 1 months
+	|
+
+"sINVeoIN<0"=
+	-0.26
+	~	1 [-0.5,0,0.01]
+	~	was - 0.2, so -0.01, so -0.5, so - 0.34, s=.1, so -0.2, so -0.3, so -0.26, \
+		so 0
+	|
+
+Demand adjustment time y=
+	1.2
+	~	y [0.9,1.3,0.01]
+	~	was 0.6, so 1, so 1.2
+	|
+
+Inventory coverage perception time y=
+	0.25
+	~	y [0.01,0.5,0.01]
+	~	was 0.25, was 0.5, was 0.1, so0.5, so 0.1, so 0.2
+	|
+
+Inventory Gu= INTEG (
+	"Output Gu/y" - "Deliveries Gu/y",
+		INV in 1980 Gu)
+	~	Gu
+	~		|
+
+"STD in fluctuation around normal (1)"=
+	0
+	~	1 [0,0.05,0.01]
+	~	was 0.01
+	|
+
+Desired inventory coverage y=
+	0.4
+	~	y [0,0.5,0.01]
+	~	was 0.25, so 0.25, so 0.4
+	|
+
+"Pink noise in sales (1)"=
+	RANDOM PINK NOISE("Normal (1)" ,"STD in fluctuation around normal (1)", Sampling time y\
+		, 1)
+	~	1
+	~		|
+
+"Change in Price Index 1/y"=
+	"Price Index (1980=1)" * "Inflation rate 1/y"
+	~	1/y
+	~		|
+
+"SWI in 1980 (1)"=
+	1
+	~	1 [0.7,1.3,0.05]
+	~		|
+
+Inventory coverage y=
+	Inventory Gu / "Recent sales Gu/y"
+	~	y
+	~		|
+
+Workers debt in 1980 G$=
+	18992 * Mult to avoid transient in worker finance
+	~	G$ [18000,23000,100]
+	~	was 1062
+		was 18992
+		equal to one year's income after tax 22140, somewhat reduced to avoid \
+		initial transient
+	|
+
+Govmnt debt in 1980 G$=
+	28087 * Mult to avoid transient in govmnt finance
+	~	G$ [26000,30000,100]
+	~	was 1500
+		was 28160
+		Equal to one year's national income 28160, somewhat reduced to avoid \
+		transient
+	|
+
+Mult to avoid transient in govmnt finance=
+	0.64
+	~	1 [0.5,0.8,0.01]
+	~	was 0.8
+		was 0.59, so 0.64
+		211126 changed from 0.65
+		was 0.7, so 0.6
+	|
+
+Mult to avoid transient in worker finance=
+	0.39
+	~	1 [0,1,0.01]
+	~	was 0.54
+		was 0.39, so 0.49
+		211126 changed from 0.54
+		was 0.7, so 0.6
+	|
+
+"Corporate borrowing cost 1/y"=
+	"Cost of capital for secured debt 1/y" + "Normal corporate credit risk 1/y"
+	~	1/y
+	~		|
+
+"Worker borrowing cost 1/y"=
+	"Cost of capital for secured debt 1/y"
+	~	1/y
+	~		|
+
+"Worker interest cost G$/y"=
+	Workers debt G$ * "Worker borrowing cost 1/y"
+	~	G$/y
+	~		|
+
+"Govmnt borrowing cost 1/y"=
+	"3m interest rate 1/y"
+	~	1/y
+	~		|
+
+Unemployment perception time CB y=
+	1
+	~	y [0,2,0.1]
+	~	was 1, so 0.5
+	|
+
+"Bank cash inflow from lending G$/y"=
+	"Cash flow from workers to banks G$/y" + "Cash flow from govmnt to banks G$/y"
+	~	G$/y
+	~		|
+
+"Sales tax owners G$/y"=
+	"Owner consumption G$/y" * "Sales tax rate (1)"
+	~	G$/y
+	~		|
+
+"Sales tax rate (1)"=
+	0.03
+	~	1 [0,0.2,0.005]
+	~	In US 1980-2020 3%. Much higher in countries with VAT around 20 %
+		In PUS=0.22 was 0.08
+	|
+
+"Sales tax workers G$/y"=
+	"Worker consumption demand G$/y" * "Sales tax rate (1)"
+	~	G$/y
+	~		|
+
+"Worker consumption demand G$/y"=
+	"Permanent worker cash inflow G$/y" * "Worker consumption fraction (1)"
+	~	G$/y
+	~		|
+
+"Govmnt purchases G$/y"=
+	"Permanent govmnt cash inflow G$/y" * "Government consumption fraction (1)"
+	~	G$/y
+	~		|
+
+"Consumption demand G$/y"=
+	"Worker consumption demand G$/y" - "Sales tax workers G$/y"
+	+ 
+	"Owner consumption G$/y" - "Sales tax owners G$/y"
+	~	G$/y
+	~		|
+
+"Govmnt investment in public capacity G$/y"=
+	"Permanent govmnt cash inflow G$/y" - "Govmnt purchases G$/y"
+	~	G$/y
+	~		|
+
+"Govmnt spending G$/y"=
+	"Govmnt purchases G$/y" + "Govmnt investment in public capacity G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust budget y=
+	1
+	~	y
+	~		|
+
+"Worker savings G$/y"=
+	"Permanent worker cash inflow G$/y" - "Worker consumption demand G$/y"
+	~	G$/y
+	~		|
+
+Time to adjust owner consumption y=
+	1
+	~	y
+	~		|
+
+Time to adjust worker consumption y=
+	1
+	~	y
+	~		|
+
+"sUNeoWSO<0"=
+	-0.035
+	~	 [-0.05,-0.02,0.001]
+	~		|
+
+"Worker consumption fraction (1)"=
+	0.9
+	~	1 [0,1,0.05]
+	~	was 0.6
+		220112 changed from 0.85 to 0.6 for China
+		was 0.95
+		
+		211126 changed from 0.95 to get total savings above 0.3
+		was 0.95, so 0.8
+	|
+
+"Cash flow from govmnt to banks G$/y"=
+	"Govmnt interest cost G$/y" + "Govmnt payback G$/y" - "Govmnt new debt G$/y"
+	~	G$/y
+	~		|
+
+"Cash flow from workers to banks G$/y"=
+	"Worker interest cost G$/y" + "Workers payback G$/y" - "Workers new debt G$/y"
+	~	G$/y
+	~		|
+
+"Workers new debt G$/y"=
+	MAX(0, ( Max workers debt G$ - Workers debt G$ ) / Workers drawdown period y)
+	~	G$/y
+	~		|
+
+Owner savings fraction in 1980=
+	0.9
+	~	1 [0,1,0.1]
+	~	was 0.7
+		220112 changed from 0.9 to 0.7 for China
+		211216 changed back from 0.9 to 0.8 to give reasonable growth in GDP 1980 to 2020 \
+		after intro of inequity
+		211126 changed from 0.8 to get total savings rate above 0.3
+		was 0.66 so 0.9, 0.75, so 0.72, so 0.64
+	|
+
+"Extra transfer of govmnt budget to workers (1)"=
+	0
+	~	1 [0,0.5,0.1]
+	~	0 in TLTL and 0.2 in GL
+		on top of 0.3 in all runs
+	|
+
+"sGDPeoOSR<0"=
+	-0.06
+	~	1 [-0.1,0,0.005]
+	~	was 0
+		220112 changed from -0.13 to 0 to prove that declinig growth rate with rising GDPpp \
+		is not caused by savings rate
+		2112nn changed to -0.05 to avoid end of capitalism
+		211205 changed from 0.055 to -0.6 to match DC data correctly
+		211126 changed from -0.17 to fit DC f(GDPpp)
+		was -0.07, so -0.15, so -0.14, so -0.05
+	|
+
+Workers debt G$= INTEG (
+	"Workers new debt G$/y"-"Workers payback G$/y",
+		Workers debt in 1980 G$
+		)
+	~	G$
+	~		|
+
+Workers drawdown period y=
+	10
+	~	 [0,10,1]
+	~	Was 2
+	|
+
+"Govmnt cash inflow G$/y"=
+	"Govmnt net income G$/y" - "Cash flow from govmnt to banks G$/y"
+	~	G$/y
+	~		|
+
+"Owner consumptin fraction (1)"=
+	1 - "Owner savings fraction (1)"
+	~	1
+	~		|
+
+"Government consumption fraction (1)"=
+	0.75
+	~	 [0,1,0.05]
+	~	was 0.85
+	|
+
+"Workers payback G$/y"=
+	Workers debt G$ / Workers payback period y
+	~	G$/y
+	~		|
+
+"Worker cash inflow G$/y"=
+	"Worker income after tax G$/y" -  "Cash flow from workers to banks G$/y"
+	~	G$/y
+	~		|
+
+"Worker income after tax G$/y"=
+	"Worker income G$/y" - "Worker taxes G$/y" + "Transfer payments G$/y"
+	~	G$/y
+	~		|
+
+Workers payback period y=
+	20
+	~	y
+	~		|
+
+"Total savings G$/y"=
+	"Owner savings G$/y" + "Worker savings G$/y"
+	~	G$/y
+	~		|
+
+Govmnt drawdown period y=
+	10
+	~	y [0,10,1]
+	~	was 2
+	|
+
+Govmnt payback period y=
+	200
+	~	y [0,1000,100]
+	~	was 100, so 1000 (did not matter),
+	|
+
+"3m interest rate 1/y"=
+	"Central bank signal rate 1/y" + "Normal basic bank margin 1/y"
+	~	1/y
+	~		|
+
+Finance sector response time y=
+	1
+	~	y [0,2,0.1]
+	~	was 0.5
+	|
+
+"Change in signal rate 1/yy"=
+	( "Indicated signal rate 1/y" - "Central bank signal rate 1/y" ) / Signal rate adjustment time y
+	~	1/y/y
+	~		|
+
+"sUNeoSR<0"=
+	-1.5
+	~	1/yy [-2,0,0.01]
+	~	was -0.5, so -1
+	|
+
+"Normal bank operating margin 1/y"=
+	0.015
+	~	1/y
+	~		|
+
+"Normal basic bank margin 1/y"=
+	0.005
+	~	1/y [0,0.01,0.001]
+	~		|
+
+"sINeoSR>0"=
+	0.7
+	~	1 [0,1,0.01]
+	~	Should be 1? Was 0, so 0.2
+	|
+
+"Normal signal rate 1/y"=
+	0.02
+	~	1/y
+	~		|
+
+"Unemployment target (1)"=
+	0.05
+	~	1
+	~		|
+
+"Inflation in 1980 (1/y)"=
+	0.02
+	~	1/y
+	~		|
+
+Signal rate adjustment time y=
+	1
+	~	 [0,2,0.1]
+	~	was 0.3
+	|
+
+"Cost of capital for secured debt 1/y"=
+	SMOOTHI("3m interest rate 1/y" + "Normal bank operating margin 1/y", Finance sector response time y\
+		, "3m interest rate 1/y" + "Normal bank operating margin 1/y")
+	~	1/y
+	~		|
+
+Inflation perception time CB y=
+	1
+	~	y [0,2,0.1]
+	~		|
+
+"Inflation target 1/y"=
+	0.02
+	~	1/y [0,0.05,0.01]
+	~		|
+
+"Indicated signal rate 1/y"=
+	"Normal signal rate 1/y" * ( 1
+	+
+	"sINeoSR>0" * ("Perceived inflation CB 1/y" / "Inflation target 1/y" - 1)
+	+
+	"sUNeoSR<0" * ("Perceived unemployment CB (1)" / "Unemployment target (1)" - 1)
+	)
+	~	1/y
+	~		|
+
+"Population growth rate 1/y"=
+	"Birth rate 1/y" - "Death rate 1/y"
+	~	1/y
+	~		|
+
+"Aged 0-20 in 1980 Mp"=
+	2170
+	~	Mp [1950,2200,10]
+	~	was 2050, so 2170, so 491
+		211202 changed to 2050 from 2170
+		211127 changed from 2050
+		was 2025
+	|
+
+"Aged 0-20 years Mp"= INTEG (
+	"Births Mp/y"-"Passing 20 Mp/y",
+		"Aged 0-20 in 1980 Mp")
+	~	Mp
+	~	was 2025
+	|
+
+"Aged 20-40 in 1980 Mp"=
+	1100
+	~	Mp [1100,1300,20]
+	~	was 1220, so 1100, so 249
+		211202 changed from 1100 back to 1220
+		211127 changed from 1220
+		was1283
+	|
+
+"Aged 20-40 years Mp"= INTEG (
+	"Passing 20 Mp/y"-"Passing 40 Mp/y",
+		"Aged 20-40 in 1980 Mp")
+	~	Mp
+	~	was 1283
+	|
+
+LEmax=
+	85
+	~	y [70,100,1]
+	~	Maximum LE in 1980
+	|
+
+"Birth rate 1/y"=
+	"Births Mp/y" / Population Mp
+	~	1/y
+	~		|
+
+Time to adapt to higher income y=
+	10
+	~	y [1,20,1]
+	~	was 3
+	|
+
+"sLEeoPa>0"=
+	0.75
+	~	1
+	~	was 0.65, so 0.75, so 0.3
+	|
+
+"Pensioners per worker p/p"=
+	On pension Mp / "Aged 20-pension age Mp"
+	~	1
+	~		|
+
+"Aged 20-pension age Mp"=
+	"Aged 20-40 years Mp" + "Aged 40-60 Mp" + "Aged 60 + Mp" - On pension Mp
+	~	Mp
+	~		|
+
+On pension Mp=
+	"Aged 60 + Mp" * (Life expectancy y - Pension age y ) / ( Life expectancy y - 60 )
+	~	Mp
+	~		|
+
+"Fraction achieving desired family size (1)"=
+	0.8
+	~	1 [0,1,0.1]
+	~		|
+
+Order=
+	10
+	~	 [1,20,1]
+	~		|
+
+DNC in 1980=
+	4.3
+	~	1 [4,5,0.1]
+	~	was 4.5, so 4.2
+		211202 changed to 4.5 from 4.2
+		211126 changed from 4.5 to get pop to 6000 in 2000
+		DF in 1980 was 4.7 so 5.0 so 4.9 so 4.4, so 4.2, so 4.4
+	|
+
+"DNCalfa<0"=
+	0
+	~	1/k$/p/y [-0.02,0.04,0.001]
+	~	was 0.02
+		220113 Changed from 0 to 0.02 to avoid too rapid decline in pop towards 2100.
+		Rate of decline of Minimum DF was 0.015, AND THEN 0.05 so 0.001, so 0.007
+	|
+
+"Fraction women (1)"=
+	0.5
+	~	1 [0.4,0.5,0.01]
+	~		|
+
+DNCmin=
+	1.2
+	~	1 [0,2,0.1]
+	~	was 1.6, so 1.5
+		211202 changed from 1.5 to 1.6
+		211129 changed from 1.2 to compensate for change in age structure
+	|
+
+"Death rate 1/y"=
+	"Deaths Mp/y" / Population Mp
+	~	1/y
+	~		|
+
+LE at 60 y=
+	Life expectancy y - 60
+	~	y
+	~		|
+
+Pension age in 1980 y=
+	62
+	~	y [60,90,1]
+	~	220113 Changed back from 67 to 62, assuming that people under 20 also participate in \
+		the workforce.
+		220109 changed from 62 to 67 to get sufficient labour force (ie over 500 \
+		Mp)
+	|
+
+"Dependency ratio p/p"=
+	( "Aged 0-20 years Mp" + "Aged 60 + Mp" ) / ( "Aged 20-40 years Mp" + "Aged 40-60 Mp"\
+		 )
+	~	1
+	~		|
+
+Population Mp=
+	"Aged 0-20 years Mp" + "Aged 20-40 years Mp" + "Aged 40-60 Mp" + "Aged 60 + Mp"
+	~	Mp
+	~		|
+
+"Output u/y"=
+	0
+	~	u/y
+	~		|
+
+DNCgamma=
+	0.14
+	~	1/k$ [0,0.4,0.01]
+	~	was 0.12, so 0.17
+		211129 changed from 0.13 to 0.12 to compensate for new PUS and CLR
+		211127 changed from 0.22 at the same time as changing initial values of age groups
+		was 0.12, so 0.17, so 0.33, so 0.4, so 0.25, so 0.2, so 0.16
+	|
+
+LE in 1980=
+	67
+	~	y [61,74,1]
+	~	was 64
+		220113 changed from 67 to 62 to fit China
+		LE in 1980
+	|
+
+Fertile period y=
+	20
+	~	y
+	~		|
+
+LEgamma=
+	0.15
+	~	1/k$/p/y
+	~	Rate of increase in LE
+	|
+
+"GDP per person in 1980 k$/p/y"=
+	6.4
+	~	k$/p/y [1,5,0.1]
+	~	was 6.1
+	|
+
+LEalfa=
+	0.001
+	~	1/k$/p/y [0,0.002,0.0001]
+	~	Rate of increase in max LE after 1980
+	|
+
+Job creation delay y=
+	0.9
+	~	 [0,2,0.1]
+	~	was 1, so 0.8, so 0.7
+	|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 2100
+	~	Year
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 1980
+	~	Year
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  = 
+        TIME STEP
+	~	Year [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 0.015625
+	~	Year [0,?]
+	~	The time step for the simulation.
+	|
+
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Overview 
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+12,1,0,488,-238,408,126,3,135,0,8,-1,0,0,0,-1--1--1,0-0-0,|20||0-0-0,0,0,0,0,0,0
+This is the Earth4All-global jr model of a modern capitalist economy with endogenous distribution and an active state (the "Human World"). It is coupled to simple models of energy/climate and food/land (two important elements of the "Natural World"). The model is an early example of a (dynamic and causal)  global integrated assessment model, made to study the evolution of human wellbeing within planetary boundaries in the 21st century. Jorgen Randers 220501. Contact: jorgen.randers@bi.no 
+12,2,2492172,767,1589,279,272,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+10-year_wave
+12,3,1247126,1362,1590,277,271,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+4-year_cycle
+12,4,1050492,2170,2921,278,267,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Financial_cycle
+10,5,"sCBCeoFRA<0",860,650,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,6,"sWSOeoFRA<0",715,651,65,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,7,"Extra transfer of govmnt budget to workers (1)",2292,1950,68,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,8,0,1832,-244,266,116,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|18||255-0-0,0,0,0,0,0,0
+THE MODEL IS TYPICALLY UPDATED EVERY 1-2 MONTHS. THIS IS THE mov220501 VERSION WHICH EQUALS THE mov220327 VERSION WITH A FEW MINOR CHANGES MADE IN DARK BLUE. ALL CHANGES MADE SINCE THE mov220226 VERSION ARE MARKED RED. POLICY HANDLES ARE PINK. IMPORTANT CROSSLINKS ARE ORANGE. JR 220501
+12,9,0,3173,2286,462,313,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Inequity_emissions_land_use_1980-2100
+10,10,"Fraction of extra taxes paid by owners (1)",307,1801,99,28,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,11,"Extra general tax rate from 2022 (1)",1908,1951,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,12,"sOWeoLoCO2>0",241,656,69,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,13,"sOWeoACY<0",563,647,61,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,14,"sCO2CeoACY>0",395,655,69,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,15,"sGDPeoOSR<0",1002,652,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,16,"sIIEeoROTA<0",227,681,74,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,17,984824,778,2191,276,260,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Growth_1980-2020
+12,18,0,1233,-268,305,96,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|18|B|0-0-128,0,0,0,0,0,0
+This version of the model (mov220501 E4A-global jr ) is used to illustrate the two scenarios described in the "Earth for All" book, to be published September 1, 2022 --- the Too-Little-Too-Late scenario (TLTL) and the Giant Leap (GL) scenarios. Details will become available in a Technical report on www.clubofrome.org/Earth4All
+10,19,"Extra general tax rate from 2022 (1)",1272,201,74,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,20,"Extra transfer of govmnt budget to workers (1)",1274,356,103,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,21,"Fraction of govmnt debt cancelled in 2022 1/y",1261,-116,73,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,22,"Goal for extra income from commons (share of NI)",1286,437,103,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,23,"Goal for extra normal LPR (1)",583,693,79,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,24,Normal reform delay y,109,224,53,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,25,984826,730,330,423,307,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+1._Main_trends
+12,26,1312652,1362,2193,274,262,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Economic_development__1980_to_2020
+10,27,"Fraction of extra taxes paid by owners (1)",1267,283,76,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,28,"sOWeoTFP<0",396,686,57,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,29,"sOWeoCOC>0",237,716,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,30,"Extra domestic ROTA from 2022 1/y",767,682,74,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,31,"Goal for renewable el fraction (1)",1474,355,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,32,"Goal for fraction new electrification (1)",1477,279,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,33,"Goal for fraction of CO2-sources with CCS (1)",1493,442,78,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,34,"Exogenous introduction period?",104,66,51,26,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,35,Exogenous introduction period y,109,142,56,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,36,"Goal for crop waste reduction (1)",1470,-37,69,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,37,"Goal for fraction regenerative agriculture (1)",1484,48,95,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,38,"Goal for fraction new red meat (1)",1491,124,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,39,"Unconventional stimulus in PIS from 2022 (share of GDP)",1262,-34,88,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,40,"Unconventional stimulus in PUS from 2022 (share of GDP)",1272,49,107,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,41,"Max imported ROTA from 2022 1/y",1269,127,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,42,"Goal for extra fertility reduction (1)",1287,514,72,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,43,"Extra empowerment tax from 2022 (share of NI)",1292,580,82,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,44,"Extra pension tax from 2022 (share of NI)",1290,660,77,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,45,1050472,2033,330,436,300,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+2._Human_footprint
+12,46,984950,739,997,427,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+3._Consumption
+12,47,984938,1628,994,415,277,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+4._Wellbeing
+12,48,1443392,2496,987,392,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+5._Turnarounds
+10,49,"Direct air capture of CO2 in 2100 GtCO2/y",1484,662,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,50,"Extra ROC in energy productivity after 2022 1/y",1479,205,73,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,51,"Extra rate of decline in N2O per kg fertilizer from 2022 1/y",1480,520,83,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,52,"Extra rate of decline in CH4 pr kg crop after 2022 1/y",1483,591,87,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,53,"Extra ROC in food sector productivity from 2022 1/y",1464,-124,90,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Population
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Aged 0-20 years Mp",1028,218,43,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"Aged 20-40 years Mp",1226,221,43,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,"Aged 40-60 Mp",1379,226,40,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Aged 60 + Mp",1565,223,40,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,5,48,868,216,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,6,8,1,4,0,0,22,0,0,0,-1--1--1,,1|(957,219)|
+1,7,8,5,100,0,0,22,0,0,0,-1--1--1,,1|(898,219)|
+11,8,48,924,219,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,9,"Births Mp/y",924,244,38,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,10,12,2,4,0,0,22,0,0,0,-1--1--1,,1|(1162,219)|
+1,11,12,1,100,0,0,22,0,0,0,-1--1--1,,1|(1100,219)|
+11,12,12410,1135,219,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,13,"Passing 20 Mp/y",1135,251,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,14,16,3,4,0,0,22,0,0,0,-1--1--1,,1|(1328,221)|
+1,15,16,2,100,0,0,22,0,0,0,-1--1--1,,1|(1287,221)|
+11,16,12300,1312,221,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,17,"Passing 40 Mp/y",1312,253,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,18,20,4,4,0,0,22,0,0,0,-1--1--1,,1|(1505,222)|
+1,19,20,3,100,0,0,22,0,0,0,-1--1--1,,1|(1446,222)|
+11,20,12102,1480,222,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,21,"Passing 60 Mp/y",1480,255,53,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,22,48,1676,224,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,25,22,4,0,0,22,0,0,0,-1--1--1,,1|(1653,224)|
+1,24,25,4,100,0,0,22,0,0,0,-1--1--1,,1|(1617,224)|
+11,25,48,1635,224,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,26,"Deaths Mp/y",1635,243,42,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,27,Population Mp,1261,442,47,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,1,27,0,0,0,0,0,128,0,-1--1--1,,1|(1147,333)|
+1,29,2,27,0,0,0,0,0,128,0,-1--1--1,,1|(1243,333)|
+1,30,3,27,0,0,0,0,0,128,0,-1--1--1,,1|(1319,335)|
+1,31,4,27,0,0,0,0,0,128,0,-1--1--1,,1|(1409,335)|
+10,32,"Dependency ratio p/p",1127,108,44,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,33,1,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1076,164)|
+1,34,4,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1354,167)|
+1,35,2,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1176,164)|
+1,36,3,32,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1259,170)|
+10,37,Fertile period y,768,256,48,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,38,"Birth rate 1/y",1105,455,47,11,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,39,27,38,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1195,441)|
+10,40,Desired no of children 1,925,421,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,41,9,38,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1007,353)|
+10,42,"Fraction women (1)",761,224,63,17,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Death rate 1/y",1424,457,50,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,44,27,43,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1345,442)|
+1,45,25,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1536,331)|
+10,46,"Fraction achieving desired family size (1)",757,319,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,47,DNCmin,794,432,30,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,DNC in 1980,799,393,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,DNCgamma,790,479,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,50,"DNCalfa<0",859,506,38,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,51,47,40,0,0,0,0,0,128,0,-1--1--1,,1|(845,427)|
+1,52,48,40,0,0,0,0,0,128,0,-1--1--1,,1|(855,404)|
+1,53,49,40,0,0,0,0,0,128,0,-1--1--1,,1|(841,456)|
+1,54,50,40,0,0,0,0,0,128,0,-1--1--1,,1|(884,473)|
+10,55,LE in 1980,1787,335,36,11,8,3,0,16,0,0,0,0,-1--1--1,0-0-0,|12|U|255-0-0,0,0,0,0,0,0
+10,56,LEmax,1825,371,24,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,57,LEgamma,1816,409,33,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,58,LEalfa,1776,430,22,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,59,Life expectancy y,1677,383,55,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,60,56,59,0,0,0,0,0,128,0,-1--1--1,,1|(1773,374)|
+1,61,55,59,0,0,0,0,0,128,0,-1--1--1,,1|(1738,356)|
+1,62,57,59,0,0,0,0,0,128,0,-1--1--1,,1|(1764,399)|
+1,63,58,59,0,0,0,0,0,128,0,-1--1--1,,1|(1733,410)|
+10,64,LE at 60 y,1673,314,34,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,65,59,64,0,0,0,0,0,128,0,-1--1--1,,1|(1675,355)|
+1,66,64,26,0,0,0,0,0,128,0,-1--1--1,,1|(1657,284)|
+1,67,9,13,1,0,0,0,0,128,0,-1--1--1,,1|(1054,312)|
+1,68,13,17,1,0,0,0,0,128,0,-1--1--1,,1|(1219,296)|
+1,69,17,21,1,0,0,0,0,128,0,-1--1--1,,1|(1410,292)|
+10,70,Order,1267,103,21,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,71,70,13,0,0,0,0,0,128,1,-1--1--1,,1|(1205,171)|
+1,72,70,17,0,0,0,0,0,128,1,-1--1--1,,1|(1287,171)|
+1,73,70,21,0,0,0,0,0,128,1,-1--1--1,,1|(1367,174)|
+10,74,"GDP per person in 1980 k$/p/y",932,562,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"Effective GDP per person k$/p/y",1222,594,54,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,76,75,40,1,0,45,12,18,64,0,-1--1--1,|12|B|255-0-0,1|(1018,524)|
+1,77,75,59,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(1567,464)|
+1,78,74,40,1,0,0,0,0,128,0,-1--1--1,,1|(925,492)|
+10,79,"Aged 20-40 in 1980 Mp",788,138,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,80,79,2,0,0,0,0,0,128,1,-1--1--1,,1|(1002,177)|
+10,81,"Aged 0-20 in 1980 Mp",723,180,43,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,82,81,1,0,0,0,0,0,128,1,-1--1--1,,1|(868,197)|
+10,83,On pension Mp,1730,177,50,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,84,4,83,0,0,0,0,0,128,0,-1--1--1,,1|(1640,201)|
+10,85,Pension age y,1790,248,44,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,86,85,83,1,0,0,0,0,128,0,-1--1--1,,1|(1788,210)|
+10,87,"Pensioners per worker p/p",1695,104,53,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,88,2,92,1,0,0,0,0,128,0,-1--1--1,,1|(1369,145)|
+1,89,3,92,1,0,0,0,0,128,0,-1--1--1,,1|(1452,149)|
+1,90,4,92,0,0,0,0,0,128,0,-1--1--1,,1|(1516,164)|
+1,91,83,92,0,0,0,0,0,128,0,-1--1--1,,1|(1611,143)|
+10,92,"Aged 20-pension age Mp",1463,102,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,93,92,87,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1573,102)|
+1,94,83,87,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1717,150)|
+10,95,"GDP per person in 1980 k$/p/y",1682,467,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,96,95,59,0,0,0,0,0,128,0,-1--1--1,,1|(1679,427)|
+10,97,Observed fertility 1,911,336,32,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,98,42,9,0,0,0,0,0,128,0,-1--1--1,,1|(848,234)|
+1,99,37,9,0,0,0,0,0,128,0,-1--1--1,,1|(844,250)|
+1,100,97,9,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(902,300)|
+1,101,2,9,1,0,0,0,0,128,0,-1--1--1,,1|(1067,344)|
+10,102,"GDP per person k$/p/y",1289,505,57,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,103,102,75,1,0,0,12,2,128,0,-1--1--1,|12||0-0-0,1|(1282,582)|
+10,104,Time to adapt to higher income y,1382,596,53,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,105,104,75,0,0,0,0,0,128,0,-1--1--1,,1|(1309,595)|
+1,106,59,85,1,0,0,0,0,128,0,-1--1--1,,1|(1751,316)|
+10,107,"sLEeoPa>0",1840,306,38,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,108,107,85,0,0,0,0,0,128,0,-1--1--1,,1|(1819,282)|
+10,109,Pension age in 1980 y,1868,193,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,110,109,85,0,0,0,0,0,128,0,-1--1--1,,1|(1829,220)|
+1,111,55,85,0,0,0,0,0,128,0,-1--1--1,,1|(1787,298)|
+1,112,59,83,1,0,0,0,0,128,0,-1--1--1,,1|(1743,266)|
+12,113,3868092,1546,906,251,267,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Population_and_workforce
+10,114,"Population growth rate 1/y",1632,528,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,43,114,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1509,486)|
+1,116,38,114,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1356,489)|
+10,117,"sOWeoLE<0",2131,393,44,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,118,Time,2122,295,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,119,Perceived warming deg C,1792,542,54,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,120,Observed warming deg C,2224,360,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,121,"Warming effect on life expectancy (1)",1996,330,70,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,122,21,26,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1541,290)|
+1,123,70,26,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1440,168)|
+10,124,"Cost of Max fertility reduction (share of GDP)",306,298,81,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,125,"Cost of extra fertility reduction (share of GDP)",546,304,61,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,126,124,125,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(429,300)|
+1,127,74,75,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1073,577)|
+10,128,Extra pension age in 2022 y,2032,118,57,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,129,Extra pension age y,1995,193,44,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,130,Goal for extra pension age y,2189,182,50,50,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,131,130,129,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(2096,186)|
+1,132,128,129,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(2016,149)|
+1,133,129,85,0,0,0,0,3,128,0,255-128-192,|12||0-0-0,1|(1897,218)|
+10,134,"Aged 40-60 in 1980 Mp",877,107,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,135,"Aged 60+ in 1980 Mp",974,81,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,136,134,3,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1124,165)|
+1,137,135,4,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1263,149)|
+10,138,"Passing 20 in 1980 Mp/y",463,181,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,139,"Passing 40 in 1980 Mp/y",504,134,42,19,8,3,0,4,0,0,0,0,-1--1--1,-1--1--1,|12||255-0-0,0,0,0,0,0,0
+10,140,"Passing 60 in 1980 Mp/y",589,92,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,141,"Dying in 1980 Mp/y",704,74,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,142,141,26,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1164,157)|
+1,143,140,21,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1022,170)|
+1,144,139,17,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(895,191)|
+1,145,138,13,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(786,214)|
+12,146,919386,459,747,228,199,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Fertility_vs_GDPpp
+1,147,40,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(919,385)|
+1,148,46,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(845,328)|
+10,149,Observed warming in 2022 deg C,2251,312,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,150,"SSP2 family action from 2022? (1)",2208,557,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,151,"Fertility multiplier (1)",1960,638,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,152,150,151,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2089,595)|
+10,153,"Life expectancy multipler (1)",1970,484,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,154,150,153,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2090,521)|
+10,155,"Max life expectancy multiplier (1)",2132,488,64,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,156,155,153,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2050,486)|
+10,157,Time,2027,566,26,11,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,158,157,153,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2005,534)|
+1,159,157,151,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2001,592)|
+1,160,117,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2078,368)|
+1,161,120,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2124,346)|
+1,162,149,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2125,320)|
+1,163,118,121,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(2086,304)|
+1,164,121,59,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1835,355)|
+10,165,"Max fertility multiplier (1)",2150,637,41,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,166,165,151,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(2069,637)|
+1,167,151,40,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1443,529)|
+1,168,153,59,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1820,432)|
+10,169,"Extra fertility reduction (1)",609,404,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,170,"Goal for extra fertility reduction (1)",452,406,54,54,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,171,170,169,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(529,405)|
+1,172,169,40,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(758,411)|
+1,173,169,125,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(584,364)|
+12,174,0,272,144,141,75,3,135,0,11,-1,0,0,0,255-0-255,0-0-0,|16||255-0-255,0,0,0,0,0,0
+TO SIMULATE POPULATION TURNAROUND: Adjust Goal for extra fertility reduction. You may want to also change other pink policy handles.
+10,175,"GDP G$/y",1139,502,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,176,27,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1269,463)|
+1,177,175,102,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1200,502)|
+10,178,Introduction period for policy y,564,481,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,179,178,169,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(582,448)|
+10,180,Introduction period for policy y,2012,256,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,181,180,129,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(2005,231)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Labour market
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Hiring/firing delay y",1004,114,37,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Unemployment rate (1)",1319,-30,48,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,Workforce in 1980 Mp,1662,267,43,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,4,"Unemployment rate in 1980 (1)",1422,-77,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,"Perceived unemployment rate (1)",1294,-150,51,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Unemployment perception time y,1165,-58,55,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,7,6,5,0,0,0,0,0,128,0,-1--1--1,,1|(1218,-96)|
+1,8,4,5,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1370,-106)|
+10,9,"Acceptable unemployment rate (1)",1162,-211,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,10,Time,2861,1354,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,11,"Optimal capital labour ratio kcu/ftj",784,100,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,12,11,13,1,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(808,146)|
+10,13,Optimal workforce Mp,843,186,47,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Indicated wage effect on optimal CLR (1)",872,-191,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,15,"sWSOeoCLR>0",808,-246,54,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,16,15,14,0,0,0,0,0,128,0,-1--1--1,,1|(829,-227)|
+10,17,"Wage effect on optimal CLR (1)",791,-46,49,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,18,Time to change tooling y,915,-108,49,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,19,14,17,1,0,0,0,0,128,0,-1--1--1,,1|(822,-139)|
+1,20,18,17,1,0,0,0,0,128,0,-1--1--1,,1|(869,-101)|
+1,21,17,11,1,0,0,0,0,128,0,-1--1--1,,1|(778,18)|
+10,22,"Worker share of output (1)",1071,-419,46,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,23,48,1261,-419,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,24,26,22,4,0,0,22,0,0,0,-1--1--1,,1|(1145,-406)|
+1,25,26,23,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1179,-419)|
+11,26,48,1179,-406,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,27,"Change in wso 1/y",1179,-387,58,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,28,48,881,-417,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,29,31,28,4,0,0,22,0,0,0,-1--1--1,,1|(919,-417)|
+1,30,31,22,100,0,0,22,0,0,0,-1--1--1,,1|(992,-417)|
+11,31,48,953,-417,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,32,"Long-term erosion of wso 1/y",953,-390,59,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,33,"WSO in 1980 (1)",1064,-291,56,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,34,33,22,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1066,-340)|
+1,35,33,14,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(981,-248)|
+10,36,"sWSOeoFRA<0",2367,-450,65,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,37,"sCBCeoFRA<0",2217,-454,62,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,38,"Real wage erosion rate 1/y",808,-344,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,39,38,32,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,-364)|
+1,40,22,26,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1132,-453)|
+1,41,22,31,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(997,-458)|
+10,42,"sWSOeoLPR>0",1499,-474,53,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Labour participation rate (1)",1573,-87,52,38,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,44,"Time to enter/leave labor market y",1657,-180,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,45,44,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1628,-148)|
+1,46,42,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1485,-442)|
+10,47,Available workforce Mp,1502,147,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"Normal LPR (1)",1465,-398,52,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,49,33,48,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1257,-342)|
+10,50,"Aged 20-pension age Mp",1701,-56,60,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,51,43,47,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1558,47)|
+1,52,50,74,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1687,-15)|
+1,53,48,72,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1532,-335)|
+10,54,"Normal LPR in 1980 (1)",1334,-426,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,55,54,48,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1391,-414)|
+10,56,"Perceived surplus workforce (1)",1388,-288,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,57,"sPUNeoLPR>0",1417,-209,51,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,5,56,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1346,-256)|
+1,59,57,56,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1406,-237)|
+10,60,Workforce Mp,1126,179,40,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,61,48,986,190,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,62,64,60,4,0,0,22,0,0,0,-1--1--1,,1|(1065,186)|
+1,63,64,61,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1014,186)|
+11,64,48,1039,186,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,65,"Change in workforce Mp/y",1039,213,53,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,66,1,64,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1021,150)|
+1,67,13,65,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(973,224)|
+1,68,3,60,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1399,223)|
+1,69,60,65,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1106,222)|
+10,70,"GDP per person k$/p/y",500,473,58,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,71,GDP per person in 1980,627,511,58,19,8,130,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,72,"Indicated labour participation rate (1)",1566,-247,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,73,72,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1582,-184)|
+10,74,Working age population Mp,1657,33,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,75,74,47,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1589,100)|
+10,76,"ROC in WSO - Table 1/y",1221,-307,52,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,77,9,76,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1187,-253)|
+1,78,76,27,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1201,-344)|
+1,79,9,56,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1267,-247)|
+10,80,Unemployed Mp,1291,130,54,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,81,60,80,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1249,164)|
+1,82,47,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1380,86)|
+10,83,"Normal hours worked kh/ftj/y",867,406,38,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,84,"Hours worked mult from GDPpp (1)",687,442,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,85,"Normal hours worked in 1980 kh/ftj/y",924,472,71,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,86,85,83,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(905,450)|
+1,87,84,83,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(777,406)|
+10,88,"Labour use Gph/y",1250,493,57,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,83,168,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(954,382)|
+1,90,60,88,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1283,335)|
+10,91,"Persons per full-time job p/ftj",692,211,53,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,92,91,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(763,199)|
+10,93,"sTIeoNHW<0",574,396,47,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,94,93,84,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(614,412)|
+1,95,71,84,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(651,481)|
+1,96,70,84,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(586,454)|
+10,97,"Labour use in 1980 Gph/y",1174,314,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,98,3,97,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1425,289)|
+1,99,85,171,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(925,403)|
+1,100,80,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1315,67)|
+1,101,2,5,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1326,-82)|
+10,102,Time to adjust hours worked y,775,341,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,103,102,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(809,365)|
+10,104,"Wage rate $/ph",521,-372,53,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,105,48,681,-377,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,106,108,104,4,0,0,22,0,0,0,-1--1--1,,1|(598,-377)|
+1,107,108,105,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(652,-377)|
+11,108,48,628,-377,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,109,"Change in wage rate $/ph/y",628,-350,51,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,110,"Wage rate in 1980 $/ph",520,-277,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,111,110,104,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(520,-311)|
+12,112,48,343,-373,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,113,115,112,4,0,0,22,0,0,0,-1--1--1,,1|(378,-373)|
+1,114,115,104,100,0,0,22,0,0,0,-1--1--1,,1|(442,-373)|
+11,115,48,410,-373,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,116,"Wage rate erosion $/ph/y",410,-346,59,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,117,"Wage rate erosion rate 1/y",329,-279,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,118,76,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(930,-327)|
+1,119,117,116,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(363,-308)|
+1,120,104,115,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(433,-395)|
+1,121,104,128,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(461,-283)|
+10,122,"Output Gu/y",455,-4,49,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,123,"Labour use Gph/y",525,-53,41,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,124,"Labour productivity $/ph",365,-98,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,125,122,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(418,-41)|
+1,126,123,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(458,-71)|
+1,127,104,108,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(612,-409)|
+10,128,"Wage share (1)",355,-194,53,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,129,"Inflation rate 1/y",154,-296,45,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,130,129,117,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(227,-288)|
+1,131,124,128,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(362,-136)|
+10,132,"Price per unit $/u",348,284,47,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,133,CAP PUS in 1980 Gcu,953,945,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,134,Capacity PIS Gcu,953,945,48,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,135,Capacity Gcu,678,129,53,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,136,135,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(745,152)|
+12,137,2558378,2062,-114,297,309,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+New_Labor_market:_10-year_wave
+10,138,"ROC in ECLR 1/y",504,339,59,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,139,"CLR in 1980 kcu/ftj",396,85,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,140,139,142,0,0,0,0,0,128,1,-1--1--1,,1|(400,130)|
+10,141,"ROC in ECLR in 1980 1/y",391,408,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,142,"Embedded CLR kcu/ftj",408,197,47,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,143,48,402,305,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,144,146,142,4,0,0,22,0,0,0,-1--1--1,,1|(402,238)|
+1,145,146,143,100,0,0,22,0,0,0,-1--1--1,,1|(402,281)|
+11,146,48,402,259,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,147,"Change in embedded CLR kcu/ftj/y",478,259,68,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,138,147,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(477,307)|
+1,149,142,147,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(474,208)|
+10,150,"Cost per unit in 1980 $/u",572,-110,55,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,151,"Optimal output in 1980 Gu/y",674,-148,60,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,152,"Labour use in 1980 Gph/y",684,-219,48,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,153,"Labour productivity in 1980 $/ph",520,-192,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,153,110,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(520,-227)|
+1,155,150,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(549,-145)|
+1,156,151,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(605,-167)|
+1,157,152,153,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(616,-208)|
+1,158,33,110,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(791,-284)|
+10,159,"Price per unit $/u",326,11,47,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,160,159,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(342,-36)|
+10,161,"Fraction of inflation compensated (1)",179,-366,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,162,161,117,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(247,-325)|
+1,163,22,14,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(972,-306)|
+1,164,142,11,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(562,40)|
+10,165,"sGDPppeoFRACA<0",1874,-456,82,9,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,166,FRACA min,2052,-453,50,11,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,167,91,168,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(907,255)|
+10,168,"Average hours worked kh/y",1056,389,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,168,88,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1168,420)|
+10,170,"Persons per full-time job in 1980 p/ftj",710,264,66,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,171,"Average hours worked in 1980 kh/y",928,322,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,172,170,171,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(811,290)|
+1,173,171,97,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1055,317)|
+1,174,22,48,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1272,-482)|
+10,175,"Average gross income per worker k$/p/y",191,-221,78,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,176,"Average hours worked kh/y",190,-147,52,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,177,104,175,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(392,-258)|
+1,178,176,175,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(190,-177)|
+10,179,"Participation (1)",1494,228,55,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,180,5,179,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1394,40)|
+1,181,43,179,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1531,77)|
+10,182,"Extra normal LPR from 2022 (1)",1606,-429,58,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,183,"Goal for extra normal LPR (1)",1709,-517,52,52,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,184,183,182,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1654,-470)|
+1,185,182,48,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1538,-414)|
+10,186,GDPppeoROCCLR,277,475,66,9,8,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,187,70,186,0,0,0,0,0,128,0,-1--1--1,,1|(399,473)|
+1,188,71,186,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(463,494)|
+10,189,"sGDPppeoROCCLR<0",1469,-13,78,9,8,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,190,189,186,0,0,0,0,0,128,0,-1--1--1,,1|(879,228)|
+1,191,186,138,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(344,348)|
+1,192,141,138,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(447,373)|
+12,193,14681756,203,199,150,150,3,12,0,0,1,0,0,0,0,0,0,0,0,0
+CLR_vs_GDPpp
+1,194,5,76,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1273,-232)|
+1,195,56,72,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1486,-279)|
+1,196,47,80,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1377,166)|
+10,197,"10-yr loop delay y",992,-18,45,33,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,198,197,18,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(952,-64)|
+1,199,197,1,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(997,48)|
+1,200,197,6,0,0,0,0,1,128,0,0-255-0,|12||0-0-0,1|(1066,-34)|
+10,201,Introduction period for policy y,1674,-365,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,202,201,182,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1645,-392)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Output
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Capacity PIS Gcu,496,544,37,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,332,542,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,2,4,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(368,542)|
+1,4,5,1,100,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(432,542)|
+11,5,48,400,542,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"Capacity discard PIS Gcu/y",400,569,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,7,Life of capacity PIS y,295,646,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,8,1,5,1,0,0,0,0,64,0,-1--1--1,,1|(427,522)|
+1,9,7,6,1,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(351,613)|
+10,10,Capacity under construction PIS Gcu,494,706,51,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,11,13,1,4,0,0,22,0,0,0,-1--1--1,,1|(492,593)|
+1,12,13,10,100,0,0,22,0,0,0,-1--1--1,,1|(492,652)|
+11,13,19222,492,622,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,14,"Capacity addition PIS Gcu/y",556,622,56,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,15,48,491,803,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,16,18,10,4,0,0,22,0,0,0,-1--1--1,,1|(493,748)|
+1,17,18,15,100,0,0,22,0,0,0,-1--1--1,,1|(493,784)|
+11,18,48,493,767,8,6,33,3,0,0,2,0,0,0,0,0,0,0,0,0
+10,19,"Capacity initiation PIS Gcu/y",428,767,57,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,20,Construction time PIS y,618,527,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,10,14,0,0,0,0,0,64,0,-1--1--1,,1|(523,664)|
+10,22,CUC PIS in 1980 Gcu,425,638,40,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,23,20,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(527,579)|
+10,24,"PCOR PIS cu/u/y",289,373,57,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,22,10,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(449,662)|
+10,26,"Excess demand effect on life of capacity (1)",126,625,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,"sEDeoLOC>0",15,575,47,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,26,0,0,0,0,0,128,0,-1--1--1,,1|(54,593)|
+10,29,"Available capital G$/y",-100,683,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,30,"Investment in new capacity PIS G$/y",255,791,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,31,29,30,1,0,0,0,0,128,0,-1--1--1,,1|(24,746)|
+1,32,26,7,1,0,0,0,0,128,0,-1--1--1,,1|(206,658)|
+10,33,CAP PIS in 1980 Gcu,500,476,39,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,33,1,0,0,0,0,0,64,1,-1--1--1,,1|(498,499)|
+10,35,Life of capacity PIS in 1980 y,342,713,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,36,33,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(465,550)|
+1,37,35,7,0,0,0,0,0,128,0,-1--1--1,,1|(322,685)|
+1,38,35,22,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(377,680)|
+10,39,"Optimal output in 1980 Gu/y",361,320,55,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,40,24,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(313,354)|
+1,41,33,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(435,403)|
+10,42,"Excess demand (1)",246,181,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Output growth rate 1/y",919,188,40,28,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,44,"Output last year G$/y",789,189,47,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,45,44,43,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(834,187)|
+1,46,39,53,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(479,306)|
+10,47,"ED effect on flow to capacity addition (1)",-29,537,66,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"sEDeoFRA>0",-106,476,46,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,49,48,47,0,0,0,0,0,128,0,-1--1--1,,1|(-78,498)|
+10,50,"Extra mult on CUC, to avoid initial transient in Investment share of GDP",814,643,92,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,51,50,22,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(600,640)|
+10,52,"Excess demand in 1980 (1)",-83,410,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,53,"Optimal real output Gu/y",596,294,40,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,54,"Embedded TFP in 1980 (1)",830,373,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,55,Kappa,483,370,23,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,56,Lambda,482,316,27,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,57,55,53,0,0,0,0,0,128,0,-1--1--1,,1|(527,339)|
+1,58,56,53,0,0,0,0,0,128,0,-1--1--1,,1|(525,307)|
+1,59,55,56,0,0,0,0,0,128,0,-1--1--1,,1|(482,349)|
+1,60,1,53,1,0,0,0,0,128,0,-1--1--1,,1|(580,469)|
+1,61,33,53,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(544,391)|
+10,62,"Output growth in 1980 1/y (to avoid transient)",870,104,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,63,62,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(888,135)|
+1,64,62,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(838,136)|
+1,65,52,47,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(-58,467)|
+1,66,53,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(679,247)|
+1,67,53,43,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(750,243)|
+1,68,39,44,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(571,255)|
+10,69,"Total savings G$/y",-171,277,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,70,"Perceived excess demand (1)",48,391,40,42,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Time to observe excess demand y,130,309,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,72,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(104,334)|
+1,73,70,47,1,0,0,0,0,128,0,-1--1--1,,1|(5,451)|
+1,74,70,26,1,0,0,0,0,128,0,-1--1--1,,1|(65,484)|
+1,75,30,19,1,0,0,0,0,128,0,-1--1--1,,1|(345,790)|
+1,76,42,70,1,0,0,0,0,128,0,-1--1--1,,1|(132,226)|
+1,77,52,26,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(16,512)|
+10,78,"Fraction of available capital to new capacity (1)",140,889,49,39,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,79,"Foreign capital inflow G$/y",-244,655,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,80,79,29,1,0,0,0,0,128,0,-1--1--1,,1|(-165,680)|
+1,81,78,30,1,0,0,0,0,128,0,-1--1--1,,1|(203,834)|
+1,82,69,29,1,0,0,0,0,128,0,-1--1--1,,1|(-212,477)|
+10,83,"WSO effect on flow to capacity addition (1)",-74,817,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,84,"sWSOeoFRA<0",-110,882,54,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,83,0,0,0,0,0,128,0,-1--1--1,,1|(-97,859)|
+10,86,"sCBCeoFRA<0",-31,1015,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,87,"CBC effect on flow to capacity addion (1)",-4,955,71,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,88,86,87,0,0,0,0,0,128,0,-1--1--1,,1|(-22,995)|
+10,89,"Corporate borrowing cost 1/y",-216,981,65,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,90,89,87,0,0,0,0,0,128,0,-1--1--1,,1|(-119,969)|
+1,91,83,78,1,0,0,0,0,128,0,-1--1--1,,1|(19,863)|
+1,92,87,78,1,0,0,0,0,128,0,-1--1--1,,1|(57,926)|
+10,93,"Corporate borrowing cost in 1980 1/y",-220,911,73,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,94,93,87,0,0,0,0,0,128,0,-1--1--1,,1|(-117,931)|
+10,95,"Total purchasing power G$/y",-14,283,54,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,96,95,42,1,0,0,0,0,128,0,-1--1--1,,1|(124,195)|
+1,97,47,78,1,0,0,0,0,128,0,-1--1--1,,1|(-42,667)|
+12,98,0,990,968,321,289,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Output:_Long_term_growth
+10,99,"Govmnt investment in public capacity G$/y",1053,462,73,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,100,99,151,1,0,0,0,0,128,0,-1--1--1,,1|(1180,481)|
+10,101,"Optimal ouput - value G$/y",444,193,51,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,102,53,101,1,0,0,0,0,128,0,-1--1--1,,1|(507,220)|
+1,103,101,42,1,0,0,0,0,128,0,-1--1--1,,1|(348,167)|
+10,104,"Deliveries Gu/y",56,120,43,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,105,"National income G$/y",-86,182,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,106,"Output Gu/y",364,76,47,21,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,107,"GDP G$/y",1232,562,60,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,108,"Indicated TFP (1)",1070,557,53,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,109,"Embedded TFP (1)",831,447,42,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,110,48,835,559,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,111,113,109,4,0,0,22,0,0,0,-1--1--1,,1|(839,493)|
+1,112,113,110,100,0,0,22,0,0,0,-1--1--1,,1|(839,538)|
+11,113,48,839,520,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,114,"Effect of capacity renewal 1/y",903,520,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,115,54,109,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(830,399)|
+1,116,108,114,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(985,548)|
+1,117,14,118,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(687,589)|
+10,118,"Capacity renewal rate 1/y",729,548,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,119,1,118,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(674,563)|
+1,120,118,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(800,529)|
+1,121,109,114,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(917,459)|
+1,122,109,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(693,396)|
+10,123,"sOWeoCOC>0",594,1086,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,124,Time,630,903,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,125,Observed warming deg C,518,994,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,126,"OWeoCOC (1)",598,856,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,127,125,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(556,927)|
+1,128,123,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(595,977)|
+1,129,124,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(618,885)|
+1,130,126,173,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(594,836)|
+10,131,Investment planning time y,225,1008,40,32,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,132,131,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(189,957)|
+10,133,"FRA in 1980 (1)",112,998,43,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,134,Capacity PUS Gcu,1345,254,37,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,135,48,1181,252,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,136,138,135,4,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(1217,252)|
+1,137,138,134,100,0,0,22,3,0,0,0-0-0,|12||0-0-0,1|(1281,252)|
+11,138,48,1249,252,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,139,"Capacity discard PUS Gcu/y",1249,279,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,140,Life of capacity PUS y,1144,356,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,134,138,1,0,0,0,0,64,0,-1--1--1,,1|(1276,232)|
+10,142,Capacity under construction PUS Gcu,1348,422,56,35,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,143,145,134,4,0,0,22,0,0,0,-1--1--1,,1|(1341,303)|
+1,144,145,142,100,0,0,22,0,0,0,-1--1--1,,1|(1341,362)|
+11,145,13444,1341,332,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,146,"Capacity addition PUS Gcu/y",1405,332,56,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,147,48,1344,552,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,150,142,4,0,0,22,0,0,0,-1--1--1,,1|(1341,469)|
+1,149,150,147,100,0,0,22,0,0,0,-1--1--1,,1|(1341,519)|
+11,150,48,1341,488,8,6,33,3,0,0,2,0,0,0,0,0,0,0,0,0
+10,151,"Capacity initiation PUS Gcu/y",1276,488,57,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,152,Construction time PUS y,1467,237,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,153,142,146,0,0,0,0,0,64,0,-1--1--1,,1|(1377,374)|
+10,154,CUC PUS in 1980 Gcu,1274,348,44,19,8,131,0,16,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,155,152,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1376,289)|
+1,156,154,142,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1298,372)|
+10,157,CAP PUS in 1980 Gcu,1349,186,42,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,158,157,134,0,0,0,0,0,64,1,-1--1--1,,1|(1347,209)|
+10,159,Life of capacity PUS in 1980 y,1191,423,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,160,157,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1314,260)|
+1,161,159,140,0,0,0,0,0,128,0,-1--1--1,,1|(1171,395)|
+1,162,159,154,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1226,390)|
+1,163,134,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(714,334)|
+1,164,50,154,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1044,494)|
+1,165,157,53,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(978,239)|
+1,166,157,39,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(868,250)|
+10,167,"Embedded labour productivity in 1980 k$/p/y",1007,266,64,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,168,39,167,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(672,294)|
+10,169,"PCOR PUS cu/u/y",385,418,60,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,170,169,39,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(375,379)|
+10,171,"Jobs in 1980 M-ftj",596,332,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,172,"Jobs in 1980 M-ftj",1007,313,46,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,173,"Cost of capacity $/cu",586,795,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,174,173,19,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(515,782)|
+10,175,"Cost of capacity in 1980 $/cu",460,842,54,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,176,175,173,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(550,828)|
+10,177,"Jobs in 1980 M-ftj",1019,158,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,178,177,167,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1014,200)|
+10,179,"Off-balance-sheet govmnt inv in PUS (share of GDP)",1491,565,85,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,180,179,151,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1390,528)|
+10,181,"Off-balance sheet govmnt inv in PIS (share of GDP)",321,886,67,35,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,182,181,19,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(376,823)|
+10,183,"GDP G$/y",220,759,45,24,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,184,183,19,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(311,761)|
+1,185,107,151,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1247,535)|
+1,186,173,151,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(924,644)|
+10,187,"Cost per unit in 1980 $/u",244,225,49,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,188,"Price per unit $/u",387,257,50,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,189,187,188,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(308,238)|
+1,190,188,101,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(454,247)|
+10,191,Capacity Gcu,677,448,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,192,1,191,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(588,495)|
+1,193,134,191,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1017,348)|
+10,194,"WSO in 1980 (1)",-328,808,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,195,"Worker share of output (1)",-309,748,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,196,194,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(-216,811)|
+10,197,"Labour use Gph/y",636,82,41,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,198,"Labour use in 1980 Gph/y",699,135,48,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,199,197,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(617,181)|
+1,200,198,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(651,208)|
+10,201,"Wage share (1)",-161,728,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,202,201,83,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(-122,767)|
+10,203,"FRACA mult from GDPpp - Table (1)",239,1146,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||0-255-0,0,0,0,0,0,0
+10,204,"FRACA mult from GDPpp - Line (1)",2,1092,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,205,"sGDPppeoFRACA<0",-219,1107,72,9,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,206,GDP per person in 1980,-121,1192,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||160-160-160,0,0,0,0,0,0
+10,207,"GDP per person k$/p/y",15,1227,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||192-192-192,0,0,0,0,0,0
+1,208,205,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(-108,1100)|
+1,209,206,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(-64,1146)|
+1,210,207,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(9,1166)|
+1,211,204,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(59,1006)|
+1,212,133,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(121,956)|
+10,213,FRACA min,-161,1040,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,214,213,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(-98,1059)|
+10,215,Observed warming in 2022 deg C,467,909,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,216,215,126,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(535,881)|
+10,217,Time,292,949,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,218,"Unconventional stimulus in PIS from 2022 (share of GDP)",383,1035,67,67,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,219,217,181,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(297,935)|
+1,220,218,181,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(349,953)|
+10,221,"Unconventional stimulus in PUS from 2022 (share of GDP)",1510,453,70,70,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,222,221,179,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1497,527)|
+10,223,Time,1497,618,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,224,223,179,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1495,602)|
+10,225,"Investment share of GDP (1)",1178,620,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,226,99,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1110,535)|
+1,227,107,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1213,581)|
+1,228,30,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(708,707)|
+10,229,"Shifts worked - index (1)",526,129,55,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,230,"GDP G$/y",199,77,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,231,"sOWeoLOC<0",298,513,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,232,Time,143,541,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,233,Observed warming deg C,200,442,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,234,"OWeoLOC (1)",241,580,50,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,235,233,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(219,508)|
+1,236,231,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(274,541)|
+1,237,232,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(184,557)|
+10,238,Observed warming in 2022 deg C,140,493,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,239,238,234,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(189,535)|
+1,240,234,7,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(260,603)|
+1,241,234,159,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(709,502)|
+1,242,20,14,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(590,568)|
+1,243,140,139,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1190,321)|
+1,244,152,146,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1439,278)|
+10,245,"Margin in 1980 (1)",245,273,47,24,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,246,245,188,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(307,265)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Demand
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Owner income G$/y",988,497,47,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Worker income G$/y",550,492,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,3,"Owner operating income after tax G$/y",1147,769,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Worker income after tax G$/y",474,794,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,"Income tax owners (1)",906,259,36,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,6,"Income tax workers (1)",614,262,39,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,7,"Govmnt net income G$/y",864,772,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,8,6,32,0,0,0,0,0,128,0,-1--1--1,,1|(574,334)|
+1,9,5,31,0,0,0,0,0,128,0,-1--1--1,,1|(918,333)|
+1,10,2,4,1,0,0,0,0,128,0,-1--1--1,,1|(479,638)|
+1,11,1,3,1,0,0,0,0,128,0,-1--1--1,,1|(1066,598)|
+10,12,"Worker cash inflow G$/y",456,1251,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,13,"Owner cash inflow G$/y",1294,1165,39,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Govmnt cash inflow G$/y",821,1278,42,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,15,3,13,1,0,0,0,0,128,0,-1--1--1,,1|(1306,980)|
+10,16,"Owner savings fraction (1)",1397,1287,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,17,"Worker savings G$/y",551,1480,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,18,"Owner savings G$/y",1245,1517,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,19,"Govmnt purchases G$/y",808,1455,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,20,"Total savings G$/y",1154,1644,53,18,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,18,20,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1210,1588)|
+1,22,16,122,0,0,0,0,0,128,0,-1--1--1,,1|(1360,1312)|
+10,23,"Effective GDP per person k$/p/y",1574,1239,79,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,24,23,16,0,0,0,0,0,128,0,-1--1--1,,1|(1476,1265)|
+10,25,Owner savings fraction in 1980,1475,1351,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,26,"sGDPeoOSR<0",1455,1193,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,27,25,16,0,0,0,0,0,128,0,-1--1--1,,1|(1441,1323)|
+1,28,26,16,0,0,0,0,0,128,0,-1--1--1,,1|(1432,1230)|
+10,29,"GDP per person in 1980 k$/p/y",1572,1293,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,30,29,16,0,0,0,0,0,128,0,-1--1--1,,1|(1486,1290)|
+10,31,"Owner taxes G$/y",933,414,58,11,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,32,"Worker taxes G$/y",528,420,44,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,33,31,3,1,0,0,0,0,128,0,-1--1--1,,1|(1061,537)|
+1,34,32,4,1,0,0,0,0,128,0,-1--1--1,,1|(414,530)|
+1,35,31,104,1,0,0,0,0,128,0,-1--1--1,,1|(859,534)|
+1,36,32,104,1,0,0,0,0,128,0,-1--1--1,,1|(633,466)|
+10,37,"Worker consumption demand G$/y",411,1420,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,38,"Owner consumption G$/y",1159,1450,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,39,13,134,1,0,0,0,0,128,0,-1--1--1,,1|(1179,1270)|
+10,40,"Consumption demand G$/y",391,1638,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,41,Max govmnt debt burden y,628,845,44,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,42,Max workers debt burden y,453,863,56,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,Max govmnt debt G$,634,899,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,44,Govmnt debt G$,801,1030,41,38,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,45,48,647,1016,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,46,48,44,4,0,0,22,0,0,0,-1--1--1,,1|(741,1012)|
+1,47,48,45,100,0,0,22,0,0,0,-1--1--1,,1|(684,1012)|
+11,48,48,717,1012,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,49,"Govmnt new debt G$/y",717,1050,39,30,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,50,48,948,1049,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,51,53,50,4,0,0,22,0,0,0,-1--1--1,,1|(923,1049)|
+1,52,53,44,100,0,0,22,0,0,0,-1--1--1,,1|(869,1049)|
+11,53,48,902,1049,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,54,"Govmnt payback G$/y",902,1081,49,24,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,55,41,43,1,0,0,0,0,128,0,-1--1--1,,1|(640,884)|
+1,56,44,54,1,0,0,0,0,128,0,-1--1--1,,1|(860,1015)|
+10,57,Govmnt payback period y,898,957,55,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,58,Govmnt drawdown period y,642,957,54,40,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,59,57,53,0,0,0,0,0,128,0,-1--1--1,,1|(899,1002)|
+10,60,"Cash flow from govmnt to banks G$/y",823,1179,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,61,49,60,1,0,0,0,0,128,0,-1--1--1,,1|(733,1132)|
+1,62,54,60,1,0,0,0,0,128,0,-1--1--1,,1|(893,1144)|
+1,63,7,14,1,0,0,0,0,128,0,-1--1--1,,1|(1070,1041)|
+1,64,60,14,1,0,0,0,0,128,0,-1--1--1,,1|(860,1244)|
+10,65,"Govmnt interest cost G$/y",797,1114,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,66,44,65,0,0,0,0,0,128,0,-1--1--1,,1|(799,1074)|
+1,67,65,60,0,0,0,0,0,128,0,-1--1--1,,1|(806,1140)|
+10,68,Govmnt debt in 1980 G$,810,927,49,19,8,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,69,68,44,0,0,0,0,0,64,1,-1--1--1,,1|(807,962)|
+10,70,Max workers debt G$,339,908,44,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Workers debt G$,411,1021,41,37,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,72,48,266,1004,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,73,75,71,4,0,0,22,0,0,0,-1--1--1,,1|(353,1005)|
+1,74,75,72,100,0,0,22,0,0,0,-1--1--1,,1|(300,1005)|
+11,75,48,330,1005,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,76,"Workers new debt G$/y",330,1040,44,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,77,48,558,1003,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,78,80,77,4,0,0,22,0,0,0,-1--1--1,,1|(532,1010)|
+1,79,80,71,100,0,0,22,0,0,0,-1--1--1,,1|(478,1010)|
+11,80,48,510,1010,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,81,"Workers payback G$/y",510,1048,52,30,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,82,70,75,1,0,0,0,0,128,0,-1--1--1,,1|(316,960)|
+1,83,71,75,1,0,0,0,0,128,0,-1--1--1,,1|(382,971)|
+1,84,71,81,1,0,0,0,0,128,0,-1--1--1,,1|(493,954)|
+10,85,Workers payback period y,533,947,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,86,Workers drawdown period y,238,962,54,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,87,86,75,0,0,0,0,0,128,0,-1--1--1,,1|(301,991)|
+1,88,85,80,0,0,0,0,0,128,0,-1--1--1,,1|(522,978)|
+10,89,"Cash flow from workers to banks G$/y",434,1171,74,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,90,76,89,1,0,0,0,0,128,0,-1--1--1,,1|(345,1124)|
+1,91,81,89,1,0,0,0,0,128,0,-1--1--1,,1|(514,1126)|
+10,92,"Worker interest cost G$/y",410,1099,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,93,71,92,0,0,0,0,0,128,0,-1--1--1,,1|(410,1062)|
+1,94,92,89,0,0,0,0,0,128,0,-1--1--1,,1|(419,1128)|
+10,95,Workers debt in 1980 G$,425,932,53,19,8,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,96,95,71,0,0,0,0,0,64,1,-1--1--1,,1|(420,960)|
+1,97,42,70,1,0,0,0,0,128,0,-1--1--1,,1|(399,868)|
+1,98,89,12,1,0,0,0,0,128,0,-1--1--1,,1|(474,1227)|
+1,99,4,12,1,0,0,0,0,128,0,-1--1--1,,1|(594,1039)|
+1,100,17,20,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(844,1559)|
+1,101,12,126,0,0,0,0,0,128,0,-1--1--1,,1|(444,1283)|
+10,102,"Transfer payments G$/y",673,727,46,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,103,"Extra transfer of govmnt budget to workers (1)",96,659,60,60,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"Govmnt gross income G$/y",804,673,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,105,104,7,0,0,0,0,0,128,0,-1--1--1,,1|(829,716)|
+1,106,104,102,0,0,0,0,0,128,0,-1--1--1,,1|(745,696)|
+1,107,102,7,0,0,0,0,0,128,0,-1--1--1,,1|(764,747)|
+1,108,102,4,0,0,0,0,0,128,0,-1--1--1,,1|(582,757)|
+1,109,60,155,1,0,0,0,0,128,0,-1--1--1,,1|(975,1196)|
+1,110,89,155,1,0,0,0,0,128,0,-1--1--1,,1|(724,1233)|
+10,111,"Worker consumption fraction (1)",287,1366,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,112,37,17,0,0,0,0,0,128,0,-1--1--1,,1|(474,1447)|
+1,113,111,37,0,0,0,0,0,128,0,-1--1--1,,1|(342,1390)|
+10,114,"Government consumption fraction (1)",667,1372,66,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,114,19,0,0,0,0,0,128,0,-1--1--1,,1|(738,1413)|
+10,116,"Govmnt investment in public capacity G$/y",988,1522,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,117,38,18,1,0,0,0,0,128,0,-1--1--1,,1|(1199,1469)|
+1,118,19,116,0,0,0,0,0,128,0,-1--1--1,,1|(890,1485)|
+1,119,37,40,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(395,1480)|
+1,120,38,40,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(774,1543)|
+10,121,"Govmnt spending G$/y",801,1641,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,122,"Owner consumptin fraction (1)",1312,1345,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,123,"Sales tax rate (1)",240,1439,40,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,"Sales tax workers G$/y",285,1509,53,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,125,Time to adjust worker consumption y,330,1262,59,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,126,"Permanent worker cash inflow G$/y",425,1341,46,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,127,125,126,0,0,0,0,0,128,0,-1--1--1,,1|(367,1293)|
+10,128,"Permanent govmnt cash inflow G$/y",820,1351,55,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,129,126,37,0,0,0,0,0,128,0,-1--1--1,,1|(418,1379)|
+1,130,37,124,0,0,0,0,0,128,0,-1--1--1,,1|(361,1455)|
+1,131,123,124,0,0,0,0,0,128,0,-1--1--1,,1|(257,1466)|
+10,132,"Sales tax owners G$/y",417,1510,46,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,133,38,132,0,0,0,0,0,128,0,-1--1--1,,1|(788,1479)|
+10,134,"Permanent owner cash inflow G$/y",1187,1352,40,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,135,134,38,0,0,0,0,0,128,0,-1--1--1,,1|(1174,1397)|
+10,136,"Sales tax owners G$/y",947,553,50,26,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,137,"Sales tax workers G$/y",665,561,49,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,138,137,104,0,0,0,0,0,128,0,-1--1--1,,1|(728,612)|
+1,139,136,104,0,0,0,0,0,128,0,-1--1--1,,1|(876,612)|
+10,140,Time to adjust budget y,676,1281,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,14,128,0,0,0,0,0,128,0,-1--1--1,,1|(820,1301)|
+1,142,128,19,0,0,0,0,0,128,0,-1--1--1,,1|(814,1402)|
+1,143,19,121,0,0,0,0,0,128,0,-1--1--1,,1|(804,1541)|
+1,144,116,121,0,0,0,0,0,128,0,-1--1--1,,1|(900,1577)|
+1,145,140,128,0,0,0,0,0,128,0,-1--1--1,,1|(733,1308)|
+10,146,Time to adjust owner consumption y,1092,1284,52,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,147,146,134,0,0,0,0,0,128,0,-1--1--1,,1|(1132,1313)|
+1,148,126,17,0,0,0,0,0,128,0,-1--1--1,,1|(488,1411)|
+1,149,128,116,0,0,0,0,0,128,0,-1--1--1,,1|(904,1437)|
+1,150,134,18,1,0,0,0,0,128,0,-1--1--1,,1|(1259,1456)|
+1,151,2,70,1,0,0,0,0,128,0,-1--1--1,,1|(390,695)|
+1,152,124,40,0,0,0,0,0,128,0,-1--1--1,,1|(337,1573)|
+1,153,132,40,0,0,0,0,0,128,0,-1--1--1,,1|(404,1570)|
+1,154,123,132,0,0,0,0,0,128,0,-1--1--1,,1|(318,1470)|
+10,155,"Bank cash inflow from lending G$/y",1112,1184,57,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,156,"Worker finance cost as share of income (1)",123,920,81,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,157,89,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(283,1049)|
+10,158,"Govmnt finance as share of NI (1)",1169,998,66,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,159,"Consumption share of GDP (1)",235,1640,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,160,40,159,0,0,0,0,0,128,0,-1--1--1,,1|(328,1638)|
+1,161,65,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(970,1060)|
+1,162,54,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1022,1043)|
+10,163,"Savings share of GDP (1)",984,1640,52,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,164,20,163,0,0,0,0,0,128,0,-1--1--1,,1|(1075,1642)|
+10,165,"Control: (C+G+S)/NI = 1",194,1714,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,166,159,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(218,1670)|
+1,167,14,186,1,0,0,0,0,128,0,-1--1--1,,1|(1066,1253)|
+1,168,13,186,0,0,0,0,0,128,0,-1--1--1,,1|(1311,1190)|
+10,169,"Worker borrowing cost 1/y",254,1152,42,40,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,170,"Govmnt borrowing cost 1/y",652,1160,47,40,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,171,169,92,0,0,0,0,0,128,0,-1--1--1,,1|(321,1128)|
+1,172,170,65,0,0,0,0,0,128,0,-1--1--1,,1|(716,1139)|
+10,173,Mult to avoid transient in worker finance,124,786,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,174,173,95,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(267,855)|
+10,175,Mult to avoid transient in govmnt finance,1140,848,71,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,176,175,68,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(970,887)|
+10,177,"National income G$/y",760,316,55,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,178,Worker debt burden y,107,858,45,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,179,71,178,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(262,941)|
+10,180,Govmnt debt burden y,1144,917,46,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,181,44,180,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(963,976)|
+10,182,"National income G$/y",232,1581,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,183,182,159,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(232,1603)|
+1,184,182,163,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(603,1609)|
+1,185,163,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(597,1675)|
+10,186,"Total purchasing power G$/y",1339,1227,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,187,"Sales tax G$/y",566,1557,46,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,188,124,187,1,0,0,0,0,128,0,-1--1--1,,1|(417,1547)|
+1,189,132,187,0,0,0,0,0,128,0,-1--1--1,,1|(490,1532)|
+1,190,187,186,0,0,0,0,0,128,0,-1--1--1,,1|(936,1398)|
+1,191,4,178,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(294,824)|
+1,192,4,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(306,853)|
+10,193,"National income G$/y",871,829,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,194,193,180,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1006,872)|
+1,195,193,158,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1013,910)|
+10,196,"Bank cash inflow as share of NI (1)",1169,1118,70,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,197,155,196,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1135,1156)|
+1,198,12,186,1,0,0,0,0,128,0,-1--1--1,,1|(883,1239)|
+10,199,WFI in 1980,516,1325,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,200,GCI in 1980,937,1332,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,201,OCI in 1980,1068,1379,41,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,202,199,126,1,0,0,0,0,128,0,-1--1--1,,1|(500,1347)|
+1,203,200,128,1,0,0,0,0,128,0,-1--1--1,,1|(911,1355)|
+1,204,201,134,1,0,0,0,0,128,0,-1--1--1,,1|(1100,1342)|
+1,205,122,38,0,0,0,0,0,128,0,-1--1--1,,1|(1241,1393)|
+10,206,"Consumption per person G$/y",790,1720,60,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,207,40,206,0,0,0,0,0,128,0,-1--1--1,,1|(575,1675)|
+10,208,Population Mp,559,1747,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,209,208,206,0,0,0,0,0,128,0,-1--1--1,,1|(665,1734)|
+12,210,0,1547,1661,280,280,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Distribution_of_national_income
+10,211,"Govmnt share of GDP (1)",584,1638,53,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,212,121,211,0,0,0,0,0,128,0,-1--1--1,,1|(697,1639)|
+1,213,182,211,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(403,1608)|
+1,214,211,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(397,1674)|
+10,215,"Fraction of extra taxes paid by owners (1)",299,391,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,216,187,7,0,1,0,0,0,64,0,-1--1--1,,1|(710,1175)|
+10,217,"Income tax rate owners in 1980 (1)",966,136,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,218,"Extra general tax rate from 2022 (1)",67,137,52,52,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,219,Time,149,219,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,220,"Basic income tax rate workers (1)",558,133,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,221,220,6,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(582,192)|
+10,222,"Extra general tax from 2022 G$/y",291,193,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,223,"Govmnt net income as share of NI (1)",990,673,68,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,224,7,223,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(921,726)|
+10,225,"INEQUALITY INDEX (1980=1)",1259,567,60,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,226,4,240,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(813,701)|
+1,227,3,240,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1152,690)|
+10,228,"Govmnt stimulus from 2022 (share of NI)",712,799,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,229,228,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(713,905)|
+10,230,"Worker share of output (1)",774,138,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,231,44,49,1,0,0,0,0,64,0,-1--1--1,,1|(761,1088)|
+1,232,58,49,0,0,0,0,0,64,0,-1--1--1,,1|(678,1002)|
+1,233,43,49,0,0,0,0,0,64,0,-1--1--1,,1|(668,962)|
+10,234,Workforce Mp,142,1395,58,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,235,"Worker disposable income k$/p/y",153,1279,67,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,236,126,235,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(306,1314)|
+1,237,234,235,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(146,1347)|
+10,238,"Inequality in 1980 (1)",1243,652,39,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,239,238,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1249,616)|
+10,240,"Inequality (1)",1159,607,42,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,241,240,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1192,593)|
+10,242,"Income from commons from 2022 G$/y",1158,461,73,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,243,242,104,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(987,563)|
+10,244,Time,1275,435,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,245,48,1053,1008,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,246,248,245,4,0,0,22,0,0,0,-1--1--1,,1|(1028,1008)|
+1,247,248,44,100,0,0,22,0,0,0,-1--1--1,,1|(921,1008)|
+11,248,48,1007,1008,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,249,"Cancellation of debt G$/y",1007,1035,48,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,250,44,249,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(895,982)|
+10,251,"Fraction of govmnt debt cancelled in 2022 1/y",1400,909,64,64,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,252,251,249,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1204,971)|
+1,253,218,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(170,163)|
+1,254,219,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(199,211)|
+1,255,244,242,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1246,440)|
+10,256,"Goal for extra income from commons (share of NI)",1181,350,61,61,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,257,256,242,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1166,418)|
+12,258,0,1599,399,272,250,3,156,0,0,1,0,0,0,0,0,0,0,0,0
+Income_inequity
+10,259,"Basic income tax rate owners (1)",1027,211,68,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,260,"Income tax rate owners in 2022 (1)",1153,146,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,261,217,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(991,169)|
+1,262,260,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1096,176)|
+1,263,259,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(967,235)|
+1,264,193,196,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1014,968)|
+1,265,193,223,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(925,756)|
+1,266,193,43,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(751,863)|
+1,267,193,48,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(792,922)|
+10,268,"Extra taxes for TAs from 2022 G$/y",270,262,62,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,269,"Fraction of extra TA cost paid by extra taxes (1)",84,333,81,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,270,269,268,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(169,299)|
+10,271,"Goal for extra taxes from 2022 G$/y",430,269,63,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,272,222,271,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(353,228)|
+1,273,215,32,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(413,405)|
+1,274,215,31,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(608,401)|
+10,275,"Goal for income tax rate owners (1)",1224,216,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,276,275,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1134,215)|
+1,277,177,6,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(685,288)|
+1,278,177,5,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(836,286)|
+1,279,230,6,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(699,196)|
+1,280,230,5,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(834,194)|
+1,281,177,1,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,406)|
+1,282,177,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(655,403)|
+1,283,230,2,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(649,308)|
+1,284,230,1,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(890,311)|
+1,285,177,222,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(531,256)|
+10,286,Time,262,323,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,287,286,268,0,0,0,0,0,64,0,-1--1--1,,1|(264,303)|
+10,288,"Cost of TAs G$/y",262,323,45,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,289,"Extra cost of TAs from 2022 G$/y",85,260,61,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,290,289,268,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(170,260)|
+1,291,268,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(342,264)|
+10,292,"Extra empowerment tax from 2022 (share of NI)",365,114,55,55,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,293,"Extra pension tax from 2022 (share of NI)",226,102,56,56,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,294,293,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(263,155)|
+1,295,292,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(322,160)|
+10,296,"Owner tax rate (1)",766,474,59,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,297,31,296,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(856,441)|
+10,298,"Worker tax rate (1)",302,482,52,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,299,32,298,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(425,447)|
+1,300,2,298,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(433,487)|
+1,301,1,296,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(889,487)|
+1,302,177,242,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(952,386)|
+10,303,"Fraction transferred in 1980 (1)",222,589,63,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,304,"Goal for fraction of govmnt budget to workers (1)",278,652,61,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,305,103,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(179,655)|
+1,306,303,304,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(240,610)|
+10,307,Time,269,710,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,308,307,304,0,0,0,0,3,64,0,255-0-255,|12||0-0-0,1|(270,696)|
+10,309,Introduction period for policy y,1221,518,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,310,309,242,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1194,494)|
+10,311,"Govmnt gross income (as share of NI)",592,620,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,312,177,311,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(677,465)|
+1,313,104,311,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(716,651)|
+10,314,Time to implement new taxes y,128,441,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,315,"Fraction of govmnt budget to workers (1)",325,540,52,32,3,131,0,3,0,0,0,0,0-0-128,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,316,"Extra taxes from 2022 G$/y",440,339,50,29,3,131,0,3,0,0,0,0,0-0-128,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,317,314,316,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(281,390)|
+1,318,314,315,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(212,483)|
+1,319,304,315,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(297,604)|
+1,320,315,102,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(495,631)|
+1,321,271,316,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(432,291)|
+1,322,316,32,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(483,379)|
+1,323,316,31,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(675,374)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Inventory
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Inventory Gu,709,284,47,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,1011,290,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,1,4,0,0,22,0,0,0,-1--1--1,,1|(814,292)|
+1,4,5,2,100,0,0,22,0,0,0,-1--1--1,,1|(943,292)|
+11,5,48,879,292,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"Output Gu/y",879,311,40,11,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,7,48,350,290,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,8,10,7,4,0,0,22,0,0,0,-1--1--1,,1|(419,289)|
+1,9,10,1,100,0,0,22,0,0,0,-1--1--1,,1|(576,289)|
+11,10,48,484,289,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,11,"Deliveries Gu/y",484,308,48,11,40,131,0,2,-1,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,12,"Recent sales Gu/y",572,370,42,31,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+10,13,Sales averaging time y,487,448,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,14,11,12,1,0,0,0,2,64,0,-1--1--1,|12||0-0-0,1|(541,332)|
+1,15,13,12,0,0,0,0,0,64,0,-1--1--1,,1|(517,419)|
+10,16,Inventory coverage y,676,440,35,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,17,Desired inventory coverage y,737,535,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,1,16,1,0,0,0,0,64,0,-1--1--1,,1|(699,363)|
+10,19,"Effective purchasing power G$/y",551,228,44,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,20,"Inflation rate 1/y",877,743,51,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,21,Inventory coverage perception time y,568,550,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,22,"Perceived relative inventory (1)",611,660,59,35,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,23,16,22,1,0,0,0,0,128,0,-1--1--1,,1|(662,506)|
+1,24,21,22,0,0,0,0,0,128,0,-1--1--1,,1|(583,590)|
+10,25,"sINVeoIN<0",792,781,44,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,26,25,20,0,0,0,0,0,128,0,-1--1--1,,1|(827,764)|
+1,27,22,20,1,0,0,0,0,128,0,-1--1--1,,1|(682,692)|
+10,28,"Price Index (1980=1)",1053,692,40,20,3,3,0,0,0,0,0,0,0,0,0,0,0,0
+12,29,48,1048,788,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,30,32,28,4,0,0,22,0,0,0,-1--1--1,,1|(1053,728)|
+1,31,32,29,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1053,768)|
+11,32,48,1053,751,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,33,"Change in Price Index 1/y",1111,751,50,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,28,33,1,0,0,0,0,128,0,-1--1--1,,1|(1118,696)|
+1,35,17,41,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(780,448)|
+10,36,"Demand pulse 2020-25 (1)",457,161,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,37,36,19,0,0,0,0,3,128,0,160-160-160,|12||0-0-0,1|(491,185)|
+10,38,"Demand in 1980 G$/y",776,206,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,39,38,19,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(665,216)|
+10,40,"SWI in 1980 (1)",913,408,53,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,41,INV in 1980 Gu,788,360,52,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,42,41,1,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(764,337)|
+1,43,19,11,0,0,0,0,0,128,0,-1--1--1,,1|(515,271)|
+10,44,"National income G$/y",223,269,57,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,45,Demand adjustment time y,615,141,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,46,45,19,0,0,0,0,0,128,0,-1--1--1,,1|(590,174)|
+1,47,38,12,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(686,277)|
+10,48,"Normal (1)",253,83,36,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,"STD in fluctuation around normal (1)",218,189,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,50,Sampling time y,219,128,50,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,51,"Pink noise in sales (1)",357,178,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,52,48,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(295,121)|
+1,53,49,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(289,183)|
+1,54,50,51,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(275,148)|
+1,55,51,11,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(457,243)|
+1,56,40,41,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(857,386)|
+10,57,Time,479,355,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,58,57,11,0,0,0,0,0,64,0,-1--1--1,,1|(480,338)|
+10,59,DDI in 1980 y,386,393,39,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,60,40,38,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(850,316)|
+1,61,40,6,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(898,366)|
+1,62,17,22,0,0,0,0,0,128,0,-1--1--1,,1|(686,584)|
+1,63,20,33,1,0,0,0,0,128,0,-1--1--1,,1|(958,749)|
+10,64,"Minimum relative inventory without inflation (1)",632,741,68,31,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,65,64,20,0,0,0,0,0,128,0,-1--1--1,,1|(756,741)|
+10,66,"Optimal real output Gu/y",1064,348,57,29,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,67,66,6,1,0,0,0,0,128,0,-1--1--1,,1|(987,321)|
+10,68,"Desired shifts worked - index (1)",943,601,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,69,"sINVeoSWI<0",888,650,50,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,70,"Shifts worked - index (1)",1017,469,48,27,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,71,Time to adjust shifts y,1051,557,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,72,22,68,1,0,0,0,0,128,0,-1--1--1,,1|(761,641)|
+10,73,"Desired relative inventory (1)",868,545,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,74,73,68,0,0,0,0,0,128,0,-1--1--1,,1|(899,568)|
+1,75,69,68,0,0,0,0,0,128,0,-1--1--1,,1|(905,634)|
+1,76,68,70,1,0,0,0,0,128,0,-1--1--1,,1|(1007,530)|
+1,77,71,70,0,0,0,0,0,128,0,-1--1--1,,1|(1038,523)|
+1,78,70,6,1,0,0,0,0,128,0,-1--1--1,,1|(974,385)|
+10,79,"ROC in DDI 1/y",292,559,53,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,80,"sINVeoDDI<0",340,624,49,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,81,"Delivery delay - index (1)",264,409,52,33,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,82,48,258,520,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,83,85,81,4,0,0,22,0,0,0,-1--1--1,,1|(262,456)|
+1,84,85,82,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(262,497)|
+11,85,48,262,476,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,86,"Change in DDI 1/y",315,476,45,28,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,87,81,86,1,0,0,0,0,128,0,-1--1--1,,1|(327,419)|
+10,88,"Sufficient relative inventory (1)",434,543,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,22,79,1,0,0,0,0,128,0,-1--1--1,,1|(381,608)|
+1,90,80,79,0,0,0,0,0,128,0,-1--1--1,,1|(320,597)|
+1,91,88,79,0,0,0,0,0,128,0,-1--1--1,,1|(369,550)|
+1,92,79,86,1,0,0,0,0,128,0,-1--1--1,,1|(304,511)|
+1,93,59,11,0,0,0,0,0,128,0,-1--1--1,,1|(435,349)|
+10,94,"Total purchasing power G$/y",431,42,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,95,94,19,1,0,0,0,0,128,0,-1--1--1,,1|(517,88)|
+10,96,"Optimal output in 1980 Gu/y",844,493,63,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,97,96,38,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(811,356)|
+1,98,96,41,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(816,428)|
+12,99,0,1397,402,222,246,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Inventory:_4-year_cycle
+10,100,"Pulse height (1)",396,111,49,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,101,100,36,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(415,127)|
+1,102,10,113,1,0,0,0,0,128,0,-1--1--1,,1|(441,259)|
+1,103,81,11,1,0,0,0,0,128,0,-1--1--1,,1|(361,339)|
+10,104,"GDP G$/y",904,166,37,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,105,"Price Index in 1980 (=1)",1060,635,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,106,105,28,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1057,656)|
+10,107,"Price per unit $/u",736,96,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,108,107,11,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(610,201)|
+1,109,107,38,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(753,144)|
+1,110,5,104,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(861,239)|
+1,111,107,104,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(822,132)|
+1,112,12,16,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(624,405)|
+10,113,"Sales G$/y",347,237,31,21,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,114,113,44,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(263,234)|
+1,115,107,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(540,166)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Finance
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Finance sector response time y,624,388,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"Perceived inflation CB 1/y",693,-70,47,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,"Indicated signal rate 1/y",470,61,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,"Central bank signal rate 1/y",509,252,43,39,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,5,48,502,136,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,6,8,4,4,0,0,22,0,0,0,-1--1--1,,1|(500,199)|
+1,7,8,5,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(500,159)|
+11,8,48,500,180,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,9,"Change in signal rate 1/yy",560,180,52,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,10,4,9,1,0,0,0,0,128,0,-1--1--1,,1|(582,225)|
+10,11,"3m interest rate 1/y",507,348,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,12,"Cost of capital for secured debt 1/y",506,468,55,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,13,"Normal basic bank margin 1/y",331,306,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,14,"Normal bank operating margin 1/y",332,395,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,15,4,11,0,0,0,0,0,128,0,-1--1--1,,1|(508,303)|
+1,16,11,12,0,0,0,0,0,128,0,-1--1--1,,1|(506,393)|
+1,17,13,11,0,0,0,0,0,128,0,-1--1--1,,1|(418,326)|
+1,18,14,12,0,0,0,0,0,128,0,-1--1--1,,1|(407,426)|
+1,19,12,43,1,0,0,0,0,128,0,-1--1--1,,1|(533,502)|
+10,20,"sUNeoSR<0",325,19,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,20,3,0,0,0,0,0,128,0,-1--1--1,,1|(384,36)|
+1,22,1,12,0,0,0,0,0,128,0,-1--1--1,,1|(581,416)|
+1,23,3,9,1,0,0,0,0,128,0,-1--1--1,,1|(451,164)|
+10,24,"sINeoSR>0",607,48,39,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,2,3,1,0,0,0,0,128,0,-1--1--1,,1|(570,-46)|
+1,26,24,3,0,0,0,0,0,128,0,-1--1--1,,1|(550,52)|
+10,27,Inflation perception time CB y,727,-150,61,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,2,0,0,0,0,0,128,0,-1--1--1,,1|(714,-122)|
+10,29,"Normal signal rate 1/y",342,93,44,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,29,3,0,0,0,0,0,128,0,-1--1--1,,1|(396,79)|
+10,31,Signal rate adjustment time y,608,116,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,32,31,9,0,0,0,0,0,128,0,-1--1--1,,1|(588,142)|
+10,33,"Inflation in 1980 (1/y)",834,-66,52,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,34,33,2,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(767,-68)|
+10,35,"Inflation target 1/y",608,-1,44,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,36,"Unemployment target (1)",321,-46,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,37,36,3,0,0,0,0,0,128,0,-1--1--1,,1|(389,3)|
+10,38,"Perceived unemployment CB (1)",462,-64,64,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,39,Unemployment perception time CB y,396,-157,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,40,39,38,0,0,0,0,0,128,0,-1--1--1,,1|(420,-122)|
+10,41,"Govmnt borrowing cost 1/y",762,354,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,42,"Worker borrowing cost 1/y",736,494,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,43,"Corporate borrowing cost 1/y",605,581,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,11,41,0,0,0,0,0,128,0,-1--1--1,,1|(622,350)|
+10,45,"Normal corporate credit risk 1/y",371,530,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,46,12,42,0,0,0,0,0,128,0,-1--1--1,,1|(611,479)|
+1,47,45,43,0,0,0,0,0,128,0,-1--1--1,,1|(480,553)|
+10,48,"Inflation rate 1/y",868,-147,43,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,49,48,2,0,0,0,0,0,128,0,-1--1--1,,1|(788,-113)|
+10,50,"Corporate borrowing cost in 1980 1/y",190,461,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,51,45,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(287,497)|
+12,52,0,1306,160,344,300,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Finance:_Interest_rates
+10,53,"10-yr govmnt interest rate 1/y",791,210,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,54,29,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(268,270)|
+1,55,13,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(265,378)|
+1,56,14,50,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(267,425)|
+10,57,"Expected long term inflation 1/y",800,68,51,32,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,58,Inflation expectation formation time y,866,-14,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,59,58,57,0,0,0,0,0,128,0,-1--1--1,,1|(842,15)|
+1,60,33,57,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(820,-13)|
+1,61,2,57,1,0,0,0,0,128,0,-1--1--1,,1|(726,7)|
+1,62,41,53,0,0,0,0,0,128,0,-1--1--1,,1|(774,288)|
+10,63,"Output growth rate 1/y",295,596,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,64,63,45,1,0,0,0,0,128,0,-1--1--1,,1|(357,558)|
+10,65,"sGReoCR<0",182,534,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,66,65,45,0,0,0,0,0,128,0,-1--1--1,,1|(261,532)|
+1,67,29,4,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(409,157)|
+10,68,"Unemployment rate (1)",600,-199,57,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,69,68,38,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(541,-142)|
+1,70,38,3,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(438,-9)|
+1,71,35,3,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(534,14)|
+1,72,57,53,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(795,138)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Public sector
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Public services per person k$/p/y",796,160,60,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Population Mp,670,105,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,3,2,1,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(717,125)|
+10,4,"Govmnt purchases G$/y",73,190,55,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,5,"Productivity of public purchases (1)",420,233,68,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Infrastructure purchases ratio y,240,307,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,7,4,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(140,277)|
+1,8,6,5,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(322,284)|
+10,9,"Value of public services supplied G$/y",582,152,62,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,10,4,9,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(375,150)|
+1,11,5,9,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(501,199)|
+10,12,"GDP G$/y",622,235,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,13,"State capacity (fraction of GDP)",752,239,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,14,9,13,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(672,191)|
+1,15,12,13,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(674,236)|
+1,16,9,1,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(682,155)|
+10,17,"TFP excluding effect of 5TAs (1)",1157,408,44,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,18,48,1006,408,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,19,21,17,4,0,0,22,0,0,0,-1--1--1,,1|(1088,407)|
+1,20,21,18,68,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1034,407)|
+11,21,48,1058,407,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,22,"Change in TFP 1/y",1058,446,38,31,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,17,22,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1107,467)|
+10,24,"TFP in 1980 (1)",1257,409,38,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,25,"Reduction in TFP from unprofitable activity (1)",949,648,62,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,26,"TFP including effect of 5TAs (1)",1158,594,64,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,"Indicated TFP (1)",939,569,50,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,28,26,27,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1048,581)|
+10,29,Infrastructure purchases ratio in 1980 y,254,226,56,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,29,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(323,228)|
+10,31,"sIPReoVPSS>0",414,312,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,32,31,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(415,283)|
+1,33,24,17,0,0,0,0,1,128,1,192-192-192,|12||0-0-0,1|(1216,408)|
+12,34,0,946,55,199,54,8,135,0,11,-1,0,0,0,0-0-255,0-0-0,|18||0-0-255,0,0,0,0,0,0
+ROTA = Rate of technological advance TFP = Total Factor productivity 1          ROC = Rate of change 1/y                    5TAs = 5 Turnarounds
+10,35,"State capacity in 1980 (fraction of GDP)",707,320,57,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,36,13,40,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(801,288)|
+1,37,35,40,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(775,334)|
+10,38,"Rate of technological advance 1/y",914,449,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,39,"Domestic ROTA in 1980 1/y",881,268,59,20,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,40,"Domestic rate of technological advance 1/y",870,357,70,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,41,40,38,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(890,401)|
+1,42,39,40,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,301)|
+10,43,"sSCeoROTA>0",713,385,52,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,43,40,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(775,373)|
+1,45,38,22,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(999,493)|
+1,46,17,26,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1157,502)|
+10,47,"Govmnt spending G$/y",76,68,60,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,48,Investment planning time y,873,711,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||160-160-160,0,0,0,0,0,0
+10,49,Construction time PIS y,1021,724,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,50,48,25,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(894,692)|
+1,51,49,25,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(997,699)|
+10,52,"National income G$/y",804,571,57,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,53,Capacity PUS Gcu,78,358,51,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,54,53,6,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(150,335)|
+10,55,"Reduction in ROTA from inequality 1/y",604,461,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,56,"sIIEeoROTA<0",392,393,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,57,"INEQUALITY INDEX (1980=1)",365,456,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,58,57,55,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(480,457)|
+1,59,56,55,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(478,420)|
+1,60,55,38,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(750,455)|
+10,61,"Imported ROTA 1/y",1042,304,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,62,"Max imported ROTA from 2022 1/y",1085,164,56,56,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,63,"GDPpp of technology leader k$/p/y",1301,262,70,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,64,"GDP per person k$/p/y",1211,195,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,65,62,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1060,244)|
+1,66,64,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1132,245)|
+1,67,63,61,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1170,282)|
+10,68,"GDP G$/y",248,24,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,69,Govmnt spending as share of GDP,263,81,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,70,68,69,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(252,41)|
+1,71,47,69,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(160,73)|
+10,72,"Cost of TAs G$/y",63,659,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,73,25,26,0,0,0,0,0,64,0,-1--1--1,,1|(1045,622)|
+10,74,"Productivity loss from unprofitable activity (1)",618,734,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"Fraction unprofitable activity in TAs (1)",453,817,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,76,75,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(528,778)|
+1,77,74,25,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(768,684)|
+10,78,"Extra cost of TAs as share of GDP (1)",432,693,66,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,79,"GDP G$/y",272,626,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,80,72,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(125,675)|
+1,81,79,78,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(335,652)|
+10,82,"Extra domestic ROTA from 2022 1/y",944,190,72,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,82,40,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(958,285)|
+10,84,Time,870,404,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,85,84,40,0,0,0,0,0,64,0,-1--1--1,,1|(870,396)|
+10,86,Time,1134,347,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,87,86,61,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(1102,332)|
+10,88,Population Mp,61,130,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,89,"Public spending per person k$/p/y",244,131,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,90,88,89,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(142,130)|
+1,91,47,89,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(152,97)|
+10,92,"sOWeoTFP<0",567,638,48,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,93,Time,624,520,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,94,Observed warming deg C,475,591,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,95,OWeoTFP,711,568,37,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,96,94,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(594,579)|
+1,97,92,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(632,606)|
+1,98,93,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(660,540)|
+10,99,Observed warming in 2022 deg C,452,538,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,100,99,95,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(589,553)|
+1,101,95,27,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(811,568)|
+10,102,"xExtra cost of TAs as share of GDP (1)",588,860,69,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,103,"xExtra TA cost in 2022 (share of GDP)",783,826,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"xExtra TA cost in 2100 (share of GDP)",762,887,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,105,103,102,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(692,840)|
+1,106,104,102,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(682,874)|
+1,107,78,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(514,710)|
+10,108,"Cost of TAs in 2022 G$/y",62,728,47,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,109,"Extra cost of TAs from 2022 G$/y",214,700,57,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,110,108,109,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(170,715)|
+1,111,109,78,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(319,692)|
+1,112,61,38,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(964,367)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Climate
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,CO2 in atmosphere GtCO2,370,190,58,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,2,48,188,193,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,3,5,1,4,0,0,22,0,0,0,-1--1--1,,1|(286,193)|
+1,4,5,2,100,0,0,22,0,0,0,-1--1--1,,1|(223,193)|
+11,5,48,255,193,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,6,"CO2 emissions GtCO2/y",255,220,49,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,7,48,556,190,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,8,10,7,4,0,0,22,0,0,0,-1--1--1,,1|(523,192)|
+1,9,10,1,100,0,0,22,0,0,0,-1--1--1,,1|(458,192)|
+11,10,48,494,192,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,11,"CO2 absorption GtCO2/y",494,222,53,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,12,Life of extra CO2 in atm y,568,288,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,13,1,11,1,0,0,0,3,192,0,0-0-255,|14||0-0-0,1|(452,249)|
+1,14,12,11,1,0,45,14,19,192,0,0-0-255,|14|B|255-0-0,1|(528,224)|
+10,15,CO2 in atm in 1850 GtCO2,625,224,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,16,15,11,0,0,0,0,0,128,0,-1--1--1,,1|(570,223)|
+10,17,CO2 in atm in 1980 GtCO2,436,106,45,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,17,1,0,0,0,0,3,128,1,192-192-192,|14||0-0-255,1|(412,136)|
+10,19,Perception delay y,351,-467,58,11,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,20,0,2077,10,398,329,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Climate
+10,21,Extra heat in surface ZJ,883,-407,49,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,22,"Melting rate surface 1/y",990,-657,39,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,23,"Heat required to melt ice kJ/kg",1131,-446,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,24,Extra heat in 1980 ZJ,729,-447,40,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,24,21,0,0,0,0,0,128,1,-1--1--1,,1|(794,-429)|
+10,26,CO2 concentration in 1980 ppm,132,-112,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,27,Global surface Mkm2,1373,-279,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,28,Amount of ice in 1980 Mkm3,1132,-561,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,29,Ton per m3 ice,1154,-491,48,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,30,"Melting rate surface in 1980 1/y",710,-659,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,31,30,22,0,0,0,0,0,128,0,-1--1--1,,1|(855,-658)|
+10,32,CH4 in atmosphere GtCH4,764,369,54,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,33,48,574,367,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,34,36,33,4,0,0,22,0,0,0,-1--1--1,,1|(614,368)|
+1,35,36,32,100,0,0,22,0,0,0,-1--1--1,,1|(683,368)|
+11,36,48,651,368,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,37,"CH4 breakdown GtCH4/y",651,395,55,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,38,48,381,329,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,39,41,1,4,0,0,22,0,0,0,-1--1--1,,1|(376,249)|
+1,40,41,38,100,0,0,22,0,0,0,-1--1--1,,1|(376,305)|
+11,41,48,376,284,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,42,"CO2 from CH4 GtCO2/y",436,284,52,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,43,36,42,1,0,0,0,0,128,0,-1--1--1,,1|(545,335)|
+10,44,Life of CH4 in atm y,585,454,44,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,45,32,37,1,0,0,0,0,128,0,-1--1--1,,1|(729,419)|
+1,46,44,37,0,0,0,0,0,128,0,-1--1--1,,1|(616,425)|
+10,47,CH4 in atm in 1980 GtCH4,799,290,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,48,47,32,0,0,0,0,0,128,1,-1--1--1,,1|(786,318)|
+1,49,32,253,1,0,0,0,0,128,0,-1--1--1,,1|(703,289)|
+10,50,CO2 concentration in atm ppm,380,11,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,51,1,50,1,0,0,0,0,128,0,-1--1--1,,1|(359,91)|
+10,52,"Ice and snow cover excl G&A Mkm2",1314,-466,46,37,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,53,48,1312,-581,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,54,56,52,36,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1316,-514)|
+1,55,56,53,68,0,0,22,2,64,0,-1--1--1,|12||0-0-0,1|(1316,-555)|
+11,56,48,1316,-531,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,57,"Melting Mha/y",1371,-531,46,11,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,58,52,57,1,0,0,0,0,128,0,-1--1--1,,1|(1400,-463)|
+10,59,GtCO2 per ppm,462,61,53,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+12,60,48,856,-528,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,61,63,60,4,0,0,22,0,0,0,-1--1--1,,1|(856,-499)|
+1,62,63,21,100,0,0,22,0,0,0,-1--1--1,,1|(856,-451)|
+11,63,48,856,-472,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,64,"Extra cooling from ice melt ZJ/y",923,-472,59,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,65,28,64,0,0,0,0,0,64,0,-1--1--1,,1|(1033,-519)|
+1,66,23,64,0,0,0,0,0,64,0,-1--1--1,,1|(1036,-457)|
+1,67,22,184,0,0,0,0,0,64,0,-1--1--1,,1|(978,-614)|
+1,68,29,64,0,0,0,0,0,64,0,-1--1--1,,1|(1050,-482)|
+12,69,48,1106,-402,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,70,72,69,4,0,0,22,0,0,0,-1--1--1,,1|(1058,-402)|
+1,71,72,21,100,0,0,22,0,0,0,-1--1--1,,1|(970,-402)|
+11,72,48,1014,-402,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,73,"Heat to space ZJ/y",1014,-368,39,26,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,74,"Albedo in 1980 (1)",1461,-376,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,75,74,155,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1309,-338)|
+10,76,Ice and snow cover excl Greenland and Antarctica in 1980 Mkm2,1470,-450,89,28,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,77,76,52,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1377,-459)|
+10,78,Warming in 1980 deg C,386,-382,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,79,Perceived warming deg C,265,-397,40,27,3,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,80,19,79,0,0,0,0,0,128,0,-1--1--1,,1|(323,-444)|
+1,81,78,22,0,0,0,0,3,64,0,192-192-192,|12||0-0-0,1|(682,-517)|
+10,82,Observed warming deg C,521,-453,49,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,78,82,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(446,-414)|
+1,84,21,82,1,0,0,0,0,128,0,-1--1--1,,1|(752,-503)|
+1,85,24,82,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(636,-449)|
+1,86,82,79,1,0,0,0,0,128,0,-1--1--1,,1|(386,-437)|
+1,87,82,22,1,0,0,0,0,128,0,-1--1--1,,1|(839,-648)|
+10,88,"CO2 from energy and industry GtCO2/y",206,437,66,35,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,89,88,6,1,0,0,0,0,128,0,-1--1--1,,1|(173,296)|
+10,90,kg CH4 per $ of GDP,1497,259,58,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,91,48,957,373,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,92,94,32,4,0,0,22,0,0,0,-1--1--1,,1|(847,373)|
+1,93,94,91,100,0,0,22,0,0,0,-1--1--1,,1|(917,373)|
+11,94,48,882,373,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,95,"CH4 emissions GtCH4/y",882,400,48,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,96,N2O in atmosphere GtN2O,1343,205,54,29,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,97,Life of N2O in atm y,1118,305,47,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,98,96,168,1,0,0,0,0,128,0,-1--1--1,,1|(1322,249)|
+1,99,97,168,0,0,0,0,0,128,0,-1--1--1,,1|(1173,274)|
+10,100,N2O in atm in 1980 GtN2O,1393,123,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,101,100,96,0,0,0,0,0,128,1,-1--1--1,,1|(1374,153)|
+10,102,kg N2O emission per kg fertiliser,1433,377,56,19,8,3,0,6,0,0,0,0,-1--1--1,255-255-255,|12||0-0-128,0,0,0,0,0,0
+10,103,"Rate of decline in N2O per kg fertiliser 1/y",1305,490,74,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,Time,1253,361,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,105,104,102,0,0,0,0,0,64,0,-1--1--1,,1|(1320,366)|
+12,106,48,1536,209,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,107,109,96,4,0,0,22,0,0,0,-1--1--1,,1|(1426,209)|
+1,108,109,106,100,0,0,22,0,0,0,-1--1--1,,1|(1496,209)|
+11,109,48,1461,209,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,110,"N2O emissions GtN2O/y",1461,236,49,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,111,96,227,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1266,97)|
+10,112,"Natural N2O emissions GtN2O/y",1371,309,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,113,"Man-made N2O emissions GtN2O/y",1546,303,63,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,114,112,110,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1410,276)|
+1,115,113,110,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1532,274)|
+10,116,"Fertilizer use Mt/y",1562,485,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,117,103,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1363,438)|
+1,118,104,112,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1295,341)|
+10,119,kg N2O per kg fertilizer in 1980,1242,426,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,119,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1328,403)|
+1,121,102,113,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1483,343)|
+1,122,116,113,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1589,404)|
+10,123,"Forcing from CO2 in 1980 W/m2",285,-110,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,kg CH4 emission per kg crop,897,545,55,19,8,3,0,6,0,0,0,0,-1--1--1,255-255-255,|12||0-0-128,0,0,0,0,0,0
+10,125,"Rate of decline in CH4 per kg crop 1/y",848,617,73,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,126,Time,732,534,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,127,126,124,0,0,0,0,0,64,0,-1--1--1,,1|(792,537)|
+10,128,"Natural CH4 emissions GtCH4/y",842,480,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,129,"Man-made CH4 emissions GtCH4/y",998,483,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,130,125,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(867,586)|
+1,131,126,128,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(772,514)|
+10,132,kg CH4 per kg crop in 1980,722,589,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,133,132,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(799,569)|
+1,134,124,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(940,517)|
+1,135,128,95,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(875,450)|
+1,136,129,95,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(932,460)|
+10,137,"Demand for red meat Mt-red-meat/y",1655,385,73,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,138,"Crop supply (after 20 % waste) Mt-crop/y",1168,580,56,34,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,139,138,129,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1060,537)|
+10,140,tCO2 per tCH4,450,353,51,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,141,140,42,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(445,329)|
+12,142,48,858,-264,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,143,145,21,4,0,0,22,0,0,0,-1--1--1,,1|(856,-352)|
+1,144,145,142,100,0,0,22,0,0,0,-1--1--1,,1|(856,-293)|
+11,145,48,856,-320,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,146,"Extra warming from forcing ZJ/y",925,-320,61,27,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,147,48,676,-408,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,148,150,147,4,0,0,22,0,0,0,-1--1--1,,1|(720,-408)|
+1,149,150,21,100,0,0,22,0,0,0,-1--1--1,,1|(800,-408)|
+11,150,48,760,-408,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,151,"Heat to deep ocean ZJ/y",760,-381,42,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,152,21,151,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(820,-359)|
+10,153,"Transfer rate for heat going to abyss 1/y",626,-283,67,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,82,153,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(523,-358)|
+10,155,"Transfer rate for heat going to space 1/y",1128,-293,67,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,156,"Transfer rate surface-abyss in 1980 1/y",618,-367,70,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,156,153,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(621,-327)|
+10,158,"Transfer rate surface-space in 1980 1/y",1263,-237,71,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,159,158,155,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1191,-266)|
+1,160,155,73,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1045,-318)|
+1,161,21,73,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(931,-357)|
+10,162,"Albedo ice and snow (1)",1498,-274,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,163,GtN2O per ppm,1154,97,43,18,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+12,164,48,1181,209,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,165,167,164,4,0,0,22,0,0,0,-1--1--1,,1|(1214,211)|
+1,166,167,96,100,0,0,22,0,0,0,-1--1--1,,1|(1269,211)|
+11,167,48,1243,211,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,168,"N2O breakdown GtN2O/y",1243,238,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,169,Observed warming deg C,1095,-235,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,170,169,155,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1118,-267)|
+10,171,"Albedo global average (1)",1596,-308,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,172,27,146,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1163,-297)|
+1,173,171,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1534,-338)|
+10,174,"Albedo (1)",1288,-380,36,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,175,27,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1332,-328)|
+1,176,162,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1391,-327)|
+1,177,171,174,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1444,-342)|
+1,178,174,155,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1246,-335)|
+1,179,52,174,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1314,-410)|
+1,180,76,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1466,-415)|
+1,181,27,74,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1411,-322)|
+1,182,162,74,0,0,0,0,3,64,0,192-192-192,|12||0-0-0,1|(1482,-318)|
+1,183,22,56,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1205,-598)|
+10,184,"Melting rate deep ice 1/y",962,-559,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,185,184,64,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(945,-521)|
+10,186,"Surface vs deep rate (1)",1077,-607,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,187,186,184,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1025,-585)|
+1,188,153,151,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(769,-334)|
+10,189,"GHG EMISSIONS GtCO2e/y",872,169,68,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,190,6,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(547,195)|
+1,191,95,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,291)|
+1,192,110,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1182,204)|
+10,193,"tCO2e/tCO2",802,222,43,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,194,"tCO2e/tCH4",930,222,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,195,"tCO2e/tN2O",1061,150,43,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,196,193,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(825,203)|
+1,197,194,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(910,204)|
+1,198,195,189,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(985,157)|
+10,199,"sOWeoLoCO2>0",230,551,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,200,Time,424,484,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,201,Observed warming deg C,352,596,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,202,OWeoLoCO2,308,486,47,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,203,201,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(331,543)|
+1,204,199,202,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(263,523)|
+1,205,200,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(383,484)|
+10,206,Life of extra CO2 in atm in 1980 y,364,406,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,207,206,12,1,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(475,372)|
+1,208,202,12,1,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(457,412)|
+10,209,"CO2 emissions from LULUC GtCO2/y",294,346,58,31,8,130,0,3,-1,0,0,0,192-192-192,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,210,209,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(248,293)|
+10,211,"Risk of extreme heat event (1)",492,-575,57,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,212,Ice and snow cover Mha,1428,-620,43,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,213,52,212,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1372,-546)|
+10,214,"Water vapor concentration g/kg",425,-292,59,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,215,"Water vapour feedback W/m2",517,-202,52,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,216,"Forcing from CH4 W/m2",678,1,49,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,217,"Forcing from CO2 W/m2",450,-90,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,218,214,215,1,0,0,0,0,128,0,-1--1--1,,1|(432,-240)|
+10,219,"Water vapour concentration 1980 g/kg",255,-262,78,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,220,"sWVeoWVF>0",364,-163,52,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,221,"CH4 forcing per ppm W/m2/ppm",791,68,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,222,221,216,0,0,0,0,0,128,0,-1--1--1,,1|(747,42)|
+1,223,216,273,1,0,0,0,0,128,0,-1--1--1,,1|(721,-112)|
+10,224,"sOWeoWV>0",284,-330,48,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,225,224,214,0,0,0,0,0,128,0,-1--1--1,,1|(338,-314)|
+10,226,"Forcing from N2O W/m2",937,-69,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,227,N2O concentration in atm ppm,1138,21,62,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,228,227,226,1,0,0,0,0,128,0,-1--1--1,,1|(1077,-17)|
+10,229,"N2O forcing per ppm W/m2/ppm",943,-4,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,230,229,226,0,0,0,0,0,128,0,-1--1--1,,1|(941,-29)|
+1,231,226,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(859,-144)|
+10,232,"Total man-made forcing W/m2",812,-215,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,233,219,214,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(342,-276)|
+1,234,220,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(429,-179)|
+10,235,"Water vapor feedback in 1980 W/m2",252,-215,72,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,236,235,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(387,-208)|
+1,237,219,215,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(392,-230)|
+1,238,215,232,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(647,-190)|
+10,239,"Forcing from other gases W/m2",618,-85,48,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,240,239,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(707,-172)|
+1,241,232,146,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(892,-260)|
+1,242,82,214,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(455,-389)|
+1,243,50,217,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(402,-41)|
+10,244,Time,960,54,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,245,244,229,0,0,0,0,0,64,0,-1--1--1,,1|(954,35)|
+1,246,82,211,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(508,-507)|
+1,247,78,214,0,0,0,0,0,64,0,-1--1--1,,1|(402,-343)|
+10,248,Observed warming in 2022 deg C,366,-526,68,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,249,CO2 concentration in 2022 ppm,296,-63,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,250,Observed warming in 2022 deg C,464,543,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,251,250,202,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(381,512)|
+1,252,217,273,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(596,-170)|
+10,253,CH4 concentration in atm ppm,656,122,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,254,253,216,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(653,69)|
+10,255,GtCH4 per ppm,728,179,37,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,256,Mass of atmosphere Zt,957,106,46,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,257,CH4 conc in 1980 ppm,966,295,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,258,256,257,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(960,193)|
+1,259,47,257,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(877,291)|
+10,260,N2O conc in 1980 ppm,1552,118,42,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,261,256,260,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1249,111)|
+1,262,100,260,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1467,120)|
+10,263,Time,600,-18,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,264,263,239,0,0,0,0,0,64,0,-1--1--1,,1|(604,-36)|
+10,265,Time,791,106,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,266,265,221,0,0,0,0,0,64,0,-1--1--1,,1|(791,98)|
+1,267,163,227,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1148,66)|
+1,268,255,253,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(697,154)|
+1,269,59,50,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(433,43)|
+10,270,"CO2 forcing per ppm W/m2/ppm",509,-4,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,271,263,270,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(574,-14)|
+1,272,270,217,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(483,-41)|
+10,273,"Man-made forcing W/m2",781,-159,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,274,273,232,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(792,-180)|
+10,275,"Warming from extra heat deg/ZJ",716,-551,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,276,275,82,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(613,-521)|
+10,277,"Direct air capture of CO2 GtCO2/y",259,146,64,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,278,"Direct air capture of CO2 in 2100 GtCO2/y",139,-19,53,53,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,279,278,277,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(203,69)|
+10,280,"Cost of air capture G$/y",269,59,42,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,281,277,5,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(257,169)|
+10,282,"Cost of CCS $/tCO2",260,-5,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,283,282,280,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(262,21)|
+1,284,277,280,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(262,109)|
+10,285,Introduction period for policy y,95,150,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,286,285,277,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(171,148)|
+10,287,Time,259,184,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,288,287,277,0,0,0,0,0,64,0,-1--1--1,,1|(259,176)|
+10,289,"CO2 per GDP (kgCO2/$)",77,239,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,290,6,289,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(172,228)|
+10,291,"GDP G$/y",64,306,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,292,291,289,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(68,283)|
+10,293,"Extra rate of decline in N2O per kg fertilizer from 2022 1/y",1475,554,90,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,294,293,102,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1454,467)|
+10,295,"Extra rate of decline in CH4 pr kg crop after 2022 1/y",1036,620,87,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,296,295,124,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(964,581)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Other performance indicators
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"RATE OF GROWTH IN GDP PER PERSON 1/y",592,71,79,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,"GDP per person k$/p/y",109,66,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,3,"Past GDP per person k$/y",396,111,44,36,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,Time to establish growth rate y,396,205,54,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,5,2,1,1,0,0,0,0,128,0,-1--1--1,,1|(353,40)|
+1,6,2,3,1,0,0,0,0,128,0,-1--1--1,,1|(252,88)|
+1,7,3,1,1,0,0,0,0,128,0,-1--1--1,,1|(469,96)|
+1,8,4,3,0,0,0,0,0,128,0,-1--1--1,,1|(396,173)|
+1,9,4,1,0,0,0,0,0,128,0,-1--1--1,,1|(481,146)|
+10,10,"GDP per person in 1980 k$/p/y",256,156,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,11,10,3,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(326,133)|
+10,12,"Factor to avoid transient in growth rate (1)",90,136,72,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,13,12,3,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(250,123)|
+12,14,0,1258,317,341,297,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Other_performance_indicators
+10,15,"Cost of food G$/y",196,339,46,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,16,"Cost of energy G$/y",189,444,52,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,17,"Cost of food and energy TAs G$/y",382,375,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,18,15,17,0,0,0,0,0,128,0,-1--1--1,,1|(277,354)|
+1,19,16,17,0,0,0,0,0,128,0,-1--1--1,,1|(277,412)|
+10,20,"Cost of TAs G$/y",592,377,57,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,21,17,20,0,0,0,0,0,128,0,-1--1--1,,1|(479,375)|
+10,22,"Fraction below 15 k$/p/y (1)",628,541,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,23,"Logistic k (1)",440,536,43,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,24,"Inequality (1)",94,512,46,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,25,"Inequity effect on logistic k (1)",265,531,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,26,24,25,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(168,519)|
+1,27,25,23,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(351,532)|
+1,28,23,22,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(519,537)|
+10,29,"sINEeoLOK<0",153,580,51,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,30,29,25,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(193,562)|
+10,31,"Normal k (1)",353,580,42,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,32,31,23,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(389,561)|
+10,33,"GDP per person k$/p/y",529,473,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,34,33,22,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(572,503)|
+10,35,"Population below 15 k$/p/y Mp",797,544,66,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,36,Population Mp,729,471,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,37,36,35,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(754,498)|
+1,38,22,35,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(702,542)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Food and land use
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,"Crop demand Mt-crop/y",731,581,45,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Forestry land Mha,1777,848,46,28,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,3,Grazing land Mha,1588,724,49,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,4,Cropland Mha,1771,989,44,25,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,5,Barren land Mha,1792,1130,43,24,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,6,Urban land Mha,1984,991,42,26,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,7,"Potential red meat from grazing land Mt-red-meat/y",1398,414,87,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,8,"Grazing land yield kg-red-meat/ha/y",1344,488,57,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,9,3,7,1,0,0,0,0,128,0,-1--1--1,,1|(1537,581)|
+10,10,"Soil quality index in conv ag (1980=1)",645,1329,59,44,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,11,13,5,4,0,0,22,0,0,0,-1--1--1,,1|(1785,1086)|
+1,12,13,4,100,0,0,22,0,0,0,-1--1--1,,1|(1785,1034)|
+11,13,7856,1785,1061,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,14,"Cropland loss Mha/y",1838,1061,45,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,15,4,13,1,0,0,0,0,128,0,-1--1--1,,1|(1746,1041)|
+1,16,18,4,4,0,0,22,0,0,0,-1--1--1,,1|(1785,940)|
+1,17,18,2,100,0,0,22,0,0,0,-1--1--1,,1|(1785,890)|
+11,18,7548,1785,911,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,19,"Cropland expansion Mha/y",1848,911,55,19,40,3,0,2,-1,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,20,22,6,4,0,0,22,0,0,0,-1--1--1,,1|(1919,992)|
+1,21,22,4,100,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1849,992)|
+11,22,7988,1890,992,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,23,"Urban expansion Mha/y",1890,1019,54,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+10,24,Urban development time y,1996,1084,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,6,23,1,0,0,0,0,128,0,-1--1--1,,1|(1959,1027)|
+10,26,"Fertilizer effect on erosion rate (1)",1450,1227,57,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,27,"Old growth removal rate 1/y",1685,592,52,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,35,1,0,0,0,0,128,0,-1--1--1,,1|(1747,604)|
+10,29,Old growth forest area Mha 1,1780,726,49,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,30,32,3,4,0,0,22,0,0,0,-1--1--1,,1|(1660,729)|
+1,31,32,29,100,0,0,22,0,0,0,-1--1--1,,1|(1713,729)|
+11,32,7372,1690,729,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,33,"New grazing land Mha/y",1690,769,56,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,34,"Fraction cleared for grazing (1)",1465,599,63,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,35,"Old growth removal Mha/y",1769,649,48,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,36,38,2,4,0,0,22,0,0,0,-1--1--1,,1|(1783,806)|
+1,37,38,29,100,0,0,22,0,0,0,-1--1--1,,1|(1783,768)|
+11,38,7350,1783,786,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,39,"New forestry land Mha/y",1856,786,58,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,40,29,35,1,0,0,0,0,128,0,-1--1--1,,1|(1831,672)|
+1,41,35,32,1,0,0,0,0,128,0,-1--1--1,,1|(1692,687)|
+1,42,35,38,1,0,0,0,0,128,0,-1--1--1,,1|(1712,700)|
+10,43,"Cropland expansion rate 1/y",1369,851,49,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,44,43,18,1,0,0,0,0,128,0,-1--1--1,,1|(1572,866)|
+1,45,4,18,1,0,0,0,0,128,0,-1--1--1,,1|(1754,931)|
+10,46,"Demand for red meat per person kg-red-meat/p/y",980,232,81,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,47,"Crop yield in reg ag t-crop/ha/y",446,616,63,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,48,"CO2 release from forest cut GtCO2/y",1857,406,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,49,"sFBeoCLE<0",1265,790,45,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,50,49,43,0,0,0,0,0,128,0,-1--1--1,,1|(1295,808)|
+10,51,"Soil quality index in 1980 (1)",625,1231,50,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,52,51,10,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(631,1264)|
+10,53,"sFUeoLER>0",1336,1179,45,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,54,53,26,0,0,0,0,0,128,0,-1--1--1,,1|(1376,1196)|
+10,55,Grazing land in 1980 Mha,1478,728,36,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,56,55,3,0,0,0,0,0,128,1,-1--1--1,,1|(1519,726)|
+10,57,Old growth forest in 1980 Mha,1944,718,64,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,57,29,0,0,0,0,3,128,1,192-192-192,|12||0-0-0,1|(1861,721)|
+10,59,Forestry land in 1980 Mha,1610,843,50,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,60,59,2,0,0,0,0,0,128,1,-1--1--1,,1|(1688,844)|
+10,61,Urban land in 1980 Mha,1984,928,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,62,61,6,0,0,0,0,0,128,1,-1--1--1,,1|(1984,949)|
+10,63,Cropland in 1980 Mha,1645,988,50,24,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,64,63,4,0,0,0,0,0,128,1,-1--1--1,,1|(1704,988)|
+10,65,"Urban land per population ha/p",1993,1228,49,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,66,"Red meat from feedlots Mt-red-meat/y",1012,403,74,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,67,8,7,1,0,0,0,0,128,0,-1--1--1,,1|(1374,454)|
+1,68,7,148,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1303,368)|
+10,69,"Feed for red meat Mt-crop/y",880,464,58,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,70,"Grazing land yied in 1980 kg-red-meat/ha/y",1308,560,74,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,71,70,8,0,0,0,0,0,128,0,-1--1--1,,1|(1322,530)|
+10,72,"Average crop yield t-crop/ha/y",884,1089,61,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,73,"Fertilizer use Mt/y",317,872,46,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,74,24,23,1,0,0,0,0,128,0,-1--1--1,,1|(1937,1055)|
+10,75,"Crop supply (after 20 % waste) Mt-crop/y",1136,1132,63,32,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,76,4,75,1,0,0,0,0,128,0,-1--1--1,,1|(1417,1107)|
+1,77,72,75,1,0,0,0,0,128,0,-1--1--1,,1|(1000,1129)|
+10,78,"Crop balance (1)",987,878,50,21,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,79,48,476,1325,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,80,82,10,4,0,0,22,0,0,0,-1--1--1,,1|(561,1327)|
+1,81,82,79,100,0,0,22,0,0,0,-1--1--1,,1|(505,1327)|
+11,82,48,530,1327,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,83,"Change in soil quality in conv ag t-crop/ha/y/y",530,1361,59,26,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+10,84,"Desired reserve capacity (1)",1049,798,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,159,0,0,0,0,0,128,0,-1--1--1,,1|(1111,819)|
+12,86,8062558,2601,317,361,324,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Food_and_land_use
+10,87,Population Mp,434,292,49,20,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,88,Population Mp,1841,1246,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+12,89,0,3432,967,430,317,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Land_yield_and_fertility
+10,90,"Sustainable fertiliser use kgN/ha/y",340,1149,56,26,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,91,"ROC in soil quality in conv ag 1/y",468,1202,64,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,92,90,91,0,0,0,0,0,128,0,-1--1--1,,1|(393,1171)|
+10,93,"sFUeoSQ<0",564,1143,42,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,94,93,91,0,0,0,0,0,128,0,-1--1--1,,1|(536,1160)|
+12,95,7341730,3418,317,424,312,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Food_demand_and_supply
+10,96,"Traditional use of crops per person kg-crop/p/y",542,246,75,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,97,"Traditional use of red meat per person kg-red-meat/p/y",780,237,89,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,98,"kg-crop per kg-red-meat",886,391,41,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,99,97,46,0,0,0,0,0,128,0,-1--1--1,,1|(877,235)|
+1,100,98,69,0,0,0,0,0,128,0,-1--1--1,,1|(883,420)|
+1,101,66,69,1,0,0,0,0,128,0,-1--1--1,,1|(944,426)|
+1,102,69,1,1,0,0,0,0,128,0,-1--1--1,,1|(801,517)|
+10,103,Indicated urban land Mha,1965,1147,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,104,88,103,0,0,0,0,0,128,0,-1--1--1,,1|(1892,1204)|
+1,105,65,103,0,0,0,0,0,128,0,-1--1--1,,1|(1981,1194)|
+1,106,103,23,0,0,0,0,0,128,0,-1--1--1,,1|(1931,1089)|
+10,107,"Crop use per person t-crop/p/y",846,931,59,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,108,"Traditional fertilizer use in conv ag kgN/ha/y",545,1009,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,109,91,82,1,0,0,0,0,128,0,-1--1--1,,1|(480,1251)|
+1,110,10,82,1,0,0,0,0,128,0,-1--1--1,,1|(562,1273)|
+1,111,10,72,1,0,0,0,0,128,0,-1--1--1,,1|(843,1223)|
+10,112,"Sustainable fertiliser use kgN/ha/y",1309,1334,68,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,113,112,26,0,0,0,0,0,128,0,-1--1--1,,1|(1373,1284)|
+10,114,"Fraction regenerative agriculture (1)",320,686,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,115,"Crop supply reg ag Mt-crop/y",519,690,47,31,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,116,47,115,0,0,0,0,0,128,0,-1--1--1,,1|(471,642)|
+10,117,"Desired crop supply conv ag Mt-crop/y",641,747,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,118,115,117,1,0,0,0,0,128,0,-1--1--1,,1|(611,699)|
+10,119,"Desired crop yield in conv ag t-crop/ha/y",663,927,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,117,119,1,0,0,0,0,128,0,-1--1--1,,1|(634,826)|
+1,121,1,153,1,0,0,0,0,128,0,-1--1--1,,1|(719,626)|
+10,122,Cropland Mha,543,787,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,123,122,119,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(594,847)|
+1,124,114,73,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(318,772)|
+1,125,114,72,1,0,0,0,0,128,0,-1--1--1,,1|(544,916)|
+1,126,122,73,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(445,823)|
+1,127,122,115,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(535,755)|
+1,128,114,115,1,0,0,0,0,128,0,-1--1--1,,1|(434,683)|
+1,129,119,108,0,0,0,0,0,128,0,-1--1--1,,1|(609,964)|
+1,130,119,72,1,0,0,0,0,128,0,-1--1--1,,1|(748,1019)|
+10,131,"Crop yield in reg ag t-crop/ha/y",851,1002,68,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,132,131,72,0,0,0,0,0,128,0,-1--1--1,,1|(864,1038)|
+1,133,114,119,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(485,802)|
+10,134,"GDP per person k$/p/y",483,137,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,135,134,97,0,0,0,0,0,128,0,-1--1--1,,1|(624,185)|
+1,136,134,96,0,0,0,0,0,128,0,-1--1--1,,1|(508,186)|
+10,137,CO2 concentration in atm ppm,1159,1259,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,138,CO2 concentration in atm ppm,1163,527,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,139,138,8,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1251,508)|
+10,140,"Biofuels use Mtoe/y",470,542,40,40,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,141,140,146,0,0,0,0,0,128,0,-1--1--1,,1|(525,544)|
+10,142,Time,376,514,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,143,142,140,0,0,0,0,0,64,0,-1--1--1,,1|(409,523)|
+10,144,Ton crops per toe biofuel,599,602,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,145,144,146,0,0,0,0,0,128,0,-1--1--1,,1|(602,582)|
+10,146,"Crops for biofuel Mt-crop/y",610,549,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,147,146,1,0,0,0,0,0,128,0,-1--1--1,,1|(668,564)|
+10,148,"Red meat from grazing land Mt-red-meat/y",1189,364,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,149,148,66,1,0,0,0,0,128,0,-1--1--1,,1|(1105,364)|
+10,150,"Traditional use of crops ex red meat Mt/y",647,429,61,32,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,151,96,170,0,0,0,0,0,128,0,-1--1--1,,1|(561,287)|
+1,152,150,1,0,0,0,0,0,128,0,-1--1--1,,1|(688,505)|
+10,153,"Desired crop supply Mt-crop/y",703,653,65,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,153,117,0,0,0,0,0,128,0,-1--1--1,,1|(675,694)|
+1,155,153,78,1,0,0,0,0,128,0,-1--1--1,,1|(803,799)|
+10,156,"Red meat supply per person kg-red-meat/p/y",877,120,76,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,148,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1038,247)|
+1,158,66,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(947,268)|
+10,159,"Perceived crop balance (1)",1185,846,48,31,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,160,78,159,1,0,0,0,0,128,0,-1--1--1,,1|(1082,846)|
+1,161,159,43,1,0,0,0,0,128,0,-1--1--1,,1|(1276,834)|
+10,162,"Crop balance (1)",839,177,48,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,163,162,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(853,155)|
+1,164,87,156,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(648,209)|
+10,165,"Traditional use of crops ex red meat per person kg-crop/p/y",389,361,84,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,166,87,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(417,317)|
+1,167,150,165,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(536,399)|
+10,168,"Traditional use of feed for red meat Mt-crop/y",745,333,64,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,148,168,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(969,348)|
+10,170,"Traditional use of crops Mt/y",588,339,55,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,171,170,150,0,0,0,0,0,128,0,-1--1--1,,1|(609,371)|
+1,172,87,170,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(501,313)|
+1,173,97,168,0,0,0,0,0,128,0,-1--1--1,,1|(766,276)|
+1,174,87,168,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(575,311)|
+1,175,98,168,0,0,0,0,0,128,0,-1--1--1,,1|(831,369)|
+1,176,168,150,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(704,372)|
+10,177,Observed warming deg C,860,1310,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,178,177,249,0,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(877,1265)|
+10,179,"Fertilizer productivity index (1980=1)",334,1047,67,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,180,"ROC in fertilizer productivity 1/y",224,966,50,50,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,181,180,179,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(280,1007)|
+1,182,179,185,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(405,1062)|
+10,183,Time,203,1053,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,184,183,179,0,0,0,0,1,64,0,255-128-192,|12||0-0-0,1|(241,1051)|
+10,185,"Fertilizer use in conv ag kgN/ha/y",478,1080,55,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,186,108,185,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(520,1035)|
+1,187,185,91,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(466,1122)|
+1,188,185,73,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(398,977)|
+1,189,185,26,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(944,1273)|
+10,190,"ROC in food sector productivity 1/y",210,460,52,52,2,131,0,3,0,0,0,0,128-0-64,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,191,190,193,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(324,454)|
+1,192,142,193,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(401,494)|
+10,193,"Food sector productivity index (1980=1)",459,449,57,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,194,193,150,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(544,439)|
+12,195,0,204,151,157,109,3,135,0,10,0,0,0,0,-1--1--1,0-0-0,|18||255-0-255,0,0,0,0,0,0
+TO SIMULATE FOOD TURNAROUND: Adjust Goals for crop waste, reg ag, and new red meat. You may want to change other pink policy handles
+10,196,"Demand for red meat Mt-red-meat/y",1078,298,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,197,46,196,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1022,262)|
+1,198,196,66,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1048,344)|
+1,199,87,196,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(739,295)|
+1,200,196,148,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1126,328)|
+10,201,Observed warming deg C,1344,526,54,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,202,201,8,0,1,0,0,0,64,0,-1--1--1,,1|(1344,507)|
+10,203,"Fertilizer cost reduction G$/y",1476,1537,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,204,"Cost of regenerative agriculture G$/y",1136,1524,65,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,205,"Extra cost of reg ag $/ha/y",932,1525,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,206,205,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1021,1524)|
+10,207,"GDP G$/y",1235,1740,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,208,"Cost of new electrification G$/y",1337,1559,65,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,209,"Cost of CCS G$/y",1337,1559,47,19,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,210,Regenerative agriculture area Mha,227,770,75,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,211,"Demand for fossil fuel for non-el use before NE Mtoe/y",1158,1464,85,28,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,212,Regenerative agriculture area Mha,1135,1459,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,213,"Cost per ton fertilizer $/t",1553,1467,41,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,214,213,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1519,1497)|
+1,215,204,224,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1198,1551)|
+1,216,212,204,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1135,1484)|
+1,217,203,224,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1388,1556)|
+10,218,"Cost index for Regenerative agriculture (1)",736,1463,76,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,219,"Cost reduction per doubling in Regenerative agriculture (1)",601,1570,89,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,220,219,218,0,0,0,0,0,128,0,-1--1--1,,1|(662,1521)|
+1,221,218,205,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(873,1496)|
+10,222,"Extra cost of reg ag in 2022 $/ha/y",940,1458,70,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,223,222,205,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(936,1484)|
+10,224,"Extra cost of Food Turnaround G$/y",1275,1584,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,225,"Extra cost of Food Turnaround as share of GDP (1)",1414,1663,73,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,226,224,225,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1329,1615)|
+1,227,207,225,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1297,1712)|
+10,228,"Amount of fertilizer saved in reg ag kgN/ha/y",1398,1466,79,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,229,228,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1431,1496)|
+1,230,212,203,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1309,1498)|
+1,231,112,228,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1349,1394)|
+10,232,"Crop use Mt/y",1000,993,51,11,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,233,75,232,1,0,0,0,0,128,0,-1--1--1,,1|(1045,1065)|
+1,234,2,19,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1862,882)|
+10,235,FFLReoOGRR,1519,643,50,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,236,235,27,1,0,0,0,0,128,0,-1--1--1,,1|(1593,615)|
+10,237,"sFFLReoOGRR<0",1371,647,62,9,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,238,237,235,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1444,645)|
+10,239,"Fraction forestry land remaining (1)",1408,798,68,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,240,2,239,1,0,0,0,0,128,0,-1--1--1,,1|(1549,781)|
+1,241,239,235,1,0,0,0,0,128,0,-1--1--1,,1|(1431,702)|
+10,242,"OGRR in 1980 1/y",1648,527,49,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,243,242,27,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1662,553)|
+10,244,"Threshold FFLR (1)",1326,716,48,27,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,245,244,235,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1424,678)|
+10,246,"CO2 release per ha of forest cut tCO2/ha",1773,485,59,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,247,"CO2 absorption in forestry land GtCO2/y",1979,484,57,35,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,248,"CO2 absorption in forestry land tCO2/ha/y",2074,578,58,37,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,249,"Warming effect on land yield (1)",901,1209,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,250,"CO2 effect on land yield (1)",1004,1171,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,251,"sCO2CeoACY>0",1140,1206,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,252,249,72,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(893,1155)|
+1,253,250,72,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(949,1133)|
+10,254,"sOWeoACY<0",991,1270,51,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,255,254,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(957,1247)|
+1,256,251,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1088,1192)|
+10,257,Time,1004,1237,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,258,257,250,0,0,0,0,3,64,0,255-128-0,|12||0-0-0,1|(1004,1215)|
+1,259,257,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(975,1229)|
+1,260,137,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1087,1218)|
+10,261,"Cost of food G$/y",1096,1654,58,11,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,262,"Agriculture as fraction of GDP (1)",1106,1738,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,263,262,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1101,1698)|
+1,264,207,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1171,1700)|
+10,265,"Cost of fertilizer G$/y",931,1657,51,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,266,"Fertilizer use Mt/y",875,1606,45,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,267,266,265,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(897,1626)|
+1,268,213,265,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1254,1557)|
+1,269,204,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1117,1586)|
+1,270,265,261,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1003,1656)|
+10,271,"Extra CO2 absorption in reg ag GtCO2/y",128,846,77,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,272,"CO2 absorbed in reg ag tCO2/ha/y",121,715,68,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,273,122,210,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(401,779)|
+1,274,114,210,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(278,723)|
+1,275,210,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(183,803)|
+1,276,272,271,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(123,773)|
+10,277,"CO2 emissions from LULUC GtCO2/y",1826,267,66,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,278,35,48,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1855,553)|
+1,279,248,247,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2030,534)|
+1,280,246,48,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1814,445)|
+1,281,2,247,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2013,700)|
+1,282,19,48,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1936,761)|
+1,283,48,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1843,343)|
+1,284,247,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1901,373)|
+10,285,"Extra CO2 absorption in reg ag GtCO2/y",1987,336,76,19,8,2,0,1,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,286,285,277,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1912,305)|
+10,287,"Loss of forest land Mha/y",1765,1308,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,288,"Loss of cropland Mha/y",1936,1302,54,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,289,35,287,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1767,971)|
+1,290,19,287,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1807,1102)|
+1,291,14,288,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1883,1175)|
+1,292,23,288,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1911,1153)|
+10,293,CO2 concentration in 2022 ppm,1136,1333,69,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,294,293,250,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(1070,1252)|
+10,295,Observed warming in 2022 deg C,993,1325,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,296,295,249,0,0,0,0,3,128,0,255-128-0,|12||0-0-0,1|(951,1272)|
+1,297,34,39,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1653,689)|
+1,298,34,33,0,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1571,679)|
+10,299,"Acceptable loss of forestry land (1)",1560,934,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,300,59,239,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1524,824)|
+1,301,299,18,1,0,0,0,0,128,0,-1--1--1,,1|(1678,931)|
+1,302,244,299,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1441,824)|
+1,303,239,299,1,0,0,0,0,128,0,-1--1--1,,1|(1439,873)|
+10,304,Total forest area Mha,2054,827,59,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,305,29,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1908,773)|
+1,306,2,304,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1902,838)|
+10,307,"Land erosion rate 1/y",1619,1161,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,308,"Land erosion rate in 1980 1/y",1460,1131,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,309,308,307,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1543,1146)|
+1,310,307,13,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1716,1113)|
+1,311,26,307,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1548,1193)|
+10,312,"sFBeoCLE<0",2131,335,54,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,313,"SSP2 land management action from 2022? (1)",2443,843,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,314,"Land erosion multiplier (1)",2215,948,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,315,313,314,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2335,892)|
+10,316,"Old growth removal rate multiplier (1)",2194,789,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,317,313,316,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2319,816)|
+10,318,"Cropland expansion multiplier (1)",2211,874,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,319,313,318,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2328,858)|
+10,320,"Forest absorption multipler (1)",2187,711,57,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,321,313,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2321,780)|
+10,322,"Max forest absorption multiplier (1)",2360,701,53,33,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||128-0-64,0,0,0,0,0,0
+1,323,322,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2282,705)|
+1,324,316,35,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(1983,719)|
+1,325,318,18,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1976,893)|
+1,326,314,307,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1923,1051)|
+1,327,320,248,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2142,658)|
+10,328,Time,2308,969,29,16,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,329,"SSP2 land management action from 2022? (1)",2132,52,80,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,330,328,320,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2251,847)|
+1,331,328,316,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2255,886)|
+1,332,328,318,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2266,927)|
+1,333,328,314,0,0,0,0,1,128,0,128-0-64,|12||0-0-0,1|(2274,961)|
+1,334,232,78,1,0,0,0,0,128,0,-1--1--1,,1|(977,942)|
+10,335,"Warming effect on land yield (1)",1627,366,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+10,336,"CO2 effect on land yield (1)",1635,420,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,337,232,107,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(939,968)|
+10,338,Population Mp,774,827,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,339,338,107,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(802,869)|
+10,340,"FOOD FOOTPRINT INDEX (1980=1)",949,615,74,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,341,"Fertilizer use in 1980 Mt/y",430,909,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-128-0,0,0,0,0,0,0
+1,342,341,347,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(721,808)|
+1,343,73,346,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(597,784)|
+1,344,4,346,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1326,842)|
+1,345,63,347,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1341,848)|
+10,346,Food footprint,880,695,46,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,347,Food footprint in 1980,1027,704,48,24,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,348,346,340,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(905,664)|
+1,349,347,340,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(990,662)|
+10,350,"Crop waste reduction (1)",1143,973,42,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,351,"Goal for crop waste reduction (1)",1289,959,51,51,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,352,351,350,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1218,964)|
+1,353,350,232,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1082,980)|
+10,354,"Fraction new red meat (1)",1253,226,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,355,"Goal for fraction new red meat (1)",1398,168,53,53,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,356,355,354,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1330,195)|
+1,357,354,196,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1171,260)|
+10,358,"Goal for fraction regenerative agriculture (1)",274,579,57,57,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,359,358,114,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(300,642)|
+10,360,Regenerative agriculture area Mha,286,1465,70,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,361,"Number of doublings in reg ag (1)",509,1469,67,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,362,360,361,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(392,1466)|
+10,363,Experience gained before 2022 Mha,331,1553,58,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,364,363,361,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(413,1513)|
+1,365,361,218,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(611,1466)|
+10,366,Normal reform delay y,1180,644,53,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,367,"Fertilizer use per person kg/p/y",732,878,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,368,73,367,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(514,874)|
+1,369,338,367,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(760,843)|
+1,370,335,70,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1473,459)|
+1,371,336,70,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1477,487)|
+1,372,335,247,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1795,422)|
+1,373,336,247,0,0,0,0,1,128,0,255-128-0,|12||0-0-0,1|(1804,451)|
+10,374,Introduction period for policy y,1200,1045,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,375,374,350,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1175,1014)|
+10,376,Introduction period for policy y,1340,279,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,377,376,354,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1302,257)|
+10,378,Introduction period for policy y,168,650,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,379,378,114,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(236,665)|
+10,380,"Extra ROC in food sector productivity from 2022 1/y",134,366,85,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-0-128,0,0,0,0,0,0
+1,381,380,193,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(298,407)|
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Wellbeing - trust and tension
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Average wellbeing perception delay y,1054,-147,53,30,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,2,"Average wellbeing from global warming (1)",804,265,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,3,"sGWeoAW<0",747,332,47,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,4,3,2,1,0,0,0,0,128,0,-1--1--1,,1|(760,308)|
+10,5,"Average wellbeing from disposable income (1)",435,-37,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,6,"AVERAGE WELLBEING INDEX (1)",682,-110,74,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,7,5,6,1,0,0,0,0,128,0,-1--1--1,,1|(550,-84)|
+10,8,"Past AWI (1)",1041,-210,40,23,3,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,9,1,8,0,0,0,0,0,128,0,-1--1--1,,1|(1048,-175)|
+10,10,"Observed rate of progress 1/y",1172,-56,47,38,3,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,11,6,8,1,0,0,0,0,128,0,-1--1--1,,1|(856,-209)|
+1,12,8,10,1,0,0,0,0,128,0,-1--1--1,,1|(1144,-163)|
+1,13,6,10,1,0,0,0,0,128,0,-1--1--1,,1|(922,-132)|
+1,14,1,10,0,0,0,0,0,128,0,-1--1--1,,1|(1102,-108)|
+10,15,Perceived warming deg C,987,319,54,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,16,15,2,0,0,0,0,0,128,0,-1--1--1,,1|(907,296)|
+12,17,0,1854,-19,351,309,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Material_and_social_cond
+12,18,0,1844,600,339,301,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Average_Wellbeing_Index
+10,19,"Average wellbeing from inequality (1)",629,270,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,20,"sIIeoAW<0",668,370,39,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,21,20,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(652,330)|
+10,22,"Worker disposable income k$/p/y",232,-23,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,23,22,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(322,-28)|
+10,24,"Inequality (1)",449,335,44,25,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,25,24,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(527,306)|
+10,26,"Threshold disposable income k$/p/y",257,60,68,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,27,26,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(339,14)|
+10,28,"Diminishing return disposable income (1)",438,46,52,33,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,29,28,5,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(436,4)|
+10,30,"Average wellbeing from public spending (1)",507,125,75,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,31,"Threshold public spending k$/p/y",345,223,53,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,32,"Diminishing return public spending (1)",509,207,49,38,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,33,"Public spending per person k$/p/y",246,161,67,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,34,33,30,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(365,144)|
+1,35,31,30,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(421,168)|
+1,36,32,30,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(508,163)|
+1,37,30,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(582,11)|
+1,38,19,6,1,0,0,0,0,64,0,-1--1--1,,1|(637,89)|
+10,39,"Threshold inequality (1)",564,358,42,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,40,39,19,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(591,319)|
+10,41,Threshold warming deg C,921,364,49,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,42,41,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(867,318)|
+10,43,"Average wellbeing from progress (1)",950,190,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,44,43,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(797,96)|
+10,45,"Threshold progress rate 1/y",1079,146,51,25,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,46,10,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1169,115)|
+1,47,45,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1023,164)|
+10,48,"sROPeoAW>0",1065,262,50,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,49,48,43,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1019,233)|
+10,50,"AWI in 1980 (1)",923,-257,54,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,51,50,8,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(969,-238)|
+10,52,"Social tension (1)",1272,333,55,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,53,10,52,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1295,234)|
+10,54,"Acceptable progress 1/y",1222,239,40,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,55,54,52,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1245,283)|
+1,56,2,6,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(700,91)|
+10,57,"Min wellbeing from global warming (1)",791,394,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,58,57,2,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(796,336)|
+10,59,"Indicated social trust (1)",854,522,50,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,60,"GDP per person k$/p/y",188,333,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,61,Public spending as share of GDP,340,393,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,62,33,61,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(289,270)|
+1,63,60,61,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(257,360)|
+10,64,"Satisfactory public spending (1)",297,454,59,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,65,61,67,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(403,447)|
+1,66,64,67,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(379,479)|
+10,67,"Public spending effect on social trust (1)",478,511,69,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,68,"Inequity effect on social trust (1)",662,474,55,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,69,24,68,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(553,403)|
+10,70,"Acceptable inequality (1)",502,437,42,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,71,70,68,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(568,451)|
+1,72,68,59,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(770,518)|
+1,73,67,59,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(609,534)|
+10,74,"Social trust (1)",1046,489,40,20,3,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,75,59,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(948,505)|
+10,76,Time to establish social trust y,946,437,54,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,77,76,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(988,459)|
+10,78,Normal reform delay y,1171,439,48,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,79,"Social trust in 1980 (1)",985,569,43,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,80,79,74,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1010,535)|
+10,81,"Social trust effect on reform delay (1)",1187,522,65,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,82,"Social tension effect on reform delay (1)",1301,431,73,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,83,74,81,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1118,507)|
+1,84,52,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1283,371)|
+1,85,82,97,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1336,489)|
+1,86,81,97,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1267,544)|
+1,87,78,97,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1260,496)|
+10,88,"Social tension in 1980 (1)",1412,319,52,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,89,79,81,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1068,549)|
+10,90,"sSTReoRD<0",1149,591,46,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,91,90,81,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1162,567)|
+1,92,88,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1361,370)|
+10,93,"sSTEeoRD>0",1450,474,45,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,94,93,82,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1395,458)|
+10,95,"sPPReoSTE<0",1154,287,49,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,96,95,52,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1205,307)|
+10,97,Indicated reform delay y,1362,562,53,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,98,97,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1372,598)|
+10,99,Time to change reform delay y,1227,642,49,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,100,99,109,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1304,645)|
+10,101,"Wellbeing effect of participation (1)",998,79,60,19,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,102,"Labour participation rate (1)",918,-20,45,28,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,103,"Threshold participation (1)",1026,-30,51,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,104,"sLPeoAWP>0",1105,30,48,11,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,105,104,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1066,47)|
+1,106,103,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1013,17)|
+1,107,102,101,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(956,28)|
+1,108,101,43,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(995,134)|
+10,109,Reform delay y,1387,649,40,20,3,3,0,3,0,0,0,0,255-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,110,109,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1375,690)|
+10,111,Exogenous introduction period y,1136,715,66,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,112,111,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1243,728)|
+10,113,"Exogenous introduction period?",1132,769,64,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,114,113,115,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1240,757)|
+10,115,Introduction period for policy y,1360,745,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+\\\---/// Sketch information - do not modify anything except names
+V300  Do not put anything below this section - it will be ignored
+*Energy
+$192-192-192,0,Times New Roman|12||0-0-0|0-0-0|0-0-255|-1--1--1|-1--1--1|96,96,75,0
+10,1,Fossil electricity capacity GW,1062,859,47,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,2,Renewable electricity capacity GW,1726,870,52,45,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,3,48,1064,735,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,4,6,1,4,0,0,22,0,0,0,-1--1--1,,1|(1063,805)|
+1,5,6,3,100,0,0,22,0,0,0,-1--1--1,,1|(1063,758)|
+11,6,48,1063,780,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,7,"Addition of fossil el capacity GW/y",1129,780,61,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,8,48,907,861,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,9,11,8,4,0,0,22,0,0,0,-1--1--1,,1|(934,866)|
+1,10,11,1,100,0,0,22,0,0,0,-1--1--1,,1|(989,866)|
+11,11,48,958,866,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,12,"Discard of fossil el capacity GW/y",958,909,51,35,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+12,13,48,1726,729,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,14,16,2,4,0,0,22,0,0,0,-1--1--1,,1|(1730,795)|
+1,15,16,13,100,0,0,22,0,0,0,-1--1--1,,1|(1730,745)|
+11,16,48,1730,759,8,6,33,3,0,0,4,0,0,0,0,0,0,0,0,0
+10,17,"Addition of renewable el capacity GW/y",1809,759,71,19,40,3,0,0,-1,0,0,0,0,0,0,0,0,0
+12,18,48,1909,874,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,19,21,18,4,0,0,22,0,0,0,-1--1--1,,1|(1876,872)|
+1,20,21,2,100,0,0,22,0,0,0,-1--1--1,,1|(1810,872)|
+11,21,48,1848,872,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,22,"Discard of renewable el capacity GW/y",1848,909,68,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,23,1,11,1,0,0,0,0,128,0,-1--1--1,,1|(1001,843)|
+10,24,Life of fossil el capacity y,1018,985,46,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,25,24,12,1,0,0,0,0,128,0,-1--1--1,,1|(1021,929)|
+1,26,2,21,1,0,0,0,0,128,0,-1--1--1,,1|(1814,847)|
+10,27,Life of renewable el capacity y,1868,987,63,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,28,27,22,0,0,0,0,0,128,0,-1--1--1,,1|(1860,954)|
+10,29,Population Mp,789,245,51,19,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,30,"GDP per person k$/p/y",583,118,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,31,"Traditional per person use of electricity before EE MWh/p/y",813,120,91,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,32,"Traditional per person use of fossil fuels for non-el-use before EE toe/p/y",585,203,91,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,33,"Demand for electricity before NE TWh/y",962,297,70,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,34,"Demand for fossil fuel for non-el use before NE Mtoe/y",707,338,80,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,35,30,31,1,0,0,0,0,128,0,-1--1--1,,1|(672,105)|
+1,36,30,32,1,0,0,0,0,128,0,-1--1--1,,1|(568,148)|
+1,37,29,33,0,0,0,0,0,128,0,-1--1--1,,1|(862,267)|
+1,38,29,34,0,0,0,0,0,128,0,-1--1--1,,1|(756,282)|
+1,39,32,34,0,0,0,0,0,128,0,-1--1--1,,1|(640,266)|
+1,40,31,33,1,0,0,0,0,128,0,-1--1--1,,1|(914,198)|
+10,41,"Extra ROC in energy productivity after 2022 1/y",1155,128,54,54,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||128-0-64,0,0,0,0,0,0
+10,42,"Extra energy productivity index 2022=1",987,198,57,34,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,43,48,1161,206,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,44,46,42,4,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1068,204)|
+1,45,46,43,100,0,0,22,2,0,0,-1--1--1,|12||0-0-0,1|(1127,204)|
+11,46,48,1098,204,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,47,"Increase in extra energy productivity index 1/y",1098,245,75,19,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,48,42,46,1,0,0,0,0,128,0,-1--1--1,,1|(1030,144)|
+1,49,41,46,0,0,0,0,3,128,0,128-0-64,|12||0-0-0,1|(1116,180)|
+1,50,42,33,0,0,0,0,0,128,0,-1--1--1,,1|(974,249)|
+1,51,42,34,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(852,265)|
+10,52,"4 TWh-el per Mtoe",829,1270,44,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,53,"Electricity balance (1)",1297,708,36,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,54,11,135,1,0,0,0,0,128,0,-1--1--1,,1|(983,743)|
+10,55,"Renewable capacity up-time kh/y",1554,805,55,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,56,"Electricity production TWh/y",1298,941,63,19,8,131,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,57,"Renewable electricity production TWh/y",1609,1014,56,36,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,58,2,57,1,0,0,0,0,128,0,-1--1--1,,1|(1645,934)|
+10,59,"Fossil electricity production TWh/y",1177,1012,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,60,"Nuclear electricity production TWh/y",1433,900,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,61,"Biomass energy Mtoe/y",1605,1317,44,44,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,62,59,56,1,0,0,0,0,128,0,-1--1--1,,1|(1258,984)|
+10,63,"Nuclear capacity up-time kh/y",1490,1002,54,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,64,Nuclear capacity GW,1398,1038,41,41,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,65,63,60,0,0,0,0,0,128,0,-1--1--1,,1|(1465,957)|
+1,66,64,60,1,0,0,0,0,128,0,-1--1--1,,1|(1433,951)|
+1,67,1,59,1,0,0,0,0,128,0,-1--1--1,,1|(1075,922)|
+1,68,60,56,1,0,0,0,0,128,0,-1--1--1,,1|(1353,979)|
+1,69,57,56,1,0,0,0,0,128,0,-1--1--1,,1|(1388,1095)|
+1,70,56,53,1,0,0,0,0,128,0,-1--1--1,,1|(1336,843)|
+10,71,"Desired supply of renewable electricity TWh/y",1434,477,65,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,72,"Fossil capacity up-time kh/y",809,805,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,73,72,59,1,0,0,0,0,128,0,-1--1--1,,1|(871,1036)|
+10,74,"CAPEX renewable el G$/y",2109,669,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,75,"OPEX renewable el G$/y",2071,865,66,20,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,76,"OPEX renewable el $/kWh",2041,1001,68,18,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,77,17,74,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1952,715)|
+1,78,7,205,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1703,722)|
+10,79,"Fraction new electrification in 2022 (1)",173,406,68,28,8,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,80,"Demand for fossil fuel for non-el use Mtoe/y",765,578,69,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,81,"Demand for electricity TWh/y",981,365,55,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,82,34,80,1,0,0,0,0,128,0,-1--1--1,,1|(745,393)|
+1,83,33,81,0,0,0,0,0,128,0,-1--1--1,,1|(969,325)|
+10,84,"Extra energy productivity index in 2022 (1)",989,104,64,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,85,84,42,0,0,0,0,0,128,1,-1--1--1,,1|(988,142)|
+1,86,81,99,1,0,0,0,0,128,0,-1--1--1,,1|(992,391)|
+1,87,52,90,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(783,1190)|
+10,88,Fossil el capacity in 1980 GW,1180,913,54,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,89,88,1,0,0,0,0,0,128,1,-1--1--1,,1|(1123,887)|
+10,90,"Fossil fuels for electricity Mtoe/y",731,1098,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,91,90,131,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(658,997)|
+10,92,tCO2 per toe,533,875,43,11,8,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,93,"CAPEX fossil el $/W",2279,581,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,94,"CAPEX renewable el $/W",2111,577,62,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,95,93,205,0,0,0,0,0,128,0,-1--1--1,,1|(2280,616)|
+1,96,94,74,0,0,0,0,0,128,0,-1--1--1,,1|(2110,617)|
+1,97,57,75,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1829,942)|
+1,98,76,75,1,0,0,0,0,128,0,-1--1--1,,1|(2022,934)|
+10,99,"Demand for fossil electricity TWh/y",997,500,56,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+12,100,0,1341,90,121,27,8,7,0,10,-1,0,0,0,-1--1--1,0-0-0,|18||0-0-255,0,0,0,0,0,0
+EE=Energy efficiency NE=New electrification
+1,101,57,114,1,0,0,0,0,128,0,-1--1--1,,1|(1496,814)|
+1,102,81,53,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1103,466)|
+1,103,99,72,1,0,0,0,0,128,0,-1--1--1,,1|(832,641)|
+1,104,59,90,1,0,0,0,0,128,0,-1--1--1,,1|(958,1140)|
+10,105,"CAPEX renewable el in 1980 $/W",2030,496,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,106,105,94,0,0,0,0,0,128,0,-1--1--1,,1|(2065,532)|
+1,107,1,72,1,0,0,0,0,128,0,-1--1--1,,1|(922,768)|
+10,108,Renewable el capacity in 1980 GW,1720,963,69,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,109,108,2,0,0,0,0,0,128,1,-1--1--1,,1|(1721,936)|
+10,110,Time,1475,1075,26,11,8,2,0,3,-1,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,111,"Renewable el fraction in 1980 (1)",1788,373,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,112,81,71,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1179,349)|
+1,113,1,135,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1032,765)|
+10,114,"Low-carbon el production TWh/y",1432,753,62,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,115,114,99,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1341,579)|
+1,116,60,114,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1444,833)|
+10,117,"Fraction new electrification in 1980 (1)",182,501,68,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,118,"Renewable el fraction in 2022 (1)",1789,309,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,119,"OPEX fossil el $/kWh",2186,1000,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,120,59,123,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1669,965)|
+10,121,"Cost of fossil electricity G$/y",2273,750,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,122,"Cost of electricity G$/y",2357,1072,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,123,"OPEX fossil el G$/y",2163,918,47,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,124,"Normal increase in energy efficiency 1/y",756,191,59,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,125,124,33,0,0,0,0,0,128,0,-1--1--1,,1|(863,247)|
+1,126,124,34,0,0,0,0,0,128,0,-1--1--1,,1|(732,261)|
+10,127,Time,839,305,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,128,127,34,0,0,0,0,0,64,0,-1--1--1,,1|(806,313)|
+10,129,"CO2 from energy and industry GtCO2/y",377,1050,70,19,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,130,80,131,1,0,0,0,0,128,0,-1--1--1,,1|(744,750)|
+10,131,"Use of fossil fuels Mtoe/y",638,916,56,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,132,92,319,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(517,918)|
+10,133,"Fraction fossil plus nuclear electricity (1)",1253,451,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,134,56,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1276,702)|
+10,135,"Desired fossil el capacity change GW/y",1168,684,72,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,136,135,7,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1172,749)|
+10,137,Fossil el cap construction time y,1214,604,60,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,138,137,135,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1194,638)|
+10,139,"8 khours per year",928,682,47,22,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,140,Normal life of fossil el capacity y,1017,1046,62,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,141,"FCUTeoLOFC (1)",867,976,51,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,142,"sFCUTeoLOFC>0",779,901,63,9,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,143,141,24,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(918,1010)|
+1,144,140,24,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1017,1022)|
+1,145,72,141,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(825,894)|
+1,146,139,153,1,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(998,635)|
+1,147,139,141,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(898,823)|
+1,148,142,141,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(811,928)|
+1,149,55,57,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1578,898)|
+10,150,Renewable el construction time y,1905,818,51,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,151,150,17,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1852,786)|
+1,152,21,17,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1833,829)|
+10,153,Desired fossil el capacity GW,1077,585,50,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,154,99,153,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1031,538)|
+1,155,153,135,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1117,630)|
+10,156,Desired renewable el capacity change GW,1649,669,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,157,71,160,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1479,523)|
+1,158,2,156,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1660,754)|
+1,159,156,17,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1763,695)|
+10,160,Desired renewable el capacity GW,1527,568,67,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,161,160,156,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1582,615)|
+1,162,55,160,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1540,689)|
+1,163,131,319,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(578,948)|
+1,164,59,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1213,738)|
+10,165,"Extra use of electricity per reduced use of non-el FF MWh/toe",494,333,83,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,166,127,33,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(871,304)|
+10,167,"Extra increase in demand for electricity from NE TWh/y",853,434,80,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,168,"Extra reduction in demand for non-el fossil fuel from NE Mtoe/y",642,503,92,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,169,168,80,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(688,554)|
+1,170,168,167,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(743,471)|
+1,171,167,81,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(918,399)|
+1,172,165,167,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(668,383)|
+1,173,34,168,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(649,422)|
+10,174,"Cost index for sun and wind capacity (1)",2253,488,72,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,175,"Cost reduction per doubling of sun and wind capacity (1)",2044,426,68,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,176,"Number of doublings in sun and wind capacity (1)",2327,412,71,30,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,177,Accumulated sun and wind capacity from 1980 GW,2185,259,67,43,3,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,178,Sun and wind capacity in 1980 GW,2189,344,69,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,179,176,174,1,0,0,0,0,128,0,-1--1--1,,1|(2306,461)|
+1,180,178,176,0,0,0,0,0,128,0,-1--1--1,,1|(2240,370)|
+1,181,178,177,0,0,0,0,0,128,1,-1--1--1,,1|(2188,321)|
+1,182,177,176,1,0,0,0,0,128,0,-1--1--1,,1|(2356,320)|
+12,183,48,1984,265,10,8,0,3,0,0,-1,0,0,0,0,0,0,0,0,0
+1,184,186,177,4,0,0,22,0,0,0,-1--1--1,,1|(2088,269)|
+1,185,186,183,100,0,0,22,0,0,0,-1--1--1,,1|(2020,269)|
+11,186,48,2052,269,6,8,34,3,0,0,1,0,0,0,0,0,0,0,0,0
+10,187,"Addition of sun and wind capacity GW/y",2052,310,58,33,40,131,0,0,-1,0,0,0,0,0,0,0,0,0
+1,188,175,174,0,0,0,0,0,128,0,-1--1--1,,1|(2143,456)|
+1,189,17,187,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1784,548)|
+10,190,Cropland Mha,2435,1063,56,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,191,Cropland Mha,2112,1110,56,11,8,2,1,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,192,174,94,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(2219,538)|
+10,193,"Cost of fossil fuel for non-el use G$/y",2113,1148,57,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,194,"GDP G$/y",2653,1283,44,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,195,"Cost of energy G$/y",2341,1176,47,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+10,196,"Cost of energy as share of GDP (1)",2531,1182,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,197,194,196,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2601,1240)|
+1,198,60,133,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1345,681)|
+10,199,"Extra cost per reduced use of non-el FF $/toe",517,585,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,200,"Cost of new electrification G$/y",568,661,60,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-128-0,0,0,0,0,0,0
+1,201,199,200,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(538,618)|
+1,202,168,200,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(605,581)|
+10,203,"Cost of new electrification G$/y",2236,1076,62,27,8,130,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,204,203,195,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2287,1125)|
+10,205,"CAPEX fossil el G$/y",2283,664,53,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,206,"Cost of renewable electricity G$/y",2103,752,59,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,207,"Cost of CCS $/tCO2",407,732,43,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,208,"Cost of CCS G$/y",401,794,59,11,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,209,"Goal for fraction of CO2-sources with CCS (1)",222,810,61,61,2,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,210,"Fraction of CO2-sources with CCS in 2022 (1)",128,926,67,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,211,207,208,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(404,760)|
+10,212,"Cost of CCS G$/y",2119,1090,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,213,212,195,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2223,1129)|
+10,214,"MEMO Fraction of non-el fossil fuels use in hard to abate sectors HTAS (1)",252,606,103,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+10,215,"Renewable heat production Mtoe/y",1326,1287,60,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,216,61,215,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1476,1337)|
+10,217,"Green hydrogen Mtoe/y",1463,1283,52,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,218,217,215,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1405,1293)|
+10,219,"Fraction of renewable electricity to hydrogen (1)",1663,1169,55,55,2,131,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,220,"kWh-el per kgH2",1497,1185,56,11,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,221,toe per tH2,1396,1232,37,11,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+10,222,"Green hydrogen MtH2/y",1541,1238,52,19,8,3,0,3,0,0,0,0,255-0-255,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,223,57,222,1,0,0,0,1,128,0,255-128-192,|12||0-0-0,1|(1607,1101)|
+1,224,222,217,1,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1527,1269)|
+1,225,221,217,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1418,1249)|
+1,226,220,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1511,1202)|
+1,227,219,222,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1601,1204)|
+1,228,119,123,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2176,965)|
+1,229,75,206,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2070,805)|
+1,230,74,206,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2106,703)|
+1,231,123,121,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2188,829)|
+1,232,205,121,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2278,700)|
+1,233,206,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2252,879)|
+1,234,121,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2334,889)|
+1,235,122,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2350,1117)|
+1,236,193,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2225,1161)|
+1,237,195,196,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2424,1178)|
+10,238,"Cost of nuclear electricity G$/y",2406,890,47,33,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,239,238,122,1,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2408,980)|
+1,240,60,238,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1918,895)|
+10,241,"Cost of nuclear el $/kWh",2376,808,56,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,242,241,238,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2385,835)|
+10,243,"Traditional cost of energy G$/y",2330,1394,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,244,"Demand for electricity before NE TWh/y",1801,1341,75,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,245,"Demand for fossil fuel for non-el use before NE Mtoe/y",1784,1277,85,28,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,246,"Traditional cost of electricity $/kWh",1808,1411,58,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+10,247,"Traditional cost of fossil fuel for non-el use $/toe",1804,1188,75,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,248,246,255,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1880,1400)|
+1,249,247,256,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1875,1221)|
+1,250,244,255,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1879,1364)|
+1,251,245,256,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1887,1272)|
+1,252,247,193,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(1960,1167)|
+10,253,"Demand for fossil fuel for non-el use Mtoe/y",1898,1119,74,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,254,253,193,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2007,1133)|
+10,255,"Traditional cost of electricity G$/y",1961,1389,52,28,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,256,"Traditional cost of fossil fuel for non-el use G$/y",1977,1268,58,29,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,257,256,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2148,1329)|
+1,258,255,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2135,1390)|
+10,259,"Cost of grid G$/y",2205,1211,50,19,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+10,260,"Transmission cost $/kWh",2109,1248,45,27,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,261,260,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2149,1235)|
+1,262,259,195,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2267,1195)|
+10,263,"Electricity production TWh/y",2048,1195,64,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,264,263,259,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2126,1202)|
+1,265,260,269,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(2151,1277)|
+10,266,"Traditional cost of energy as share of GDP (1)",2530,1388,81,25,8,131,0,0,0,0,0,0,0,0,0,0,0,0
+1,267,243,266,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2411,1391)|
+1,268,194,266,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(2605,1323)|
+10,269,"Traditional grid cost G$/y",2196,1307,48,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,270,244,269,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2005,1323)|
+1,271,269,243,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2256,1346)|
+10,272,"Adjustment factor to make costs match 1980-2022 (1)",2167,1429,88,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||0-255-0,0,0,0,0,0,0
+1,273,272,256,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(2083,1358)|
+1,274,272,255,0,0,0,0,3,128,0,0-255-0,|12||0-0-0,1|(2052,1406)|
+10,275,"Ratio of Energy cost to Trad energy cost (1)",2340,1267,73,19,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,276,243,275,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2333,1337)|
+1,277,195,275,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(2340,1214)|
+10,278,"Extra cost of Energy Turnaround as share of GDP (1)",2518,1277,73,28,8,3,0,0,0,0,0,0,0,0,0,0,0,0
+1,279,243,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2410,1343)|
+1,280,194,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2606,1281)|
+1,281,195,278,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2414,1218)|
+10,282,Time,2520,1338,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,283,282,278,0,0,0,0,0,64,0,-1--1--1,,1|(2519,1322)|
+10,284,"ENERGY USE Mtoe/y",1179,1123,53,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+1,285,80,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(967,844)|
+1,286,56,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1242,1026)|
+1,287,52,284,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(996,1199)|
+12,288,0,2850,531,366,330,3,188,0,0,1,0,0,0,0,0,0,0,0,0
+Energy
+10,289,"IIASA Renewable energy production EJ/yr",1163,1211,71,29,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,290,"Mtoe per EJ - calorific equivalent",702,1344,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,291,"TWh-heat per EJ - calorific equivalent",963,1354,61,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,292,"IIASA Fossil energy production EJ/yr",598,1226,62,35,8,131,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,293,290,292,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(661,1298)|
+10,294,"TWh-el per EJ - engineering equivalent",1071,1279,69,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,295,291,294,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1010,1320)|
+10,296,"Efficiency of fossil power plant TWh-el/TWh-heat",1149,1352,80,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,297,296,294,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1115,1320)|
+1,298,294,289,0,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(1103,1254)|
+1,299,131,292,1,0,0,0,3,128,0,192-192-192,|12||0-0-0,1|(582,1105)|
+1,300,57,289,1,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1416,1188)|
+1,301,290,52,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(758,1310)|
+1,302,294,52,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(944,1274)|
+1,303,215,284,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1257,1210)|
+1,304,215,289,0,0,0,0,3,128,0,0-0-255,|12||0-0-0,1|(1261,1256)|
+1,305,290,289,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(919,1280)|
+10,306,Time,502,824,26,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,307,306,92,0,0,0,0,1,64,0,192-192-192,|12||0-0-0,1|(513,843)|
+10,308,"ROC in tCO2 per toe 1/y",580,804,58,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,309,308,92,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(557,837)|
+10,310,"CO2 from non-fossil industrial processes GtCO2/y",299,1173,66,28,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,311,"GDP per person k$/p/y",252,1345,58,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+10,312,"Non-fossil CO2 per person tCO2/p/y",275,1257,65,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,313,Population Mp,134,1189,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,314,313,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(204,1182)|
+1,315,312,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(283,1226)|
+1,316,311,312,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(261,1307)|
+10,317,"Max non-fossil CO2 per person tCO2/p/y",451,1266,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,318,317,312,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(368,1261)|
+10,319,"CO2 from energy production GtCO2/y",495,983,67,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,320,"CO2 emissions per person tCO2/y",482,1125,67,19,8,3,0,18,0,0,0,0,-1--1--1,0-0-0,|12|B|0-128-0,0,0,0,0,0,0
+10,321,Population Mp,746,1200,56,11,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,322,321,320,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(634,1168)|
+1,323,129,320,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(423,1083)|
+1,324,319,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(442,1013)|
+1,325,310,129,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(336,1112)|
+10,326,"Desired renewable electricity share (1)",1595,387,61,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,327,"Goal for renewable el fraction (1)",1621,276,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,328,327,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1605,344)|
+1,329,118,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1698,346)|
+1,330,111,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1694,380)|
+1,331,326,71,0,0,0,0,3,128,0,255-0-255,|12||0-0-0,1|(1529,425)|
+12,332,0,278,156,154,90,3,135,0,10,-1,0,0,0,-1--1--1,0-0-0,|16||255-0-255,0,0,0,0,0,0
+TO SIMULATE ENERGY TURNAROUND: Adjust goals for renewable el fraction, new electrification, other point sources with CCS. You may want to also change other pink policy handles
+10,333,"Fraction new electrification (1)",401,464,54,19,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+10,334,"Goal for fraction new electrification (1)",303,346,58,58,2,131,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,335,334,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(358,413)|
+1,336,117,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(291,484)|
+1,337,79,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(287,436)|
+1,338,333,168,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(495,480)|
+10,339,"Energy use per person toe/p/y",909,1174,48,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12||255-0-0,0,0,0,0,0,0
+1,340,321,339,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(824,1187)|
+1,341,284,339,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(1048,1147)|
+1,342,110,64,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1449,1062)|
+10,343,"Fraction of CO2-sources with CCS (1)",258,989,59,28,8,3,0,2,0,0,0,0,0-0-0,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,344,210,343,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(187,955)|
+1,345,209,343,0,0,0,0,1,64,0,255-0-255,|12||0-0-0,1|(241,908)|
+1,346,343,319,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(365,986)|
+1,347,343,310,0,0,0,0,1,128,0,0-0-255,|12||0-0-0,1|(276,1074)|
+10,348,Introduction period for policy y,148,1049,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,349,348,343,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(187,1026)|
+10,350,Introduction period for policy y,356,553,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,351,350,333,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(374,515)|
+10,352,Introduction period for policy y,1628,499,66,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||255-0-255,0,0,0,0,0,0
+1,353,352,326,0,0,0,0,1,128,0,255-0-255,|12||0-0-0,1|(1613,450)|
+10,354,"Installed CCS capacity GtCO2/y",378,862,59,19,8,3,0,2,0,0,0,0,-1--1--1,0-0-0,|12|B|255-0-0,0,0,0,0,0,0
+1,355,310,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(337,1019)|
+1,356,343,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(317,926)|
+1,357,319,354,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(441,927)|
+1,358,354,208,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(388,830)|
+10,359,"Cost of air capture G$/y",2504,1090,47,19,8,2,0,3,-1,0,0,0,128-128-128,0-0-0,|12||128-128-128,0,0,0,0,0,0
+1,360,359,195,0,0,0,0,1,128,0,192-192-192,|12||0-0-0,1|(2428,1129)|
+///---\\\
+:GRAPH 1._Main_trends
+:TITLE 1. Main trends - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 2.4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequality (1)"
+:Y-MIN 0
+:Y-MAX 1.6
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Social tension (1)"
+:Y-MIN 0
+
+:GRAPH 2._Human_footprint
+:TITLE 2. Human footprint - World 1980 to 2020
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Population below 15 k$/p/y Mp"
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "ENERGY USE Mtoe/y"
+:Y-MIN 0
+:Y-MAX 20000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR "GHG EMISSIONS GtCO2e/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR "Govmnt gross income (as share of NI)"
+:Y-MIN 0
+:Y-MAX 0.4
+:LINE-WIDTH 2
+
+:GRAPH 3._Consumption
+:TITLE 3. Consumption  - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions per person tCO2/y"
+:Y-MIN 0
+:Y-MAX 6
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Energy use per person toe/p/y"
+:Y-MIN 0
+:Y-MAX 4
+:SCALE
+:VAR Forestry land Mha
+:Y-MIN 0
+:Y-MAX 2000
+:LINE-WIDTH 2
+
+:GRAPH 4._Wellbeing
+:TITLE 4. Wellbeing - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Average wellbeing from disposable income (1)"
+:Y-MIN 0
+:Y-MAX 8
+:LINE-WIDTH 2
+:VAR "Average wellbeing from public spending (1)"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 2.4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Average wellbeing from inequality (1)"
+:Y-MIN 0
+:Y-MAX 1.2
+:VAR "Average wellbeing from global warming (1)"
+:Y-MIN 0
+:VAR "Average wellbeing from progress (1)"
+:Y-MIN 0
+
+:GRAPH 5._Turnarounds
+:TITLE 5. Turnaround indicators - World 1980 to 2100
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Fraction below 15 k$/p/y (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequality (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "Birth rate 1/y"
+:Y-MIN 0
+:Y-MAX 0.04
+:LINE-WIDTH 2
+:SCALE
+:VAR "FOOD FOOTPRINT INDEX (1980=1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:Y-MAX 50
+:LINE-WIDTH 2
+
+:GRAPH 4-year_cycle
+:TITLE 4-year cycle in inventories
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR Inventory coverage y
+:Y-MIN 0
+:Y-MAX 0.5
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.05
+:Y-MAX 0.05
+:LINE-WIDTH 2
+:SCALE
+:VAR "Hours worked - index (1)"
+:Y-MIN 0.9
+:Y-MAX 1.1
+:LINE-WIDTH 2
+:VAR "Delivery delay - index (1)"
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 100000
+:SCALE
+:VAR "Price Index $/1980$"
+:Y-MIN 0
+:Y-MAX 4
+
+:GRAPH 10-year_wave
+:TITLE 10-year wave in labour market
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 0.8
+:LINE-WIDTH 2
+:SCALE
+:VAR "Investment share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Savings share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+:LINE-WIDTH 1
+:SCALE
+:VAR "Labor particiption rate (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Capital labour ratio k$/j"
+:Y-MIN 0
+:Y-MAX 200
+
+:GRAPH Economic_development__1980_to_2020
+:TITLE Economic development
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 120000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 24
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 1
+:SCALE
+:VAR "Corporate borrowing cost 1/y"
+:Y-MIN 0
+:Y-MAX 0.1
+:SCALE
+:VAR "Govmnt share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH Growth_1980-2020
+:TITLE Economic growth
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 120000
+:LINE-WIDTH 2
+:VAR "Govmnt spending G$/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Workforce M-ftp"
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 30
+:VAR "Consumption per person G$/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+
+:GRAPH Population_and_workforce
+:TITLE Population and workforce - World
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Aged 20-pension age Mp"
+:Y-MIN 0
+:Y-MAX 2000
+:LINE-WIDTH 2
+:VAR Population Mp
+:LINE-WIDTH 2
+:VAR "Workforce M-ftp"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Dependency ratio p/p"
+:Y-MIN 0
+:Y-MAX 6
+:SCALE
+:VAR Life expectancy y
+:Y-MIN 0
+:Y-MAX 100
+:SCALE
+:VAR Observed fertility 1
+:Y-MIN 0
+:Y-MAX 6
+
+:GRAPH New_Labor_market:_10-year_wave
+:TITLE New Labor market: 10-year wave - World
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker share of output (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR Workforce Mp
+:Y-MIN 0
+:Y-MAX 6000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Capacity addition PIS G$/y"
+:Y-MIN 0
+:Y-MAX 16000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Labour participation rate (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 1
+:SCALE
+:VAR "Optimal capital labour ratio kcu/ftj"
+:Y-MIN 0
+:Y-MAX 400
+:LINE-WIDTH 1
+
+:GRAPH Distribution_of_national_income
+:TITLE Distribution of national income
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Consumption share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:VAR "Savings share of GDP (1)"
+:LINE-WIDTH 2
+:VAR "Govmnt share of GDP (1)"
+:LINE-WIDTH 2
+:SCALE
+:VAR "National income G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:SCALE
+:VAR Govmnt debt burden y
+:Y-MIN 0
+:Y-MAX 2
+:VAR Worker debt burden y
+
+:GRAPH Cashflows_as_share_of_NI
+:TITLE Cashflows as share of NI
+:SCALE
+:VAR "WCF/NI (1)"
+:Y-MIN 0
+:Y-MAX 1
+:VAR "GCF/NI (1)"
+:VAR "OCF/NI (1)"
+:VAR "Sales tax/NI"
+
+:GRAPH Output:_Long_term_growth
+:TITLE Output: Long term growth
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Investment share of GDP (1)"
+:Y-MIN 0
+:Y-MAX 0.6
+:VAR "Savings share of GDP (1)"
+:SCALE
+:VAR "Output growth rate 1/y"
+:Y-MIN -0.1
+:Y-MAX 0.1
+
+:GRAPH Inventory:_4-year_cycle
+:TITLE Inventory: 4-year cycle
+:X-DIV 15
+:X-MIN 1980
+:X-MAX 2040
+:SCALE
+:VAR "Pink noise in sales (1)"
+:Y-MIN 0
+:Y-MAX 2
+:SCALE
+:VAR "Perceived relative inventory (1)"
+:Y-MIN 0
+:Y-MAX 1.5
+:SCALE
+:VAR "Hours worked - index (1)"
+:Y-MIN 0
+:Y-MAX 1.25
+:SCALE
+:VAR "Delivery delay - index (1)"
+:Y-MIN 0.9
+:Y-MAX 1.1
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.1
+:Y-MAX 0.1
+:SCALE
+:VAR "Price Index (1980=1)"
+:Y-MIN 0
+:Y-MAX 4
+
+:GRAPH Food_demand_and_supply
+:TITLE Food demand and supply
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:VAR "Crop demand Mt-crop/y"
+:SCALE
+:VAR "Demand for red meat Mt-red-meat/y"
+:Y-MIN 0
+:Y-MAX 400
+:LINE-WIDTH 2
+:VAR "Red meat from grazing land Mt-red-meat/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Red meat supply per person kg-red-meat/p/y"
+:Y-MIN 0
+:Y-MAX 80
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1.2
+
+:GRAPH Food_and_land_use
+:TITLE Food and land use
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Crop use Mt/y"
+:Y-MIN 0
+:Y-MAX 8000
+:LINE-WIDTH 2
+:SCALE
+:VAR Total forest area Mha
+:Y-MIN 0
+:Y-MAX 4000
+:LINE-WIDTH 2
+:VAR Cropland Mha
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR "Crop use per person t-crop/p/y"
+:Y-MIN 0
+:Y-MAX 1.2
+:SCALE
+:VAR "Fraction regenerative agriculture (1)"
+:Y-MIN 0
+:Y-MAX 1
+
+:GRAPH Financial_cycle
+:TITLE Financial cycle
+:X-DIV 10
+:X-MIN 1980
+:X-MAX 2020
+:SCALE
+:VAR "Central bank signal rate 1/y"
+:Y-MIN 0
+:Y-MAX 0.1
+:LINE-WIDTH 2
+:VAR "10-yr govmnt interest rate 1/y"
+:LINE-WIDTH 2
+:VAR "Corporate borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Worker borrowing cost 1/y"
+:SCALE
+:VAR Govmnt debt burden y
+:Y-MIN 0
+:Y-MAX 1
+:VAR Worker debt burden y
+:LINE-WIDTH 2
+
+:GRAPH Finance:_Interest_rates
+:TITLE Finance: Interest rates
+:X-DIV 4
+:X-MIN 2010
+:X-MAX 2030
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN 0
+:Y-MAX 0.1
+:VAR "Corporate borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Central bank signal rate 1/y"
+:LINE-WIDTH 2
+:VAR "Govmnt borrowing cost 1/y"
+:LINE-WIDTH 2
+:VAR "Worker borrowing cost 1/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inflation rate 1/y"
+:Y-MIN -0.05
+:Y-MAX 0.05
+
+:GRAPH Climate
+:TITLE Climate
+:X-DIV 6
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:Y-MAX 44
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR CO2 concentration in atm ppm
+:Y-MIN 0
+:Y-MAX 600
+:LINE-WIDTH 2
+:SCALE
+:VAR "Man-made forcing W/m2"
+:Y-MIN 0
+:Y-MAX 8
+:VAR "Water vapour feedback W/m2"
+:SCALE
+:VAR "Ice and snow cover excl G&A Mkm2"
+:Y-MIN 0
+:Y-MAX 20
+
+:GRAPH C_G_S
+:TITLE C G S
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Consumption rate (1)"
+:Y-MIN 0
+:Y-MAX 1
+:VAR "Savings rate (1)"
+:VAR "Government tax rate (1)"
+:SCALE
+:VAR "Total demand G$/y"
+:Y-MIN 0
+:Y-MAX 320000
+:VAR "National income G$/y"
+
+:GRAPH Public_sector:_Services_and_tech_advance
+:TITLE Public sector: Services and tech advance
+:SCALE
+:VAR Public infrastructure G$
+:Y-MIN 0
+:SCALE
+:VAR "Public services per person G$/p/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Rate of technological advance 1/y"
+:Y-MIN -0.04
+:Y-MAX 0.04
+:SCALE
+:VAR "CO2 per GDP tCO2/k$"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions GtCO2/y"
+:Y-MIN 0
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fraction of workforce in public sector (1)"
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH Other_performance_indicators
+:TITLE Other performance indicators
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "RATE OF GROWTH IN GDP PER PERSON 1/y"
+:Y-MIN 0
+:Y-MAX 0.04
+:LINE-WIDTH 2
+:SCALE
+:VAR "Participation (1)"
+:Y-MIN 0
+:Y-MAX 1
+:LINE-WIDTH 2
+:SCALE
+:VAR "Unemployment rate (1)"
+:Y-MIN -0.1
+:Y-MAX 0.1
+:SCALE
+:VAR "Population below 15 k$/p/y Mp"
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+
+:GRAPH Energy
+:TITLE Energy
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "ENERGY USE Mtoe/y"
+:Y-MIN 0
+:Y-MAX 24000
+:LINE-WIDTH 2
+:VAR "Total use of fossil fuels Mtoe/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "Electricity production TWh/y"
+:Y-MIN 0
+:Y-MAX 80000
+:LINE-WIDTH 2
+:VAR "Renewable electricity production TWh/y"
+:LINE-WIDTH 2
+:SCALE
+:VAR "CO2 emissions from fossil fuels GtCO2/y"
+:Y-MIN 0
+:Y-MAX 44
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MIN 0
+:Y-MAX 6000
+
+:GRAPH Fertility_vs_GDPpp
+:TITLE Fertility vs GDPpp
+:X-AXIS "Effective GDP per person k$/p/y"
+:SCALE
+:VAR Observed fertility 1
+
+:GRAPH 1._State_of_affairs
+:TITLE 1. State of affairs - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "GDP G$/y"
+:Y-MIN 0
+:Y-MAX 400000
+:LINE-WIDTH 2
+:SCALE
+:VAR Population Mp
+:Y-MIN 0
+:Y-MAX 10000
+:LINE-WIDTH 2
+:SCALE
+:VAR "GDP per person k$/p/y"
+:Y-MIN 0
+:Y-MAX 80
+:LINE-WIDTH 2
+:SCALE
+:VAR "Inequity Index (1)"
+:Y-MIN -1
+:Y-MAX 3
+:SCALE
+:VAR Govmnt spending as share of GDP
+:Y-MIN 0
+:Y-MAX 0.4
+
+:GRAPH 2._Ecological_damage
+:TITLE 2. Ecological damage - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Loss of forest land Mha/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR Observed warming deg C
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Loss of cropland Mha/y"
+:Y-MIN 0
+:Y-MAX 60
+:LINE-WIDTH 2
+:SCALE
+:VAR Ice and snow cover Mha
+:Y-MIN 0
+:Y-MAX 3000
+:VAR Old growth forest area Mha 1
+
+:GRAPH 3._Human_footprint
+:TITLE 3. Human footprint - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "CO2 emissions from fossil fuels GtCO2/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Fertilizer use Mt/y"
+:Y-MIN 0
+:Y-MAX 200
+:LINE-WIDTH 2
+:SCALE
+:VAR Cropland Mha
+:Y-MIN 0
+:Y-MAX 3000
+:LINE-WIDTH 2
+:SCALE
+:VAR "Total use of fossil fuels Mtoe/y"
+:Y-MIN 0
+:Y-MAX 12000
+
+:GRAPH 4._Average_wellbeing
+:TITLE 4. Average wellbeing - World 1980 to 2100 - Medium GL
+:X-DIV 12
+:X-MIN 1980
+:X-MAX 2100
+:SCALE
+:VAR "Social tension (1)"
+:Y-MIN 0
+:Y-MAX 2
+:LINE-WIDTH 2
+:SCALE
+:VAR "AVERAGE WELLBEING INDEX (1)"
+:Y-MIN 0
+:Y-MAX 4
+:LINE-WIDTH 2
+:SCALE
+:VAR "Worker disposable income k$/p/y"
+:Y-MIN 0
+:Y-MAX 40
+:LINE-WIDTH 2
+:SCALE
+:VAR "Labour participation rate (1)"
+:Y-MIN 0
+:Y-MAX 2
+:SCALE
+:VAR "Cost of food G$/y"
+:Y-MAX 24000
+:SCALE
+:VAR "Cost of energy G$/y"
+:Y-MAX 6000
+
+:GRAPH CLR_vs_GDPpp
+:TITLE CLR vs GDPpp
+:X-AXIS "GDP per person k$/p/y"
+:X-DIV 10
+:X-MIN 0
+:X-MAX 100
+:SCALE
+:VAR "Embedded CLR k$/j"
+:Y-MIN 0
+:L<%^E!@
+1:E4A-220501 TLTL.vdfx
+9:E4A-220501 TLTL
+15:0,0,0,0,0,0
+19:75,0
+27:0,
+34:0,
+4:Time
+5:Population Mp
+35:Date
+36:YYYY-MM-DD
+37:2000
+38:1
+39:1
+40:0
+41:0
+42:0
+72:0
+73:0
+76:0
+77:0
+78:0
+79:0
+80:0
+81:0
+24:1980
+25:2100
+26:2100
+75:
+43:


### PR DESCRIPTION
The current PR adds links to the original Vensim sources for the E4A model, also providing them in the `vensim_source` folder. 